### PR TITLE
공통 응답, 전역 예외 처리

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -1,0 +1,27 @@
+package hanium.modic.backend.common.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	// Common
+	USER_INPUT_EXCEPTION(HttpStatus.BAD_REQUEST, "C-001", "사용자 입력 오류"),
+	USER_ROLE_EXCEPTION(HttpStatus.FORBIDDEN, "C-002", "유저 권한 오류"),
+	AUTHENTICATION_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-003", "공통 권한 에러(필터)"),
+
+	// Post
+	POST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "P-001", "해당 포스트를 찾을 수 없습니다."),
+
+	// Server
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "서버 내부에서 에러가 발생하였습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/hanium/modic/backend/common/error/exception/AppException.java
+++ b/src/main/java/hanium/modic/backend/common/error/exception/AppException.java
@@ -1,0 +1,15 @@
+package hanium.modic.backend.common.error.exception;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AppException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public AppException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package hanium.modic.backend.common.error.exception.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+	@ExceptionHandler(AppException.class)
+	public ResponseEntity<ErrorResponse> handleAppException(AppException e) {
+		log.error("AppException 발생: errorCode={}, message={}", e.getErrorCode().getCode(), e.getMessage());
+
+		ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
+
+		return ResponseEntity
+			.status(e.getErrorCode().getStatus())
+			.body(errorResponse);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("처리되지 않은 예외 발생: ", e);
+
+		ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
+
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(errorResponse);
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/response/ApiResponse.java
+++ b/src/main/java/hanium/modic/backend/common/response/ApiResponse.java
@@ -1,0 +1,39 @@
+package hanium.modic.backend.common.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> extends BaseResponse {
+	private final T data;
+
+	private ApiResponse(HttpStatusCode status, T data) {
+		super(true, status);
+		this.data = data;
+	}
+
+	// HTTP 200 OK
+	public static <T> ApiResponse<T> ok(T data) {
+		return new ApiResponse<>(HttpStatus.OK, data);
+	}
+
+	// HTTP 201 Created
+	public static <T> ApiResponse<T> created(T data) {
+		return new ApiResponse<>(HttpStatus.CREATED, data);
+	}
+
+	// HTTP 204 No Content
+	public static ApiResponse<Void> noContent() {
+		return new ApiResponse<>(HttpStatus.NO_CONTENT, null);
+	}
+
+	// Custom status code
+	public static <T> ApiResponse<T> of(HttpStatus status, T data) {
+		return new ApiResponse<>(status, data);
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/response/BaseResponse.java
+++ b/src/main/java/hanium/modic/backend/common/response/BaseResponse.java
@@ -1,0 +1,16 @@
+package hanium.modic.backend.common.response;
+
+import org.springframework.http.HttpStatusCode;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseResponse {
+	private final boolean isSuccess;
+	private final int status;
+
+	protected BaseResponse(boolean isSuccess, HttpStatusCode status) {
+		this.isSuccess = isSuccess;
+		this.status = status.value();
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/response/BaseResponse.java
+++ b/src/main/java/hanium/modic/backend/common/response/BaseResponse.java
@@ -2,14 +2,11 @@ package hanium.modic.backend.common.response;
 
 import org.springframework.http.HttpStatusCode;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Getter;
 
 @Getter
 public abstract class BaseResponse {
 
-	@JsonProperty("isSuccess")
 	private final Boolean isSuccess;
 	private final int status;
 

--- a/src/main/java/hanium/modic/backend/common/response/BaseResponse.java
+++ b/src/main/java/hanium/modic/backend/common/response/BaseResponse.java
@@ -2,11 +2,15 @@ package hanium.modic.backend.common.response;
 
 import org.springframework.http.HttpStatusCode;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 
 @Getter
 public abstract class BaseResponse {
-	private final boolean isSuccess;
+
+	@JsonProperty("isSuccess")
+	private final Boolean isSuccess;
 	private final int status;
 
 	protected BaseResponse(boolean isSuccess, HttpStatusCode status) {

--- a/src/main/java/hanium/modic/backend/common/response/ErrorResponse.java
+++ b/src/main/java/hanium/modic/backend/common/response/ErrorResponse.java
@@ -1,0 +1,43 @@
+package hanium.modic.backend.common.response;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse extends BaseResponse {
+	private final String code;
+	private final String message;
+	private final List<String> reason;
+
+	private ErrorResponse(HttpStatus status, String code, String message, List<String> reason) {
+		super(false, status);
+		this.code = code;
+		this.message = message;
+		this.reason = reason;
+	}
+
+	public static ErrorResponse from(ErrorCode errorCode) {
+		return new ErrorResponse(
+			errorCode.getStatus(),
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			null
+		);
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, List<String> reason) {
+		return new ErrorResponse(
+			errorCode.getStatus(),
+			errorCode.getCode(),
+			errorCode.getMessage(),
+			reason
+		);
+	}
+}

--- a/src/test/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,56 @@
+package hanium.modic.backend.common.error.exception.handler;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.response.ErrorResponse;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+	@InjectMocks
+	private GlobalExceptionHandler globalExceptionHandler;
+
+	@Test
+	@DisplayName("AppException이 발생하면 ErrorResponse를 생성하여 반환한다")
+	void handleAppExceptionSuccess() {
+		// given
+		ErrorCode errorCode = ErrorCode.USER_INPUT_EXCEPTION;
+		AppException exception = new AppException(errorCode);
+
+		// when
+		ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleAppException(exception);
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(errorCode.getStatus());
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getCode()).isEqualTo(errorCode.getCode());
+		assertThat(response.getBody().getMessage()).isEqualTo(errorCode.getMessage());
+		assertThat(response.getBody().getReason()).isNull();
+	}
+
+	@Test
+	@DisplayName("처리되지 않은 예외가 발생하면 INTERNAL_SERVER_ERROR를 반환한다")
+	void handleExceptionSuccess() {
+		// given
+		Exception exception = new Exception("처리되지 않은 예외");
+
+		// when
+		ResponseEntity<ErrorResponse> response = globalExceptionHandler.handleException(exception);
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getStatus());
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getCode());
+		assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+		assertThat(response.getBody().getReason()).isNull();
+	}
+}


### PR DESCRIPTION
```
{
  "isSuccess": false,
  "status": 0, // 400 등
  "error": "string", // 에러 상세 설명, NOT FOUND 등
  "code": "string", // MEMBER-001 등
}
```
원래 위처럼 하기로 되어있었는데, error라는 필드명이 ErrorCode의 메시지랑 대응되는데 이름이 다른게 모호한 것 같아서, message로 통일 했습니다.
```
{
    "status": 500,
    "code": "S-001",
    "message": "서버 내부에서 에러가 발생하였습니다.",
    "isSuccess": false
}
```

예외 처리 부분은 조금씩 추가해 나가면 좋을 것 같습니다.
