### PR TITLE
Feature: 유저 회원가입 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
 	USER_ROLE_EXCEPTION(HttpStatus.FORBIDDEN, "C-002", "유저 권한 오류"),
 	AUTHENTICATION_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-003", "공통 권한 에러(필터)"),
 
+	// User
+	USER_EMAIL_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, "U-001", "이미 사용중인 이메일입니다."),
+
 	// Post
 	POST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "P-001", "해당 포스트를 찾을 수 없습니다."),
 

--- a/src/main/java/hanium/modic/backend/common/property/property/SwaggerProperties.java
+++ b/src/main/java/hanium/modic/backend/common/property/property/SwaggerProperties.java
@@ -1,12 +1,10 @@
 package hanium.modic.backend.common.property.property;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 import lombok.Getter;
 import lombok.Setter;
 
-@Component
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "swagger")

--- a/src/main/java/hanium/modic/backend/common/security/EncodeConfig.java
+++ b/src/main/java/hanium/modic/backend/common/security/EncodeConfig.java
@@ -1,0 +1,14 @@
+package hanium.modic.backend.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class EncodeConfig {
+
+	@Bean
+	public BCryptPasswordEncoder encoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/security/SecurityConfig.java
+++ b/src/main/java/hanium/modic/backend/common/security/SecurityConfig.java
@@ -1,0 +1,23 @@
+package hanium.modic.backend.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll())
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.build();
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/swagger/conf/SwaggerConfig.java
+++ b/src/main/java/hanium/modic/backend/common/swagger/conf/SwaggerConfig.java
@@ -3,6 +3,7 @@ package hanium.modic.backend.common.swagger.conf;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
+@EnableConfigurationProperties(SwaggerProperties.class)
 @RequiredArgsConstructor
 public class SwaggerConfig {
 

--- a/src/main/java/hanium/modic/backend/common/validator/Password.java
+++ b/src/main/java/hanium/modic/backend/common/validator/Password.java
@@ -1,0 +1,22 @@
+package hanium.modic.backend.common.validator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordValidator.class)
+public @interface Password {
+
+	String message() default "Invalid password format";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}
+

--- a/src/main/java/hanium/modic/backend/common/validator/PasswordValidator.java
+++ b/src/main/java/hanium/modic/backend/common/validator/PasswordValidator.java
@@ -1,0 +1,17 @@
+package hanium.modic.backend.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+	private static final String PASSWORD_REGEX = "^(?=.{8,20}$)(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z0-9]).*$";
+
+	@Override
+	public boolean isValid(String password, ConstraintValidatorContext context) {
+		if (password == null) {
+			return false;
+		}
+		return password.matches(PASSWORD_REGEX);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,11 @@ public class UserEntity {
 	private String password;
 
 	private String name;
+
+	@Builder
+	private UserEntity(String email, String password, String name) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+	}
 }

--- a/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
@@ -1,0 +1,30 @@
+package hanium.modic.backend.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "user")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(unique = true, nullable = false)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	private String name;
+}

--- a/src/main/java/hanium/modic/backend/domain/user/repository/UserEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/user/repository/UserEntityRepository.java
@@ -1,0 +1,9 @@
+package hanium.modic.backend.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+
+public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
+	boolean existsByEmail(String email);
+}

--- a/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
+++ b/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
@@ -1,0 +1,43 @@
+package hanium.modic.backend.domain.user.service;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.user.dto.UserCreateResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserEntityRepository userEntityRepository;
+
+	private final BCryptPasswordEncoder passwordEncoder;
+
+	@Transactional
+	public UserCreateResponse createUser(final String email, final String password, final String name) {
+		checkDuplicateEmail(email);
+
+		final String encodedPassword = passwordEncoder.encode(password);
+
+		final UserEntity user = UserEntity.builder()
+			.email(email)
+			.password(encodedPassword)
+			.name(name)
+			.build();
+		userEntityRepository.save(user);
+
+		return UserCreateResponse.from(user);
+	}
+
+	private void checkDuplicateEmail(final String email) {
+		if (userEntityRepository.existsByEmail(email)) {
+			throw new AppException(ErrorCode.USER_EMAIL_DUPLICATED_EXCEPTION);
+		}
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
+++ b/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package hanium.modic.backend.web.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hanium.modic.backend.common.response.ApiResponse;
+import hanium.modic.backend.domain.user.service.UserService;
+import hanium.modic.backend.web.user.dto.UserCreateRequest;
+import hanium.modic.backend.web.user.dto.UserCreateResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<UserCreateResponse>> createUser(@RequestBody @Valid UserCreateRequest request) {
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(ApiResponse.created(userService.createUser(request.email(), request.password(), request.name())));
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/user/dto/UserCreateRequest.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/UserCreateRequest.java
@@ -1,0 +1,15 @@
+package hanium.modic.backend.web.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+
+public record UserCreateRequest(
+	@Email(message = "이메일 형식으로 요청해주세요.")
+	@NotNull(message = "이메일은 필수입니다.")
+	String email,
+
+	String name,
+	@NotNull(message = "비밀번호는 필수입니다.")
+	String password
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/user/dto/UserCreateRequest.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/UserCreateRequest.java
@@ -1,5 +1,8 @@
 package hanium.modic.backend.web.user.dto;
 
+import org.hibernate.validator.constraints.Length;
+
+import hanium.modic.backend.common.validator.Password;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 
@@ -8,8 +11,10 @@ public record UserCreateRequest(
 	@NotNull(message = "이메일은 필수입니다.")
 	String email,
 
+	@NotNull(message = "이름은 필수입니다.")
+	@Length(min = 1, max = 20, message = "이름은 2자 이상 20자 이하로 입력해주세요.")
 	String name,
-	@NotNull(message = "비밀번호는 필수입니다.")
+	@Password(message = "비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다.")
 	String password
 ) {
 }

--- a/src/main/java/hanium/modic/backend/web/user/dto/UserCreateRequest.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/UserCreateRequest.java
@@ -4,14 +4,14 @@ import org.hibernate.validator.constraints.Length;
 
 import hanium.modic.backend.common.validator.Password;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record UserCreateRequest(
 	@Email(message = "이메일 형식으로 요청해주세요.")
-	@NotNull(message = "이메일은 필수입니다.")
+	@NotBlank(message = "이메일은 필수입니다.")
 	String email,
 
-	@NotNull(message = "이름은 필수입니다.")
+	@NotBlank(message = "이름은 필수입니다.")
 	@Length(min = 1, max = 20, message = "이름은 2자 이상 20자 이하로 입력해주세요.")
 	String name,
 	@Password(message = "비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다.")

--- a/src/main/java/hanium/modic/backend/web/user/dto/UserCreateResponse.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/UserCreateResponse.java
@@ -1,0 +1,11 @@
+package hanium.modic.backend.web.user.dto;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+
+public record UserCreateResponse(
+	Long userId
+) {
+	public static UserCreateResponse from(UserEntity user) {
+		return new UserCreateResponse(user.getId());
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
@@ -1,0 +1,67 @@
+package hanium.modic.backend.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.user.dto.UserCreateResponse;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@InjectMocks
+	private UserService userService;
+
+	@Mock
+	private UserEntityRepository userEntityRepository;
+
+	@Mock
+	private BCryptPasswordEncoder passwordEncoder;
+
+	@Test
+	@DisplayName("유저 회원가입 테스트")
+	void userCreateTest() {
+		// given
+		String email = "user@cotato.kr";
+		String password = "password";
+		String name = "user";
+
+		when(userEntityRepository.existsByEmail(email)).thenReturn(false);
+		when(passwordEncoder.encode(password)).thenReturn("encodedPassword");
+
+		// when
+		UserCreateResponse user = userService.createUser(email, password, name);
+
+		// then
+		verify(userEntityRepository, times(1)).save(any(UserEntity.class));
+		assertNotNull(user);
+	}
+
+	@Test
+	@DisplayName("유저 회원 가입 시 중복 이메일 예외 테스트")
+	void userCreateExceptionTest() {
+		// given
+		String email = "user@cotato.kr";
+		String password = "password";
+		String name = "user";
+
+		when(userEntityRepository.existsByEmail(email)).thenReturn(true);
+
+		// when
+		AppException appException = assertThrows(AppException.class, () -> userService.createUser(email, password, name));
+
+		// then
+		assertEquals(ErrorCode.USER_EMAIL_DUPLICATED_EXCEPTION, appException.getErrorCode());
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
@@ -44,6 +44,7 @@ class UserServiceTest {
 		UserCreateResponse user = userService.createUser(email, password, name);
 
 		// then
+		verify(passwordEncoder, times(1)).encode(password);
 		verify(userEntityRepository, times(1)).save(any(UserEntity.class));
 		assertNotNull(user);
 	}

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -11,12 +11,9 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -38,11 +35,7 @@ import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 
 @WebMvcTest(controllers = PostController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@ExtendWith(MockitoExtension.class)
 class PostControllerTest {
-
-	@InjectMocks
-	private PostController postController;
 
 	@MockitoBean
 	private PostService postService;

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
@@ -1,0 +1,51 @@
+package hanium.modic.backend.web.user.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.user.dto.UserCreateRequest;
+
+public class UserControllerIntegrationTest extends BaseIntegrationTest {
+
+	@Autowired
+	private UserEntityRepository userEntityRepository;
+
+	@Autowired
+	private BCryptPasswordEncoder passwordEncoder;
+
+	@BeforeEach
+	void setUp() {
+		userEntityRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("회원가입 API 테스트")
+	void createUserApiTest() throws Exception {
+		// given
+		UserCreateRequest request = new UserCreateRequest("youth@cotato.kr", "youth", "youth");
+		String json = objectMapper.writeValueAsString(request);
+
+		// when
+		mockMvc.perform(post("/api/users")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(json))
+			.andExpect(status().isCreated());
+
+		// then
+		assertThat(userEntityRepository.findAll()).hasSize(1);
+
+		var saved = userEntityRepository.findAll().get(0);
+		assertThat(saved.getEmail()).isEqualTo("youth@cotato.kr");
+		assertThat(saved.getName()).isEqualTo("youth");
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
@@ -19,9 +18,6 @@ public class UserControllerIntegrationTest extends BaseIntegrationTest {
 
 	@Autowired
 	private UserEntityRepository userEntityRepository;
-
-	@Autowired
-	private BCryptPasswordEncoder passwordEncoder;
 
 	@BeforeEach
 	void setUp() {

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -87,6 +87,11 @@ class UserControllerTest {
 				"비밀번호가 형식이 맞지 않는 경우",
 				new UserCreateRequest("youth@cotato.kr", "youth", null),
 				"비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다."
+			),
+			Arguments.of(
+				"이름이 20자 이상인 경우",
+				new UserCreateRequest("youth@cotato.kr", "youthyouthyouthyouthyouth", "youth@123"),
+				"이름은 2자 이상 20자 이하로 입력해주세요."
 			)
 		);
 	}

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -8,13 +8,9 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -22,7 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.amazonaws.services.kms.model.CreateAliasRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hanium.modic.backend.domain.user.service.UserService;
@@ -30,11 +25,7 @@ import hanium.modic.backend.web.user.dto.UserCreateRequest;
 
 @WebMvcTest(controllers = UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@ExtendWith(MockitoExtension.class)
 class UserControllerTest {
-
-	@InjectMocks
-	private UserController userController;
 
 	@MockitoBean
 	private UserService userService;

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -1,0 +1,102 @@
+package hanium.modic.backend.web.user.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.amazonaws.services.kms.model.CreateAliasRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hanium.modic.backend.domain.user.service.UserService;
+import hanium.modic.backend.web.user.dto.UserCreateRequest;
+
+@WebMvcTest(controllers = UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+	@InjectMocks
+	private UserController userController;
+
+	@MockitoBean
+	private UserService userService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@DisplayName("유저 회원가입 컨트롤러 테스트")
+	void createUserSuccessTest() throws Exception {
+		// given
+		UserCreateRequest request = new UserCreateRequest("youth@cotato.kr", "password", "youth");
+		String json = objectMapper.writeValueAsString(request);
+
+		// when
+		mockMvc.perform(post("/api/users")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(json))
+			.andExpect(status().isCreated());
+
+		// then
+		verify(userService).createUser(
+			request.email(),
+			request.password(),
+			request.name()
+		);
+	}
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@MethodSource("invalidUserCreateRequests")
+	@DisplayName("유저 회원가입 컨트롤러 테스트 - 유효성 검사 실패")
+	void createUserValidationTest(String description, UserCreateRequest request, String expectedErrorMessage) throws Exception {
+		// given
+		String json = objectMapper.writeValueAsString(request);
+
+		// when
+		mockMvc.perform(post("/api/users")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(json))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.reason").value(expectedErrorMessage));
+	}
+
+	static Stream<Arguments> invalidUserCreateRequests() {
+		return Stream.of(
+			Arguments.of(
+				"이메일 형식이 올바르지 않은 경우",
+				new UserCreateRequest("invalid-email", "youth", "password"),
+				"이메일 형식으로 요청해주세요."
+			),
+			Arguments.of(
+				"이메일이 null인 경우",
+				new UserCreateRequest(null, "youth", "password"),
+				"이메일은 필수입니다."
+			),
+			Arguments.of(
+				"비밀번호가 null인 경우",
+				new UserCreateRequest("youth@cotato.kr", "youth", null),
+				"비밀번호는 필수입니다."
+			)
+		);
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -75,18 +75,18 @@ class UserControllerTest {
 		return Stream.of(
 			Arguments.of(
 				"이메일 형식이 올바르지 않은 경우",
-				new UserCreateRequest("invalid-email", "youth", "password"),
+				new UserCreateRequest("invalid-email", "youth", "qwer1234@#!"),
 				"이메일 형식으로 요청해주세요."
 			),
 			Arguments.of(
 				"이메일이 null인 경우",
-				new UserCreateRequest(null, "youth", "password"),
+				new UserCreateRequest(null, "youth", "qwer1234@#!"),
 				"이메일은 필수입니다."
 			),
 			Arguments.of(
-				"비밀번호가 null인 경우",
+				"비밀번호가 형식이 맞지 않는 경우",
 				new UserCreateRequest("youth@cotato.kr", "youth", null),
-				"비밀번호는 필수입니다."
+				"비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다."
 			)
 		);
 	}


### PR DESCRIPTION
## 개요

유저 회원 가입 API 를 구현하자

### 주의 사항
아래 내용은 기획자에게 문의된 상태입니다.

- [x] : 비밀번호 관련 제약 조건

## 작업사항

- 유저 엔티티 설정
- 중복 이메일 존재 시 에러 발생
- Spring Security password encoder 설정

resolve: https://github.com/Modic-2025/modic_backend/issues/18


### 참고
통합 테스트 간에 h2 user 예약어 설정으로 인해 applicayion-test.yml에 아래와 같은 설정 추가가 필요합니다. (노션 업데이트 완료)

```yml
spring:
  application:
    name: backend

  datasource:
    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL;NON_KEYWORDS=USER
    driver-class-name: org.h2.Driver
    username: sa
    password:
```

