### PR TITLE
비동기 처리를 통한 트랜잭션 로직 개선

### DIFF
--- a/src/main/java/hanium/modic/backend/common/async/AsyncConfig.java
+++ b/src/main/java/hanium/modic/backend/common/async/AsyncConfig.java
@@ -1,0 +1,75 @@
+package hanium.modic.backend.common.async;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import org.slf4j.MDC;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+	@Bean(name = TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
+	public ThreadPoolTaskExecutor asyncTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(2);
+		executor.setThreadNamePrefix("async");
+		executor.setQueueCapacity(1000000);
+		executor.setAwaitTerminationSeconds(5); // shutdown시 5초 대기
+		executor.setWaitForTasksToCompleteOnShutdown(true); // shutdown 시 남은 작업 대기
+		executor.setTaskDecorator(new MdcTaskDecorator());
+		executor.initialize();
+		executor.getThreadPoolExecutor().prestartAllCoreThreads();
+		return executor;
+	}
+
+	@Override
+	public Executor getAsyncExecutor() {
+		return asyncTaskExecutor();
+	}
+
+	@Override
+	public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+		return new AsyncExceptionHandler();
+	}
+
+	// 비동기 예외 핸들러
+	@Slf4j
+	private static class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+		@Override
+		public void handleUncaughtException(Throwable throwable, Method method, Object... objects) {
+			log.error("Error on async execution: ", throwable);
+		}
+	}
+
+	private static class MdcTaskDecorator implements TaskDecorator {
+
+		@Override
+		public Runnable decorate(Runnable runnable) {
+			Map<String, String> contextMap = MDC.getCopyOfContextMap();
+			return () -> {
+				try {
+					if (contextMap != null) {
+						MDC.setContextMap(contextMap);
+					}
+					runnable.run();
+				} finally {
+					MDC.clear();
+				}
+			};
+		}
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.List;
@@ -75,5 +76,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         log.error("ConstraintViolationException 발생: requestURI={}, error={}", requestURI, ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorCode.USER_INPUT_EXCEPTION, messages));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException ex, WebRequest request) {
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
+        String requestURI = httpServletRequest.getRequestURI();
+
+        String message = String.format("잘못된 타입의 인자입니다. 경로: %s, 잘못된 값: %s", ex.getName(), ex.getValue());
+
+        log.error("MethodArgumentTypeMismatchException 발생: requestURI={}, error={}", requestURI, message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(ErrorCode.USER_INPUT_EXCEPTION));
     }
 }

--- a/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.util.Date;
 import java.util.UUID;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import com.amazonaws.HttpMethod;
@@ -32,6 +33,7 @@ public class S3ImageUtil implements ImageUtil {
 
 	// 이미지 삭제
 	@Override
+	@Async
 	public void deleteImage(String imagePath) {
 		validateImagePath(imagePath);
 

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
@@ -42,14 +42,14 @@ public class PostImageService extends ImageService {
 	}
 
 	// 이미지 삭제
-	// Transactional 안 묶음. 각 delete 메서드 실패 시 RuntTimeException으로 롤백, 동시 삭제 요청오면 한쪽만 성공
 	@Override
+	@Transactional
 	public void deleteImage(Long id) {
 		PostImageEntity image = postImageEntityRepository.findById(id)
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
 
 		postImageEntityRepository.delete(image);
-		imageUtil.deleteImage(image.getImagePath());
+		imageUtil.deleteImage(image.getImagePath()); // s3는 비동기로 삭제, 트랜잭션 무관
 	}
 
 	// 원격 저장소에 이미지 저장 확인 후 DB에 저장

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -93,6 +93,7 @@ public class PostService {
 		return PageResponse.of(responsePages);
 	}
 
+	@Transactional
 	public void deletePost(Long postId) {
 		PostEntity post = postEntityRepository.findById(postId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND_EXCEPTION));

--- a/src/test/java/hanium/modic/backend/domain/post/entityfactory/PostFactory.java
+++ b/src/test/java/hanium/modic/backend/domain/post/entityfactory/PostFactory.java
@@ -8,7 +8,7 @@ import hanium.modic.backend.domain.post.entity.PostEntity;
 
 public class PostFactory {
 
-	public static PostEntity createMockPost(Long id) {
+	public static PostEntity createMockPostWithId(Long id) {
 		PostEntity post = PostEntity.builder()
 			.title("테스트 게시글 " + id)
 			.description("테스트 설명 " + id)
@@ -20,5 +20,14 @@ public class PostFactory {
 		when(spyPost.getId()).thenReturn(id);
 
 		return spyPost;
+	}
+
+	public static PostEntity createMockPost() {
+		return PostEntity.builder()
+			.title("테스트 게시글")
+			.description("테스트 설명")
+			.commercialPrice(10000L)
+			.nonCommercialPrice(5000L)
+			.build();
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
@@ -15,7 +15,10 @@ import org.springframework.http.MediaType;
 import hanium.modic.backend.base.BaseIntegrationTest;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
+import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
+import hanium.modic.backend.domain.post.entityfactory.PostFactory;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
 import hanium.modic.backend.web.post.dto.request.CreatePostRequest;
@@ -84,5 +87,21 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 		assertThat(saved.getCommercialPrice()).isEqualTo(10000L);
 		assertThat(saved.getNonCommercialPrice()).isEqualTo(5000L);
 		assertThat(images.size()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("게시글 삭제 요청 API")
+	void deletePost_ValidRequest_ShouldReturn200AndDeleteData() throws Exception {
+		// given
+		PostEntity post = postEntityRepository.save(PostFactory.createMockPost());
+		postImageEntityRepository.save(ImageFactory.createMockPostImage(post));
+
+		// when
+		mockMvc.perform(delete("/api/posts/{id}", post.getId())
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNoContent());
+
+		assertThat(postEntityRepository.count()).isEqualTo(0);
+		assertThat(postImageEntityRepository.count()).isEqualTo(0);
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -52,18 +52,6 @@ class PostControllerTest {
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
-	//    @BeforeEach
-	//    void setUp() {
-	//        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
-	//        validator.afterPropertiesSet();
-	//
-	//        mockMvc = MockMvcBuilders
-	//                .standaloneSetup(postController)
-	//                .setValidator(validator)
-	//                .setControllerAdvice(new GlobalExceptionHandler())
-	//                .build();
-	//    }
-
 	@Test
 	@DisplayName("게시물 생성 요청 성공")
 	void createPost_ValidRequest_ShouldReturn200AndInvokeService() throws Exception {
@@ -294,6 +282,24 @@ class PostControllerTest {
 			Arguments.of("page", "-1"),
 			Arguments.of("size", "9"),
 			Arguments.of("size", "21")
+		);
+	}
+
+	@ParameterizedTest
+	@DisplayName("게시물 삭제 실패 - 잘못된 RequestParam")
+	@MethodSource("provideInvalidDeleteParameters")
+	void deletePost_InvalidRequestParam(Long postId) throws Exception {
+		// when
+		mockMvc.perform(delete("/api/posts/{id}", postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(ErrorCode.USER_INPUT_EXCEPTION.getCode()));
+	}
+
+	static Stream<Arguments> provideInvalidDeleteParameters() {
+		return Stream.of(
+			Arguments.of(-1L),
+			Arguments.of("null")
 		);
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
@@ -118,7 +118,7 @@ public class PostImageControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("이미지 저장 콜백 실패 : 이미지 경로 중복")
 	public void createImageUrlCallbackFail() throws Exception {
 		// given
-		PostEntity post = PostFactory.createMockPost(1L);
+		PostEntity post = PostFactory.createMockPostWithId(1L);
 		PostImageEntity savedPostImage = ImageFactory.createMockPostImage(post);
 
 		CallbackImageSaveUrlRequest request = new CallbackImageSaveUrlRequest(


### PR DESCRIPTION
## 개요
- close #21 

## 작업사항
### 비동기 쓰레드 풀 설정
`@Async` 비동기 처리를 위해 비동기 쓰레드 풀을 설정해주었다.(기본적으로 항상 Thread를 생성하는 방식으로 동작하기에, 비효율을 방지하고자 설정했다.)
![image](https://github.com/user-attachments/assets/ee797030-0612-4d73-a5f2-e04a39444969)
- 기본 ThreadPoolSize 1(당장은 t2.micro로 운영되기 때문에 1개로 고정했다.)
- 최대 Size 2(다만 추가 요청을 고려하여 2개까지 허용했다.)
- MDC 설정을 통한 context 정보 이동 설정
- 비동기 예외 핸들링

### 이미지 삭제 로직 개선
![image](https://github.com/user-attachments/assets/1f21bfc2-2193-420e-95e9-724ed10e480e)
기존 Image삭제 로직은 메서드에 @Transactional을 감싸지 않으므로써, Connection 문제를 예방했다.
허나, 협업을 하면서 의도하지 않은 코드를 쓸 수 있기 때문에 좀 더 안정적인 방법을 생각하게 되었고,
아예 IO를 사용하는 로직을 비동기로 처리하여 기존의 Tranaction과 무관하게 하며 성능을 보장하는 방법을 생각하게 되었다.

![image](https://github.com/user-attachments/assets/4883d8c6-adc0-45f5-883e-c2a1bca87942)
이로 인해 deleteImage에는 @Async를 설정해주었고
![image](https://github.com/user-attachments/assets/221b8c80-8b47-4461-905e-10e007bd0612)
PostImageService,deleteImage는 익숙하게 @Transactional을 붙여주었다.

### 기타
- Post 삭제 테스트 구현
