### PR TITLE
Feature: 포스트 변경 API 및 테스트 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 	INVALID_IMAGE_FILE_NAME_EXCEPTION(HttpStatus.BAD_REQUEST, "I-003", "잘못된 이미지 파일 이름입니다."),
 	INVALID_IMAGE_FILE_PATH_EXCEPTION(HttpStatus.BAD_REQUEST, "I-004", "잘못된 이미지 파일 경로입니다."),
 	IMAGE_PATH_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, "I-005", "이미지 경로가 중복되었습니다."),
+	IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION(HttpStatus.BAD_REQUEST, "I-006", "이미지를 훔칠 수 없습니다."),
 
 	// Server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "서버 내부에서 에러가 발생하였습니다."),

--- a/src/main/java/hanium/modic/backend/domain/image/util/ImageUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/image/util/ImageUtil.java
@@ -1,5 +1,7 @@
 package hanium.modic.backend.domain.image.util;
 
+import java.util.List;
+
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
 
@@ -7,6 +9,9 @@ public interface ImageUtil {
 
 	// 이미지 삭제
 	void deleteImage(String imagePath);
+
+	// 여러 이미지 삭제
+	void deleteImages(List<String> imagePaths);
 
 	// 이미지 URL 생성
 	String createImageUrl(ImagePrefix imagePrefix, String imagePath);

--- a/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
@@ -5,14 +5,19 @@ import static hanium.modic.backend.common.error.ErrorCode.*;
 
 import java.net.URL;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
 
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.common.property.property.S3Properties;
@@ -37,7 +42,40 @@ public class S3ImageUtil implements ImageUtil {
 	public void deleteImage(String imagePath) {
 		validateImagePath(imagePath);
 
+		// TODO : 실패한 이미지 경로를 로그로 남기거나 처리하는 로직 추가
 		amazonS3Client.deleteObject(s3Properties.getBucketName(), imagePath);
+	}
+
+	// 여러 이미지 삭제
+	@Override
+	@Async
+	public void deleteImages(List<String>imagePaths) {
+		if (imagePaths == null || imagePaths.isEmpty()) {
+			return;
+		}
+		for (String imagePath : imagePaths) {
+			validateImagePath(imagePath);
+		}
+
+		// KeyVersion 객체 리스트로 변환
+		List<KeyVersion> keyVersions = imagePaths.stream()
+			.map(KeyVersion::new)
+			.toList();
+
+		DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(s3Properties.getBucketName())
+			.withKeys(keyVersions);
+
+		try {
+			amazonS3Client.deleteObjects(deleteObjectsRequest);
+		} catch (MultiObjectDeleteException e) {
+			// 일부 실패한 경우
+			log.error("S3ImageUtil.deleteImages() - MultiObjectDeleteException: {}", e.getMessage());
+
+			// TODO : 실패한 이미지 경로를 로그로 남기거나 처리하는 로직 추가
+			e.getErrors().forEach(error ->
+				System.err.println(error.getKey())
+			);
+		}
 	}
 
 	// 이미지 URL 생성

--- a/src/main/java/hanium/modic/backend/domain/post/entity/PostEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/post/entity/PostEntity.java
@@ -37,4 +37,18 @@ public class PostEntity {
         this.commercialPrice = commercialPrice;
         this.nonCommercialPrice = nonCommercialPrice;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+    public void updateCommercialPrice(Long commercialPrice) {
+        this.commercialPrice = commercialPrice;
+    }
+
+    public void updateNonCommercialPrice(Long nonCommercialPrice) {
+        this.nonCommercialPrice = nonCommercialPrice;
+    }
 }

--- a/src/main/java/hanium/modic/backend/domain/post/entity/PostImageEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/post/entity/PostImageEntity.java
@@ -1,5 +1,8 @@
 package hanium.modic.backend.domain.post.entity;
 
+import static hanium.modic.backend.common.error.ErrorCode.*;
+
+import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.image.domain.Image;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
@@ -47,6 +50,11 @@ public class PostImageEntity extends Image {
 	}
 
 	public void updatePost(PostEntity postEntity) {
+		// 이미 Post에 속해있는 이미지에 대해 다시 Post를 설정할 경우 예외 발생
+		// Image에 해당하는 Post가 없었을 경우는 무관하지만, 있는 상황에서 다시 설정하려하는 것은 도용이다.
+		if (postId != null) {
+			throw new AppException(IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
+		}
 		this.postId = postEntity.getId();
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/entity/PostImageEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/post/entity/PostImageEntity.java
@@ -2,6 +2,8 @@ package hanium.modic.backend.domain.post.entity;
 
 import static hanium.modic.backend.common.error.ErrorCode.*;
 
+import java.util.Objects;
+
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.image.domain.Image;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
@@ -49,12 +51,16 @@ public class PostImageEntity extends Image {
 		}
 	}
 
+	// 포스트ID 변경
 	public void updatePost(PostEntity postEntity) {
 		// 이미 Post에 속해있는 이미지에 대해 다시 Post를 설정할 경우 예외 발생
+		// 만약 PostId가 있지만 PostEntity값과 같으면 예외발생x
 		// Image에 해당하는 Post가 없었을 경우는 무관하지만, 있는 상황에서 다시 설정하려하는 것은 도용이다.
-		if (postId != null) {
+		if (postId != null && !Objects.equals(this.postId, postEntity.getId())) {
 			throw new AppException(IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
+
 		}
 		this.postId = postEntity.getId();
+
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/repository/PostImageEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/post/repository/PostImageEntityRepository.java
@@ -3,9 +3,13 @@ package hanium.modic.backend.domain.post.repository;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostImageEntityRepository extends JpaRepository<PostImageEntity, Long> {
     List<PostImageEntity> findAllByPostId(Long postId);
 
 	boolean existsByImagePath(String imagePath);
+
+	@Query("SELECT pi FROM PostImageEntity pi WHERE pi.id IN :ids")
+	List<PostImageEntity> findAllByIds(List<Long> ids);
 }

--- a/src/main/java/hanium/modic/backend/domain/post/repository/PostImageEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/post/repository/PostImageEntityRepository.java
@@ -3,7 +3,9 @@ package hanium.modic.backend.domain.post.repository;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostImageEntityRepository extends JpaRepository<PostImageEntity, Long> {
     List<PostImageEntity> findAllByPostId(Long postId);
@@ -12,4 +14,8 @@ public interface PostImageEntityRepository extends JpaRepository<PostImageEntity
 
 	@Query("SELECT pi FROM PostImageEntity pi WHERE pi.id IN :ids")
 	List<PostImageEntity> findAllByIds(List<Long> ids);
+
+	@Modifying
+	@Query("DELETE FROM PostImageEntity i WHERE i.id IN :ids")
+	void deleteAllByIds(List<Long> ids);
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
@@ -2,6 +2,8 @@ package hanium.modic.backend.domain.post.service;
 
 import static hanium.modic.backend.common.error.ErrorCode.*;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +37,7 @@ public class PostImageService extends ImageService {
 	// POST 이미지는 public이므로 get URL 생성 없이 바로 URL 응답
 	@Override
 	@Transactional(readOnly = true)
-	public String createImageGetUrl(Long id) {
+	public String createImageGetUrl(final Long id) {
 		PostImageEntity image = postImageEntityRepository.findById(id)
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
 		return image.getImageUrl();
@@ -44,7 +46,7 @@ public class PostImageService extends ImageService {
 	// 이미지 삭제
 	@Override
 	@Transactional
-	public void deleteImage(Long id) {
+	public void deleteImage(final Long id) {
 		PostImageEntity image = postImageEntityRepository.findById(id)
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
 
@@ -52,9 +54,27 @@ public class PostImageService extends ImageService {
 		imageUtil.deleteImage(image.getImagePath()); // s3는 비동기로 삭제, 트랜잭션 무관
 	}
 
+	// 여러 이미지 삭제
+	@Transactional
+	public void deleteImages(final List<PostImageEntity> postImages) {
+		if (postImages == null || postImages.isEmpty()) {
+			return;
+		}
+
+		final List<String> imagePaths = postImages.stream()
+			.map(PostImageEntity::getImagePath)
+			.toList();
+		final List<Long> ids = postImages.stream()
+			.map(PostImageEntity::getId)
+			.toList();
+
+		postImageEntityRepository.deleteAllByIds(ids);
+		imageUtil.deleteImages(imagePaths); // s3는 비동기로 삭제, 트랜잭션 무관
+	}
+
 	// 원격 저장소에 이미지 저장 확인 후 DB에 저장
 	@Override
-	public Long saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath) {
+	public Long saveImage(final ImagePrefix imagePrefix, final String fullFileName, final String imagePath) {
 		imageValidationService.validateImageSaved(imagePath, imagePrefix);
 		imageValidationService.validateFullFileName(fullFileName);
 		validateDuplicatedImagePath(imagePath);
@@ -78,7 +98,7 @@ public class PostImageService extends ImageService {
 	}
 
 	// 이미지 경로가 중복되면 에러
-	private void validateDuplicatedImagePath(String imagePath) {
+	private void validateDuplicatedImagePath(final String imagePath) {
 		if (postImageEntityRepository.existsByImagePath(imagePath)) {
 			throw new AppException(IMAGE_PATH_DUPLICATED_EXCEPTION);
 		}

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -61,12 +61,9 @@ public class PostService {
 		PostEntity postEntity = postEntityRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND_EXCEPTION));
 
-		List<String> imageUrls = postImageEntityRepository.findAllByPostId(id)
-			.stream()
-			.map(PostImageEntity::getImageUrl)
-			.toList();
+		List<PostImageEntity> postImages = postImageEntityRepository.findAllByPostId(id);
 
-		return GetPostResponse.from(postEntity, imageUrls);
+		return GetPostResponse.from(postEntity, postImages);
 	}
 
 	@Transactional(readOnly = true)
@@ -82,12 +79,9 @@ public class PostService {
 		}
 
 		Page<GetPostResponse> responsePages = posts.map(post -> {
-			List<String> imageUrls = postImageEntityRepository.findAllByPostId(post.getId())
-				.stream()
-				.map(PostImageEntity::getImageUrl)
-				.toList();
+			List<PostImageEntity> postImages = postImageEntityRepository.findAllByPostId(post.getId());
 
-			return GetPostResponse.from(post, imageUrls);
+			return GetPostResponse.from(post, postImages);
 		});
 
 		return PageResponse.of(responsePages);

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -125,9 +125,10 @@ public class PostService {
 		List<PostImageEntity> postImages = postImageEntityRepository.findAllByPostId(id);
 
 		// imageIds에 포함되지 않은 이미지 삭제
-		postImages.stream()
+		List<PostImageEntity> deleteImages = postImages.stream()
 			.filter(postImageEntity -> !imageIds.contains(postImageEntity.getId()))
-			.forEach(postImageEntity -> postImageService.deleteImage(postImageEntity.getId()));
+			.toList();
+		postImageService.deleteImages(deleteImages);
 
 		// 새로 추가된 이미지에 PostId 업데이트
 		postImageEntityRepository.findAllByIds(imageIds)

--- a/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,7 @@ import hanium.modic.backend.common.response.ApiResponse;
 import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.web.post.dto.request.CreatePostRequest;
+import hanium.modic.backend.web.post.dto.request.UpdatePostRequest;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import jakarta.validation.Valid;
@@ -68,4 +70,14 @@ public class PostController {
 		postService.deletePost(id);
 		return ResponseEntity.status(NO_CONTENT).body(ApiResponse.noContent());
 	}
+
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse<Void>> updatePost(
+		@PathVariable Long id,
+		@RequestBody @Valid UpdatePostRequest request) {
+		postService.updatePost(id, request.title(), request.description(), request.commercialPrice(),
+			request.nonCommercialPrice(), request.imageIds());
+		return ResponseEntity.status(NO_CONTENT).body(ApiResponse.noContent());
+	}
+
 }

--- a/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
@@ -6,9 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -71,7 +71,7 @@ public class PostController {
 		return ResponseEntity.status(NO_CONTENT).body(ApiResponse.noContent());
 	}
 
-	@PatchMapping("/{id}")
+	@PutMapping("/{id}")
 	public ResponseEntity<ApiResponse<Void>> updatePost(
 		@PathVariable Long id,
 		@RequestBody @Valid UpdatePostRequest request) {

--- a/src/main/java/hanium/modic/backend/web/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/request/CreatePostRequest.java
@@ -11,7 +11,11 @@ public record CreatePostRequest(
         @NotBlank(message = "제목은 필수입니다.")
         @Length(min = 1, max = 20)
         String title,
+
+        @NotBlank(message = "설명은 필수입니다.")
+        @Length(min = 1, max = 10000, message = "설명은 최대 10000자까지 가능합니다.")
         String description,
+
         @NotNull(message = "상업적 가격은 필수입니다.")
         @Min(value = 0, message = "상업적 가격은 0 이상이어야 합니다.")
         Long commercialPrice,

--- a/src/main/java/hanium/modic/backend/web/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/request/UpdatePostRequest.java
@@ -1,0 +1,32 @@
+package hanium.modic.backend.web.post.dto.request;
+
+import java.util.List;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePostRequest(
+	@NotBlank(message = "제목은 필수입니다.")
+	@Length(min = 1, max = 20)
+	String title,
+
+	String description,
+
+	@NotNull(message = "상업적 가격은 필수입니다.")
+	@Min(value = 0, message = "상업적 가격은 0 이상이어야 합니다.")
+	Long commercialPrice,
+
+	@NotNull(message = "비상업적 가격은 필수입니다.")
+	@Min(value = 0, message = "비상업적 가격은 0 이상이어야 합니다.")
+	Long nonCommercialPrice,
+
+	@NotNull(message = "이미지는 필수입니다.")
+	@Size(min = 1, message = "이미지는 최소 1개 이상이어야 합니다.")
+	@Size(max = 8, message = "이미지는 최대 8개까지 업로드 가능합니다.")
+	List<Long> imageIds
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/request/UpdatePostRequest.java
@@ -14,6 +14,8 @@ public record UpdatePostRequest(
 	@Length(min = 1, max = 20)
 	String title,
 
+	@NotBlank(message = "설명은 필수입니다.")
+	@Length(min = 1, max = 10000, message = "설명은 최대 10000자까지 가능합니다.")
 	String description,
 
 	@NotNull(message = "상업적 가격은 필수입니다.")

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
@@ -3,6 +3,10 @@ package hanium.modic.backend.web.post.dto.response;
 import java.util.List;
 
 import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.entity.PostImageEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 public record GetPostResponse(
 	Long id,
@@ -10,16 +14,27 @@ public record GetPostResponse(
 	String description,
 	Long commercialPrice,
 	Long nonCommercialPrice,
-	List<String> imageUrls
+	List<ImageDto> images
 ) {
-	public static GetPostResponse from(PostEntity postEntity, List<String> imageUrls) {
+	public static GetPostResponse from(PostEntity postEntity, List<PostImageEntity> images) {
+		List<ImageDto> imageDtos = images.stream()
+			.map(image -> new ImageDto(image.getImageUrl(), image.getId()))
+			.toList();
+
 		return new GetPostResponse(
 			postEntity.getId(),
 			postEntity.getTitle(),
 			postEntity.getDescription(),
 			postEntity.getCommercialPrice(),
 			postEntity.getNonCommercialPrice(),
-			imageUrls
+			imageDtos
 		);
+	}
+
+	@Getter
+	@AllArgsConstructor(access = AccessLevel.PUBLIC)
+	public static class ImageDto {
+		private String imageUrl;
+		private Long imageId;
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/image/entityfactory/ImageFactory.java
+++ b/src/test/java/hanium/modic/backend/domain/image/entityfactory/ImageFactory.java
@@ -1,7 +1,11 @@
 package hanium.modic.backend.domain.image.entityfactory;
 
+import static org.mockito.Mockito.*;
+
 import java.util.Arrays;
 import java.util.List;
+
+import org.mockito.Mockito;
 
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
@@ -33,7 +37,7 @@ public class ImageFactory {
 		);
 	}
 
-	public static PostImageEntity createMockPostImage(PostEntity postEntity ) {
+	public static PostImageEntity createMockPostImage(PostEntity postEntity) {
 		return PostImageEntity.builder()
 			.imagePath("imagePath1")
 			.imageUrl("http://dqweq2ejh93-img1.jpg")
@@ -43,5 +47,22 @@ public class ImageFactory {
 			.imagePurpose(ImagePrefix.POST)
 			.postEntity(postEntity)
 			.build();
+	}
+
+	public static PostImageEntity createMockPostImageWithId(PostEntity postEntity, Long postImageId) {
+		PostImageEntity postImage = PostImageEntity.builder()
+			.imagePath("imagePath1")
+			.imageUrl("http://dqweq2ejh93-img1.jpg")
+			.fullImageName("img1.jpg")
+			.imageName("img1")
+			.extension(ImageExtension.JPG)
+			.imagePurpose(ImagePrefix.POST)
+			.postEntity(postEntity)
+			.build();
+
+		PostImageEntity spyPostImage = Mockito.spy(postImage);
+		when(spyPostImage.getId()).thenReturn(postImageId);
+
+		return spyPostImage;
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/image/entityfactory/ImageFactory.java
+++ b/src/test/java/hanium/modic/backend/domain/image/entityfactory/ImageFactory.java
@@ -2,6 +2,7 @@ package hanium.modic.backend.domain.image.entityfactory;
 
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -14,27 +15,21 @@ import hanium.modic.backend.domain.post.entity.PostImageEntity;
 
 public class ImageFactory {
 
-	public static List<PostImageEntity> createMockPostImages(PostEntity postEntity) {
-		return Arrays.asList(
-			PostImageEntity.builder()
-				.imagePath("imagePath1")
-				.imageUrl("http://dqweq2ejh93-img1.jpg")
-				.fullImageName("img1.jpg")
-				.imageName("img1")
+	public static List<PostImageEntity> createMockPostImages(PostEntity postEntity, int count) {
+		List<PostImageEntity> postImages = new ArrayList<>();
+		for (int c = 1; c <= count; c++) {
+			postImages.add(PostImageEntity.builder()
+				.imagePath("imagePath" + c)
+				.imageUrl("http://dqweq2ejh93-img" + c + ".jpg")
+				.fullImageName("img" + c + ".jpg")
+				.imageName("img" + c)
 				.extension(ImageExtension.JPG)
 				.imagePurpose(ImagePrefix.POST)
 				.postEntity(postEntity)
-				.build(),
-			PostImageEntity.builder()
-				.imagePath("imagePath2")
-				.imageUrl("http://dqweq2ejh93-img2.jpg")
-				.fullImageName("img2.jpg")
-				.imageName("img2")
-				.extension(ImageExtension.JPG)
-				.imagePurpose(ImagePrefix.POST)
-				.postEntity(postEntity)
-				.build()
-		);
+				.build());
+		}
+
+		return postImages;
 	}
 
 	public static PostImageEntity createMockPostImage(PostEntity postEntity) {

--- a/src/test/java/hanium/modic/backend/domain/image/util/S3ImageUtilTest.java
+++ b/src/test/java/hanium/modic/backend/domain/image/util/S3ImageUtilTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +63,26 @@ class S3ImageUtilTest {
 		// then
 		assertEquals(ErrorCode.INVALID_IMAGE_FILE_PATH_EXCEPTION.getCode(), exception.getErrorCode().getCode());
 	}
+
+	@ParameterizedTest
+	@DisplayName("여러 이미지 삭제 : imagePath가 유효하지 않을 경우 에러가 발생한다.")
+	@MethodSource("provideInvalidImagePaths")
+	void testDeleteImagesWithInvalidImagePaths(List<String> imagePaths) {
+		// when
+		AppException exception = assertThrows(AppException.class, () -> {
+			s3ImageUtil.deleteImages(imagePaths);
+		});
+
+		// then
+		assertEquals(ErrorCode.INVALID_IMAGE_FILE_PATH_EXCEPTION.getCode(), exception.getErrorCode().getCode());
+	}
+	private static Stream<List<String>> provideInvalidImagePaths() {
+		return Stream.of(
+			List.of(""),
+			List.of("test/image.jpg", "")
+		);
+	}
+
 
 	@Test
 	@DisplayName("이미지 url 생성 : 성공")

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -65,7 +65,7 @@ class PostServiceTest {
 		Long nonCommercialPrice = 500L;
 
 		List<Long> imageIds = new ArrayList<>();
-		List<PostImageEntity> postImageEntities = ImageFactory.createMockPostImages(null);
+		List<PostImageEntity> postImageEntities = ImageFactory.createMockPostImages(null, 2);
 
 		for (int i = 0; i < postImageEntities.size(); i++) {
 			imageIds.add((long)i);
@@ -102,7 +102,7 @@ class PostServiceTest {
 		// Given
 		Long postId = 1L;
 		PostEntity mockPost = createMockPostWithId(postId);
-		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost);
+		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost, 2);
 		List<String> expectedImageUrls = mockImages.stream()
 			.map(PostImageEntity::getImageUrl)
 			.toList();
@@ -159,8 +159,8 @@ class PostServiceTest {
 			PageRequest.of(page, size, SORT_DIRECTION, SORT_CRITERIA),
 			mockPosts.size());
 
-		List<PostImageEntity> mockImagesForPost1 = ImageFactory.createMockPostImages(mockPosts.get(0));
-		List<PostImageEntity> mockImagesForPost2 = ImageFactory.createMockPostImages(mockPosts.get(1));
+		List<PostImageEntity> mockImagesForPost1 = ImageFactory.createMockPostImages(mockPosts.get(0), 2);
+		List<PostImageEntity> mockImagesForPost2 = ImageFactory.createMockPostImages(mockPosts.get(1), 2);
 
 		when(postEntityRepository.findAll(any(Pageable.class))).thenReturn(mockPostPage);
 		when(postImageEntityRepository.findAllByPostId(1L)).thenReturn(mockImagesForPost1);
@@ -210,7 +210,7 @@ class PostServiceTest {
 		// Given
 		final Long postId = 1L;
 		PostEntity mockPost = PostFactory.createMockPostWithId(postId);
-		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost);
+		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost, 2);
 
 		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
 		when(postImageEntityRepository.findAllByPostId(postId)).thenReturn(mockImages);

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
@@ -1,6 +1,8 @@
 package hanium.modic.backend.web.post.controller;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -10,9 +12,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
@@ -22,6 +28,7 @@ import hanium.modic.backend.domain.post.entityfactory.PostFactory;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
 import hanium.modic.backend.web.post.dto.request.CreatePostRequest;
+import hanium.modic.backend.web.post.dto.request.UpdatePostRequest;
 
 class PostControllerIntegrationTest extends BaseIntegrationTest {
 
@@ -30,6 +37,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 
 	@Autowired
 	private PostImageEntityRepository postImageEntityRepository;
+
 
 	@BeforeEach
 	void setUp() {
@@ -103,5 +111,99 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 
 		assertThat(postEntityRepository.count()).isEqualTo(0);
 		assertThat(postImageEntityRepository.count()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("게시글 수정 요청 API")
+	void updatePost_ValidRequest_ShouldReturn200AndUpdateData() throws Exception {
+		// given
+		PostEntity post = postEntityRepository.save(PostFactory.createMockPost());
+		postImageEntityRepository.save(ImageFactory.createMockPostImage(post));
+
+		CreatePostRequest request = new CreatePostRequest(
+			"수정된 제목",
+			"수정된 설명",
+			20000L,
+			10000L,
+			List.of(1L, 2L)
+		);
+		String json = objectMapper.writeValueAsString(request);
+
+		// when
+		mockMvc.perform(put("/api/posts/{id}", post.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isOk());
+
+		assertThat(postEntityRepository.count()).isEqualTo(1);
+		assertThat(postImageEntityRepository.count()).isEqualTo(2);
+
+		var updatedPost = postEntityRepository.findById(post.getId()).orElseThrow();
+		assertThat(updatedPost.getTitle()).isEqualTo("수정된 제목");
+		assertThat(updatedPost.getDescription()).isEqualTo("수정된 설명");
+		assertThat(updatedPost.getCommercialPrice()).isEqualTo(20000L);
+		assertThat(updatedPost.getNonCommercialPrice()).isEqualTo(10000L);
+	}
+
+	@Test
+	@DisplayName("게시글 수정 요청 API - 남의 Image를 도용하면 에러")
+	void updatePost_ValidRequest_ShouldReturn400AndThrowException() throws Exception {
+		// given
+		// 다른 사람의 게시글
+		PostEntity otherPersonsPost = postEntityRepository.save(PostFactory.createMockPost());
+		PostImageEntity otherPersonsImage = postImageEntityRepository
+			.save(ImageFactory.createMockPostImage(otherPersonsPost));
+
+		// 내 게시글
+		PostEntity myPost = postEntityRepository.save(PostFactory.createMockPost());
+
+		UpdatePostRequest request = new UpdatePostRequest(
+			"수정된 제목",
+			"수정된 설명",
+			20000L,
+			10000L,
+			List.of(otherPersonsImage.getId())
+		);
+		String json = objectMapper.writeValueAsString(request);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/posts/{id}", myPost.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isBadRequest());
+
+		resultActions
+			.andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+			.andExpect(jsonPath("$.code").value(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION.getCode()));
+	}
+
+	@Test
+	@DisplayName("게시글 수정 요청 API - 없어진 이미지는 삭제")
+	void updatePost_ValidRequest_ShouldReturn200AndDeleteImage() throws Exception {
+		// given
+		PostEntity post = postEntityRepository.save(PostFactory.createMockPost());
+		PostImageEntity image1 = postImageEntityRepository.save(ImageFactory.createMockPostImage(post));
+		PostImageEntity image2 = postImageEntityRepository.save(ImageFactory.createMockPostImage(post));
+
+		UpdatePostRequest request = new UpdatePostRequest(
+			"수정된 제목",
+			"수정된 설명",
+			20000L,
+			10000L,
+			List.of(image1.getId())
+		);
+		String json = objectMapper.writeValueAsString(request);
+
+		// when
+		mockMvc.perform(patch("/api/posts/{id}", post.getId())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isNoContent());
+
+		assertThat(postEntityRepository.count()).isEqualTo(1);
+		assertThat(postImageEntityRepository.count()).isEqualTo(1);
+
+		var remainingImage = postImageEntityRepository.findById(image1.getId()).orElseThrow();
+		assertThat(remainingImage.getId()).isEqualTo(image1.getId());
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -279,24 +279,6 @@ class PostControllerTest {
 		);
 	}
 
-	@ParameterizedTest
-	@DisplayName("게시물 삭제 실패 - 잘못된 RequestParam")
-	@MethodSource("provideInvalidDeleteParameters")
-	void deletePost_InvalidRequestParam(Long postId) throws Exception {
-		// when
-		mockMvc.perform(delete("/api/posts/{id}", postId)
-				.contentType(MediaType.APPLICATION_JSON))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ErrorCode.USER_INPUT_EXCEPTION.getCode()));
-	}
-
-	static Stream<Arguments> provideInvalidDeleteParameters() {
-		return Stream.of(
-			Arguments.of(-1L),
-			Arguments.of("null")
-		);
-	}
-
 	@ParameterizedTest(name = "[{index}] {2}")
 	@DisplayName("게시글 변경 요청 실패 - 잘못된 RequestParam")
 	@MethodSource("provideInvalidUpdateParameters")

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -167,7 +167,7 @@ class PostControllerTest {
 		// given
 		Long postId = 1L;
 		GetPostResponse response = new GetPostResponse(
-			1L, "제목", "설명", 10000L, 5000L, List.of("http://img1.jpg"));
+			1L, "제목", "설명", 10000L, 5000L, List.of(new GetPostResponse.ImageDto("http://img1.jpg", 1L)));
 
 		when(postService.getPost(postId)).thenReturn(response);
 
@@ -199,9 +199,9 @@ class PostControllerTest {
 	void getPosts_DefaultParams_Success() throws Exception {
 		// given
 		GetPostResponse post1 = new GetPostResponse(
-			1L, "제목1", "설명1", 10000L, 5000L, List.of("http://img1.jpg"));
+			1L, "제목1", "설명1", 10000L, 5000L, List.of(new GetPostResponse.ImageDto("http://img1.jpg", 1L)));
 		GetPostResponse post2 = new GetPostResponse(
-			2L, "제목2", "설명2", 20000L, 8000L, List.of("http://img2.jpg"));
+			2L, "제목2", "설명2", 20000L, 8000L, List.of(new GetPostResponse.ImageDto("http://img2.jpg", 2L)));
 
 		List<GetPostResponse> content = List.of(post1, post2);
 		Page<GetPostResponse> page = new PageImpl<>(content, PageRequest.of(0, 10), 2);
@@ -228,7 +228,7 @@ class PostControllerTest {
 		Exception {
 		// given
 		GetPostResponse post = new GetPostResponse(
-			1L, "제목", "설명", 10000L, 5000L, List.of("http://img1.jpg"));
+			1L, "제목", "설명", 10000L, 5000L, List.of(new GetPostResponse.ImageDto("http://img1.jpg", 1L)));
 
 		List<GetPostResponse> content = List.of(post);
 		Page<GetPostResponse> page = new PageImpl<>(content, PageRequest.of(pageNumber, size), totalElements);
@@ -285,7 +285,7 @@ class PostControllerTest {
 	void updatePost_InvalidRequestParam(UpdatePostRequest request, String expectedErrorMessage) throws Exception {
 		String json = objectMapper.writeValueAsString(request);
 
-		mockMvc.perform(patch("/api/posts/{id}", 1L)
+		mockMvc.perform(put("/api/posts/{id}", 1L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(json))
 			.andExpect(status().isBadRequest())

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -308,6 +308,29 @@ class PostControllerTest {
 			Arguments.of(
 				new UpdatePostRequest(
 					"제목",
+					null,
+					0L,
+					0L,
+					List.of(1L)
+				),
+				"설명은 필수입니다.",
+				"설명 누락"
+			),
+			Arguments.of(
+				new UpdatePostRequest(
+					"제목",
+					"",
+					0L,
+					0L,
+					List.of(1L)
+				),
+				"설명은 필수입니다.",
+				"설명 비어있음"
+			),
+
+			Arguments.of(
+				new UpdatePostRequest(
+					"제목",
 					"설명",
 					null,
 					0L,


### PR DESCRIPTION
## 개요
- close #14

## 작업사항
### 이미지 도용 공격 방어
![image](https://github.com/user-attachments/assets/5b0935f9-871a-4123-92d7-046006b6a32a)
기존에 포스트를 생성할 때 ImageID를 입력하게 했고, 이 때 해당 Image에 postId를 외래키로 넣어주었다.
다만 다른 포스트에서 기존 포스트 이미지 ID를 적으면 PostId가 변경되어 도용되는 일이 발생했다.

![image](https://github.com/user-attachments/assets/ca5f7430-e339-45e0-aa0a-1399cc689144)
이로 인해 한번 결정된 PostId는 수정하지 못하도록 변경했다.

### 포스트 변경 로직 및 테스트 구현
포스트 변경 로직 시 이미지 처리가 가장 중요했다.

![image](https://github.com/user-attachments/assets/804d3eca-1626-4b9f-9380-7c9cc612ebe7)
없어진 Image들은 삭제하게 했으며, 추가된 이미지에 대해서는 Image에 외래키를 등록하도록 했다.

이에 맞게
- 포스트에서 이미지를 제외했을 때 삭제되는 지 테스트
- 이미지를 도용하려 했을 때 에러 테스트 등을 작성했다.

- 그 외에 Controller, Integration, Service 테스트도 작성했다.