### PR TITLE
[REFACTOR] saveImage 메서드 리턴 타입 변경

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.domain.image.service;
 
+import hanium.modic.backend.domain.image.domain.Image;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
 import hanium.modic.backend.domain.image.util.ImageUtil;
@@ -25,5 +26,5 @@ public abstract class ImageService {
 	public abstract void deleteImage(Long id);
 
 	// 이미지 저장
-	public abstract Long saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath);
+	public abstract Image saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath);
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
@@ -74,7 +74,7 @@ public class PostImageService extends ImageService {
 
 	// 원격 저장소에 이미지 저장 확인 후 DB에 저장
 	@Override
-	public Long saveImage(final ImagePrefix imagePrefix, final String fullFileName, final String imagePath) {
+	public PostImageEntity saveImage(final ImagePrefix imagePrefix, final String fullFileName, final String imagePath) {
 		imageValidationService.validateImageSaved(imagePath, imagePrefix);
 		imageValidationService.validateFullFileName(fullFileName);
 		validateDuplicatedImagePath(imagePath);
@@ -83,7 +83,7 @@ public class PostImageService extends ImageService {
 		String fileName = fileNameParts[0];
 		String fileExtension = fileNameParts[1];
 
-		PostImageEntity image = postImageEntityRepository.save(
+		return postImageEntityRepository.save(
 			PostImageEntity.builder()
 				.imagePurpose(imagePrefix)
 				.imageUrl(imageUtil.createImageUrl(imagePrefix, imagePath))
@@ -93,8 +93,6 @@ public class PostImageService extends ImageService {
 				.imagePath(imagePath)
 				.build()
 		);
-
-		return image.getId();
 	}
 
 	// 이미지 경로가 중복되면 에러

--- a/src/main/java/hanium/modic/backend/web/post/controller/PostImageController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PostImageController.java
@@ -49,7 +49,7 @@ public class PostImageController {
 			request.imageUsagePurpose(),
 			request.fileName(),
 			request.imagePath()
-		);
+		).getId();
 
 		return ResponseEntity.status(CREATED)
 			.body(ApiResponse.created(new CallbackImageSaveUrlResponse(id)));

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostImageServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostImageServiceTest.java
@@ -17,10 +17,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
 import hanium.modic.backend.domain.image.service.ImageValidationService;
 import hanium.modic.backend.domain.image.util.ImageUtil;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
-import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -122,7 +122,7 @@ class PostImageServiceTest {
 			postImageEntity.getImagePurpose(),
 			postImageEntity.getFullImageName(),
 			postImageEntity.getImagePath()
-		);
+		).getId();
 
 		// then
 

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
@@ -20,9 +20,9 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import hanium.modic.backend.base.BaseIntegrationTest;
 import hanium.modic.backend.common.property.property.S3Properties;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
-import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
 import hanium.modic.backend.domain.post.entityfactory.PostFactory;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
@@ -158,7 +158,7 @@ public class PostImageControllerIntegrationTest extends BaseIntegrationTest {
 		try {
 			// 이미지 업로드
 			uploadImage(imagePath, "test content");
-			Long imageId = postImageService.saveImage(imagePurpose, fileName, imagePath);
+			Long imageId = postImageService.saveImage(imagePurpose, fileName, imagePath).getId();
 
 			// when
 			ResultActions resultActions2 = mockMvc.perform(get("/api/posts/images/{imageId}/get-url", imageId)


### PR DESCRIPTION
## 개요
resolve #36 
자세한 설명은 issue에 명시함

## 작업사항

- `ImageService`의 `saveImage()` - `Image` 반환
- `PostImageService`의 `saveImage()` - `PostImageEntity` 반환
- 관련 테스트 수정