### PR TITLE
[FEATURE] AI 이미지 생성 요청, 상태 확인 기능 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
+++ b/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
@@ -23,6 +23,9 @@ public class RabbitMqConfig {
 	public static final String AI_IMAGE_REQUEST_QUEUE = "ai.image.request.queue";
 	public static final String AI_IMAGE_REQUEST_EXCHANGE = "ai.image.request.exchange";
 	public static final String AI_IMAGE_REQUEST_ROUTING_KEY = "ai.image.request";
+	public static final String AI_IMAGE_CREATED_QUEUE = "ai.image.created.queue";
+	public static final String AI_IMAGE_CREATED_EXCHANGE = "ai.image.created.exchange";
+	public static final String AI_IMAGE_CREATED_ROUTING_KEY = "ai.image.created";
 
 	private final RabbitMqProperties rabbitMqProperties;
 
@@ -41,6 +44,23 @@ public class RabbitMqConfig {
 		return BindingBuilder.bind(aiImageRequestQueue)
 			.to(aiImageRequestExchange)
 			.with(AI_IMAGE_REQUEST_ROUTING_KEY);
+	}
+
+	@Bean
+	public Queue aiImageCreatedQueue() {
+		return new Queue(AI_IMAGE_CREATED_QUEUE, true);
+	}
+
+	@Bean
+	public TopicExchange aiImageCreatedExchange() {
+		return new TopicExchange(AI_IMAGE_CREATED_EXCHANGE, true, false);
+	}
+
+	@Bean
+	public Binding aiImageCreatedBinding(Queue aiImageCreatedQueue, TopicExchange aiImageCreatedExchange) {
+		return BindingBuilder.bind(aiImageCreatedQueue)
+			.to(aiImageCreatedExchange)
+			.with(AI_IMAGE_CREATED_ROUTING_KEY);
 	}
 
 	@Bean

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
 
 	// AI
 	AI_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "A-001", "해당 AI 요청을 찾을 수 없습니다."),
-	;
+	CREATED_AI_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "A-002", "생성된 AI 이미지를 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
 	// Server
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-001", "서버 내부에서 에러가 발생하였습니다."),
 	S3_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-002", "S3 서버에서 에러가 발생하였습니다."),
+
+	// AI
+	AI_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "A-001", "해당 AI 요청을 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/hanium/modic/backend/domain/ai/dto/AiImageRequestMessageDto.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/dto/AiImageRequestMessageDto.java
@@ -1,0 +1,10 @@
+package hanium.modic.backend.domain.ai.dto;
+
+import java.util.List;
+
+public record AiImageRequestMessageDto(
+	String requestId,
+	String requestImageUrl,
+	List<String> styleImageUrls
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/dto/CreatedAiImageMessageDto.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/dto/CreatedAiImageMessageDto.java
@@ -1,0 +1,7 @@
+package hanium.modic.backend.domain.ai.dto;
+
+public record CreatedAiImageMessageDto(
+	String requestId,
+	String imageUrl
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
@@ -1,0 +1,40 @@
+package hanium.modic.backend.domain.ai.listener;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
+import hanium.modic.backend.domain.ai.dto.CreatedAiImageMessageDto;
+import hanium.modic.backend.domain.ai.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
+import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiImageCreatedListener {
+	private final CreatedAiImageRepository createdAiImageRepository;
+	private final AiRequestRepository aiRequestRepository;
+
+	@Transactional
+	@RabbitListener(queues = "ai.image.created.queue")
+	public void handleImageCreated(CreatedAiImageMessageDto message) {
+		log.info("[AI 이미지 생성 완료] 메시지 수신: {}", message);
+
+		CreatedAiImageEntity created = CreatedAiImageEntity.builder()
+			.requestId(message.requestId())
+			.imageUrl(message.imageUrl())
+			.build();
+		createdAiImageRepository.save(created);
+
+		AiRequestEntity aiRequest = aiRequestRepository.findByRequestId(message.requestId())
+			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
+		aiRequest.updateStatus(AiImageStatus.DONE);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
@@ -2,12 +2,12 @@ package hanium.modic.backend.domain.ai.listener;
 
 import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
 
+import java.util.Optional;
+
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import hanium.modic.backend.common.error.ErrorCode;
-import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
 import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 import hanium.modic.backend.domain.ai.dto.CreatedAiImageMessageDto;
@@ -29,14 +29,19 @@ public class AiImageCreatedListener {
 	public void handleImageCreated(CreatedAiImageMessageDto message) {
 		log.info("[AI 이미지 생성 완료] 메시지 수신: {}", message);
 
+		Optional<AiRequestEntity> aiRequestOpt = aiRequestRepository.findByRequestId(message.requestId());
+		if (aiRequestOpt.isEmpty()) {
+			log.error("[AI 이미지 처리 실패] AI 요청을 찾을 수 없습니다. requestId: {}", message.requestId());
+			return;
+		}
+
+		AiRequestEntity aiRequest = aiRequestOpt.get();
 		CreatedAiImageEntity created = CreatedAiImageEntity.builder()
 			.requestId(message.requestId())
 			.imageUrl(message.imageUrl())
 			.build();
 		createdAiImageRepository.save(created);
 
-		AiRequestEntity aiRequest = aiRequestRepository.findByRequestId(message.requestId())
-			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
 		aiRequest.updateStatus(AiImageStatus.DONE);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
@@ -1,5 +1,7 @@
 package hanium.modic.backend.domain.ai.listener;
 
+import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
+
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +25,7 @@ public class AiImageCreatedListener {
 	private final AiRequestRepository aiRequestRepository;
 
 	@Transactional
-	@RabbitListener(queues = "ai.image.created.queue")
+	@RabbitListener(queues = AI_IMAGE_CREATED_QUEUE)
 	public void handleImageCreated(CreatedAiImageMessageDto message) {
 		log.info("[AI 이미지 생성 완료] 메시지 수신: {}", message);
 

--- a/src/main/java/hanium/modic/backend/domain/ai/repository/CreatedAiImageRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/repository/CreatedAiImageRepository.java
@@ -1,9 +1,13 @@
 package hanium.modic.backend.domain.ai.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 
 public interface CreatedAiImageRepository extends JpaRepository<CreatedAiImageEntity, Long> {
 	boolean existsByImagePath(String imagePath);
+
+	Optional<CreatedAiImageEntity> findByRequestId(String requestId);
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -15,6 +15,7 @@ import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.web.ai.dto.response.RequestAiImageGenerationResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +32,7 @@ public class AiImageGenerationService {
 	private final CreatedAiImageService createdAiImageService;
 
 	@Transactional
-	public AiRequestEntity processImageGeneration(ImagePrefix imageUsagePurpose, String fileName,
+	public RequestAiImageGenerationResponse processImageGeneration(ImagePrefix imageUsagePurpose, String fileName,
 		String imagePath, Long postId) {
 		// ToDO: 인증 로직 추가되면 userId를 통해 검증 예정
 		// validateUserPermission(userId);
@@ -50,7 +51,7 @@ public class AiImageGenerationService {
 			aiRequestEntity.getImageUrl(),
 			styleImageUrls);
 
-		return aiRequestEntity;
+		return RequestAiImageGenerationResponse.from(aiRequestEntity);
 	}
 
 	public String createImageGetUrl(Long imageId) {

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -8,8 +8,10 @@ import org.springframework.transaction.annotation.Transactional;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
+import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
@@ -25,6 +27,8 @@ public class AiImageGenerationService {
 	private final MessageQueueService messageQueueService;
 	private final PostImageEntityRepository postImageEntityRepository;
 	private final AiRequestRepository aiRequestRepository;
+	private final CreatedAiImageRepository createdAiImageRepository;
+	private final CreatedAiImageService createdAiImageService;
 
 	@Transactional
 	public AiRequestEntity processImageGeneration(ImagePrefix imageUsagePurpose, String fileName,
@@ -60,6 +64,16 @@ public class AiImageGenerationService {
 		AiRequestEntity request = aiRequestRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
 		return request.getStatus();
+	}
+
+	public String createAiImageGetUrl(String requestId) {
+		/**
+		 * ToDo: AI 이미지 조회 권한 검증
+		 */
+		CreatedAiImageEntity createdAiImageEntity = createdAiImageRepository.findByRequestId(requestId)
+			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
+
+		return createdAiImageService.createImageGetUrl(createdAiImageEntity.getId());
 	}
 
 	private void validateUserPermission(Long userId) {

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -1,10 +1,14 @@
 package hanium.modic.backend.domain.ai.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.post.entity.PostImageEntity;
+import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -15,16 +19,28 @@ public class AiImageGenerationService {
 
 	private final AiImageService aiImageService;
 	private final MessageQueueService messageQueueService;
+	private final PostImageEntityRepository postImageEntityRepository;
 
 	@Transactional
-	public AiRequestEntity processImageGeneration(ImagePrefix imageUsagePurpose, String fileName, String imagePath) {
+	public AiRequestEntity processImageGeneration(ImagePrefix imageUsagePurpose, String fileName,
+		String imagePath, Long postId) {
 		// ToDO: 인증 로직 추가되면 userId를 통해 검증 예정
 		// validateUserPermission(userId);
+
+		List<String> styleImageUrls = postImageEntityRepository.findAllByPostId(postId)
+			.stream()
+			.map(PostImageEntity::getImageUrl)
+			.toList();
 
 		// 이미지 저장 및 ID 반환
 		AiRequestEntity aiRequestEntity = aiImageService.saveImage(imageUsagePurpose, fileName, imagePath);
 
-		// ToDo: MQ에 이미지 생성 요청 전송
+		// MQ에 이미지 생성 요청 전송
+		messageQueueService.sendImageGenerationRequest(
+			aiRequestEntity.getRequestId(),
+			aiRequestEntity.getImageUrl(),
+			styleImageUrls);
+
 		return aiRequestEntity;
 	}
 

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -5,7 +5,11 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+import hanium.modic.backend.domain.ai.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
@@ -20,6 +24,7 @@ public class AiImageGenerationService {
 	private final AiImageService aiImageService;
 	private final MessageQueueService messageQueueService;
 	private final PostImageEntityRepository postImageEntityRepository;
+	private final AiRequestRepository aiRequestRepository;
 
 	@Transactional
 	public AiRequestEntity processImageGeneration(ImagePrefix imageUsagePurpose, String fileName,
@@ -49,6 +54,12 @@ public class AiImageGenerationService {
 		 * ToDo: 이미지 조회 권한 검증
 		 */
 		return aiImageService.createImageGetUrl(imageId);
+	}
+
+	public AiImageStatus getAiImageStatus(String requestId) {
+		AiRequestEntity request = aiRequestRepository.findByRequestId(requestId)
+			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
+		return request.getStatus();
 	}
 
 	private void validateUserPermission(Long userId) {

--- a/src/main/java/hanium/modic/backend/domain/ai/service/CreatedAiImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/CreatedAiImageService.java
@@ -1,0 +1,50 @@
+package hanium.modic.backend.domain.ai.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
+import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
+import hanium.modic.backend.domain.image.domain.Image;
+import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.image.service.ImageService;
+import hanium.modic.backend.domain.image.service.ImageValidationService;
+import hanium.modic.backend.domain.image.util.ImageUtil;
+
+@Service
+public class CreatedAiImageService extends ImageService {
+
+	private final CreatedAiImageRepository createdAiImageRepository;
+
+	@Autowired
+	public CreatedAiImageService(ImageUtil imageUtil, ImageValidationService imageValidationService,
+		CreatedAiImageRepository createdAiImageRepository) {
+		super(imageValidationService, imageUtil);
+		this.createdAiImageRepository = createdAiImageRepository;
+	}
+
+	@Override
+	public String createImageGetUrl(Long id) {
+		CreatedAiImageEntity createdAiImageEntity = createdAiImageRepository.findById(id)
+			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
+
+		return imageUtil.createImageGetUrl(createdAiImageEntity.getImagePath());
+	}
+
+	@Override
+	public void deleteImage(Long id) {
+		CreatedAiImageEntity createdAiImageEntity = createdAiImageRepository.findById(id)
+			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
+
+		createdAiImageRepository.delete(createdAiImageEntity);
+		imageUtil.deleteImage(createdAiImageEntity.getImagePath());
+	}
+
+	// 사용되지 않는 메서드
+	@Override
+	public Image saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath) {
+		return null;
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/service/MessageQueueService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/MessageQueueService.java
@@ -1,11 +1,27 @@
 package hanium.modic.backend.domain.ai.service;
 
+import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
+
+import java.util.List;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 
+import hanium.modic.backend.domain.ai.dto.AiImageRequestMessageDto;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class MessageQueueService {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	public void sendImageGenerationRequest(String requestId, String requestImageUrl, List<String> styleImageUrls) {
+		AiImageRequestMessageDto message = new AiImageRequestMessageDto(requestId, requestImageUrl, styleImageUrls);
+		rabbitTemplate.convertAndSend(
+			AI_IMAGE_REQUEST_EXCHANGE,
+			AI_IMAGE_REQUEST_ROUTING_KEY,
+			message);
+	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -11,12 +11,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.response.ApiResponse;
+import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
+import hanium.modic.backend.web.ai.dto.response.AiRequestStatusResponse;
+import hanium.modic.backend.web.ai.dto.response.RequestAiImageGenerationResponse;
 import hanium.modic.backend.web.common.image.dto.request.CreateImageSaveUrlRequest;
-import hanium.modic.backend.web.common.image.dto.response.CallbackImageSaveUrlResponse;
 import hanium.modic.backend.web.common.image.dto.response.CreateImageGetUrlResponse;
 import hanium.modic.backend.web.common.image.dto.response.CreateImageSaveUrlResponse;
 import jakarta.validation.Valid;
@@ -47,17 +50,17 @@ public class AiImageController {
 
 	// AI 요청 이미지 저장 완료 후 AI 이미지 생성 요청
 	@PostMapping("/requests")
-	public ResponseEntity<ApiResponse<CallbackImageSaveUrlResponse>> requestAiImageGeneration(
+	public ResponseEntity<ApiResponse<RequestAiImageGenerationResponse>> requestAiImageGeneration(
 		@RequestBody @Valid AiImageGenerationRequest request) {
-		Long id = aiImageGenerationService.processImageGeneration(
+		AiRequestEntity aiRequestEntity = aiImageGenerationService.processImageGeneration(
 			request.imageUsagePurpose(),
 			request.fileName(),
 			request.imagePath(),
-			request.postId()
-		).getId();
+			request.postId());
 
 		return ResponseEntity.status(CREATED)
-			.body(ApiResponse.created(new CallbackImageSaveUrlResponse(id)));
+			.body(ApiResponse.created(
+				new RequestAiImageGenerationResponse(aiRequestEntity.getId(), aiRequestEntity.getRequestId())));
 	}
 
 	// AI 요청 이미지 URL 조회
@@ -70,5 +73,13 @@ public class AiImageController {
 		String imageGetUrl = aiImageGenerationService.createImageGetUrl(imageId);
 
 		return ResponseEntity.ok(ApiResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
+	}
+
+	// AI 이미지 생성 상태를 조회
+	@GetMapping("/requests/{requestId}/status")
+	public ResponseEntity<ApiResponse<AiRequestStatusResponse>> getAiRequestStatus(
+		@PathVariable String requestId) {
+		AiImageStatus status = aiImageGenerationService.getAiImageStatus(requestId);
+		return ResponseEntity.ok(ApiResponse.ok(new AiRequestStatusResponse(status)));
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.response.ApiResponse;
-import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
@@ -52,15 +51,16 @@ public class AiImageController {
 	@PostMapping("/requests")
 	public ResponseEntity<ApiResponse<RequestAiImageGenerationResponse>> requestAiImageGeneration(
 		@RequestBody @Valid AiImageGenerationRequest request) {
-		AiRequestEntity aiRequestEntity = aiImageGenerationService.processImageGeneration(
+
+		RequestAiImageGenerationResponse response = aiImageGenerationService.processImageGeneration(
 			request.imageUsagePurpose(),
 			request.fileName(),
 			request.imagePath(),
-			request.postId());
+			request.postId()
+		);
 
 		return ResponseEntity.status(CREATED)
-			.body(ApiResponse.created(
-				new RequestAiImageGenerationResponse(aiRequestEntity.getId(), aiRequestEntity.getRequestId())));
+			.body(ApiResponse.created(response));
 	}
 
 	// AI 요청 이미지 URL 조회

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -14,7 +14,7 @@ import hanium.modic.backend.common.response.ApiResponse;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
-import hanium.modic.backend.web.common.image.dto.request.CallbackImageSaveUrlRequest;
+import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
 import hanium.modic.backend.web.common.image.dto.request.CreateImageSaveUrlRequest;
 import hanium.modic.backend.web.common.image.dto.response.CallbackImageSaveUrlResponse;
 import hanium.modic.backend.web.common.image.dto.response.CreateImageGetUrlResponse;
@@ -48,11 +48,13 @@ public class AiImageController {
 	// AI 요청 이미지 저장 완료 후 AI 이미지 생성 요청
 	@PostMapping("/requests")
 	public ResponseEntity<ApiResponse<CallbackImageSaveUrlResponse>> requestAiImageGeneration(
-		@RequestBody @Valid CallbackImageSaveUrlRequest request) {
+		@RequestBody @Valid AiImageGenerationRequest request) {
 		Long id = aiImageGenerationService.processImageGeneration(
 			request.imageUsagePurpose(),
 			request.fileName(),
-			request.imagePath()).getId();
+			request.imagePath(),
+			request.postId()
+		).getId();
 
 		return ResponseEntity.status(CREATED)
 			.body(ApiResponse.created(new CallbackImageSaveUrlResponse(id)));

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -75,6 +75,18 @@ public class AiImageController {
 		return ResponseEntity.ok(ApiResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
 	}
 
+	// 생성된 AI 이미지 조회 URL 생성
+	@GetMapping("/requests/{requestId}/get-url")
+	public ResponseEntity<ApiResponse<CreateImageGetUrlResponse>> createAiImageGetUrl(
+		@PathVariable String requestId) {
+		/*
+		 * ToDo: AiImageGenerationService 에서 이미지 조회 권한 검증
+		 */
+		String imageGetUrl = aiImageGenerationService.createAiImageGetUrl(requestId);
+
+		return ResponseEntity.ok(ApiResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
+	}
+
 	// AI 이미지 생성 상태를 조회
 	@GetMapping("/requests/{requestId}/status")
 	public ResponseEntity<ApiResponse<AiRequestStatusResponse>> getAiRequestStatus(

--- a/src/main/java/hanium/modic/backend/web/ai/dto/request/AiImageGenerationRequest.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/request/AiImageGenerationRequest.java
@@ -1,0 +1,17 @@
+package hanium.modic.backend.web.ai.dto.request;
+
+import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AiImageGenerationRequest(
+	@NotBlank(message = "파일명은 필수입니다.")
+	String fileName,
+	@NotBlank(message = "이미지 Path는 필수입니다.")
+	String imagePath,
+	@NotNull(message = "이미지 사용 목적은 필수입니다.")
+	ImagePrefix imageUsagePurpose,
+	@NotNull(message = "postId는 필수입니다.")
+	Long postId
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/AiRequestStatusResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/AiRequestStatusResponse.java
@@ -1,0 +1,8 @@
+package hanium.modic.backend.web.ai.dto.response;
+
+import hanium.modic.backend.domain.ai.enums.AiImageStatus;
+
+public record AiRequestStatusResponse(
+	AiImageStatus status
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/RequestAiImageGenerationResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/RequestAiImageGenerationResponse.java
@@ -1,7 +1,16 @@
 package hanium.modic.backend.web.ai.dto.response;
 
+import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+
 public record RequestAiImageGenerationResponse(
 	Long imageId,
 	String requestId
 ) {
+
+	public static RequestAiImageGenerationResponse from(AiRequestEntity aiRequestEntity) {
+		return new RequestAiImageGenerationResponse(
+			aiRequestEntity.getId(),
+			aiRequestEntity.getRequestId()
+		);
+	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/RequestAiImageGenerationResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/RequestAiImageGenerationResponse.java
@@ -1,0 +1,7 @@
+package hanium.modic.backend.web.ai.dto.response;
+
+public record RequestAiImageGenerationResponse(
+	Long imageId,
+	String requestId
+) {
+}

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
+import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
 import hanium.modic.backend.web.common.image.dto.request.CreateImageSaveUrlRequest;
 
 @WebMvcTest(AiImageController.class)
@@ -59,5 +60,42 @@ class AiImageControllerTest {
 		);
 	}
 
+	@ParameterizedTest
+	@DisplayName("AI 이미지 생성 요청 실패 - 필수값 누락 시 400 응답")
+	@MethodSource("provideInvalidAiImageGenerationRequests")
+	void requestAiImageGenerationValidationFail(AiImageGenerationRequest request) throws Exception {
+		// when + then
+		mockMvc.perform(post("/api/ai/images/requests")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(ErrorCode.USER_INPUT_EXCEPTION.getCode()));
+	}
 
+	private static Stream<AiImageGenerationRequest> provideInvalidAiImageGenerationRequests() {
+		return Stream.of(
+			// 파일명 누락
+			new AiImageGenerationRequest(null, "valid/path", AI_REQUEST, 1L),
+			// 파일명 빈 문자열
+			new AiImageGenerationRequest("", "valid/path", AI_REQUEST, 1L),
+			// 파일명 공백
+			new AiImageGenerationRequest("   ", "valid/path", AI_REQUEST, 1L),
+
+			// 이미지 Path 누락
+			new AiImageGenerationRequest("valid.jpg", null, AI_REQUEST, 1L),
+			// 이미지 Path 빈 문자열
+			new AiImageGenerationRequest("valid.jpg", "", AI_REQUEST, 1L),
+			// 이미지 Path 공백
+			new AiImageGenerationRequest("valid.jpg", "   ", AI_REQUEST, 1L),
+
+			// 이미지 사용 목적 누락
+			new AiImageGenerationRequest("valid.jpg", "valid/path", null, 1L),
+
+			// postId 누락
+			new AiImageGenerationRequest("valid.jpg", "valid/path", AI_REQUEST, null),
+
+			// 모든 필수값 누락
+			new AiImageGenerationRequest(null, null, null, null)
+		);
+	}
 }

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
@@ -1,13 +1,16 @@
 package hanium.modic.backend.web.ai.controller;
 
 import static hanium.modic.backend.domain.image.domain.ImagePrefix.*;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
@@ -97,5 +101,47 @@ class AiImageControllerTest {
 			// 모든 필수값 누락
 			new AiImageGenerationRequest(null, null, null, null)
 		);
+	}
+
+	@ParameterizedTest
+	@DisplayName("AI 이미지 URL 조회 실패 - 잘못된 imageId로 400 응답")
+	@MethodSource("provideInvalidImageIds")
+	void createImageGetUrlValidationFail(String imageId, String expectedErrorCode) throws Exception {
+		// when + then
+		mockMvc.perform(get("/api/ai/images/" + imageId + "/get-url")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(expectedErrorCode));
+	}
+
+	private static Stream<Arguments> provideInvalidImageIds() {
+		return Stream.of(
+			// 숫자가 아닌 문자열
+			Arguments.of("abc", ErrorCode.USER_INPUT_EXCEPTION.getCode()),
+			// 음수
+			Arguments.of("-1", ErrorCode.USER_INPUT_EXCEPTION.getCode()),
+			// 0
+			Arguments.of("0", ErrorCode.USER_INPUT_EXCEPTION.getCode()),
+			// 빈 문자열 (URL 구조상 404가 될 수 있음)
+			Arguments.of("", ErrorCode.USER_INPUT_EXCEPTION.getCode()),
+			// 특수문자
+			Arguments.of("@#$", ErrorCode.USER_INPUT_EXCEPTION.getCode())
+		);
+	}
+
+	@Test
+	@DisplayName("AI 이미지 생성 상태 조회 성공 - 정상적인 requestId로 200 응답")
+	void getAiRequestStatusSuccess() throws Exception {
+		// given
+		String requestId = "valid-request-id";
+		AiImageStatus expectedStatus = AiImageStatus.DONE;
+		given(aiImageGenerationService.getAiImageStatus(requestId)).willReturn(expectedStatus);
+
+		// when + then
+		mockMvc.perform(get("/api/ai/images/requests/" + requestId + "/status")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("200"))
+			.andExpect(jsonPath("$.data.status").value(expectedStatus.name()));
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
@@ -1,0 +1,63 @@
+package hanium.modic.backend.web.ai.controller;
+
+import static hanium.modic.backend.domain.image.domain.ImagePrefix.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
+import hanium.modic.backend.domain.ai.service.AiImageService;
+import hanium.modic.backend.web.common.image.dto.request.CreateImageSaveUrlRequest;
+
+@WebMvcTest(AiImageController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AiImageControllerTest {
+
+	@MockitoBean
+	private AiImageService aiImageService;
+	@MockitoBean
+	private AiImageGenerationService aiImageGenerationService;
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@ParameterizedTest
+	@DisplayName("AI 요청 이미지 Url 생성 실패 - 필수값 누락 시 400 응답")
+	@MethodSource("provideInvalidCreateImageSaveUrlRequests")
+	void createImageSaveUrlRequestValidationFail(CreateImageSaveUrlRequest request) throws Exception {
+		// when + then
+		mockMvc.perform(post("/api/ai/images/save-url")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(ErrorCode.USER_INPUT_EXCEPTION.getCode()));
+	}
+
+	private static Stream<CreateImageSaveUrlRequest> provideInvalidCreateImageSaveUrlRequests() {
+		return Stream.of(
+			// 이미지 사용 목적 누락
+			new CreateImageSaveUrlRequest(null, "example.jpg"),
+			// 파일 이름 누락
+			new CreateImageSaveUrlRequest(AI_REQUEST, null),
+			// 둘 다 누락
+			new CreateImageSaveUrlRequest(null, null)
+		);
+	}
+
+
+}


### PR DESCRIPTION
## 개요
사용자가 이미지를 S3에 저장한 이후, AI 이미지 생성 요청을 보내고 완료되기 까지의 과정에 해당하는 로직을 작성하였습니다.

## 작업사항
### 이미지 생성 요청
`requestId`, `화풍 이미지 URL(최대 8개 리스트)`, `생성 요청할 이미지 URL`을 포함하여 MQ에 요청

### 이미지 생성 완료 리스너
생성 완료되면 완료 큐 listener가 메시지에서 `requestId`, `imageUrl`을 읽어서 `CreatedAiImageEntity`에 저장하고,  생성 상태를 `DONE`으로 변경

### 이미지 생성 상태 확인 API
client가 주기적으로 생성 상태를 확인할 수 있는 API

### 이미지 조회 URL 생성 API
이 부분에서 또 문제가 좀 있었는데, 
aiImageService에서는 생성 전 원본 이미지의 조회 url을 발급하고 있기 때문에, 생성된 ai 이미지와 관련된 서비스를 새로 생성했습니다.
(CreatedAiImageService)
하지만, 생성된 aiImage의 경우 사용자가 저장하는 것이 아니기 때문에 deleteImage, saveImage 등의 기능이 필요가 없는데 이미지 조회용 url을 생성하기 위해서는 imageService를 extends 해야 하다보니 좀 더러운 코드가 된 것 같아요..

로그인 기능 구현되면 검증 기능도 추가할 예정입니다.
