### PR TITLE
Feature: 유저 이메일 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,13 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+	runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
 
 	// User
 	USER_EMAIL_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, "U-001", "이미 사용중인 이메일입니다."),
+	USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "U-002", "해당 유저를 찾을 수 없습니다."),
+	USER_PASSWORD_MISMATCH_EXCEPTION(HttpStatus.UNAUTHORIZED, "U-003", "비밀번호가 일치하지 않습니다."),
 
 	// Post
 	POST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "P-001", "해당 포스트를 찾을 수 없습니다."),

--- a/src/main/java/hanium/modic/backend/common/property/config/PropertyConfig.java
+++ b/src/main/java/hanium/modic/backend/common/property/config/PropertyConfig.java
@@ -5,12 +5,14 @@ import org.springframework.context.annotation.Configuration;
 
 import hanium.modic.backend.common.property.property.S3Properties;
 import hanium.modic.backend.common.property.property.SwaggerProperties;
+import hanium.modic.backend.common.property.property.TokenProperty;
 
 // 전역적으로 사용되는 상수
 @Configuration
 @EnableConfigurationProperties(value = {
 	S3Properties.class,
-	SwaggerProperties.class
+	SwaggerProperties.class,
+	TokenProperty.class
 })
 public class PropertyConfig {
 }

--- a/src/main/java/hanium/modic/backend/common/property/property/TokenProperty.java
+++ b/src/main/java/hanium/modic/backend/common/property/property/TokenProperty.java
@@ -1,0 +1,18 @@
+package hanium.modic.backend.common.property.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class TokenProperty {
+
+	private String secretKey;
+
+	private long accessExpirationTime;
+
+	private long refreshExpirationTime;
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/dto/Token.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/dto/Token.java
@@ -1,0 +1,7 @@
+package hanium.modic.backend.domain.auth.dto;
+
+public record Token(
+	String accessToken,
+	String refreshToken
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
@@ -1,0 +1,36 @@
+package hanium.modic.backend.domain.auth.service;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.auth.dto.Token;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.auth.dto.LoginResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final BCryptPasswordEncoder passwordEncoder;
+
+	private final UserEntityRepository userEntityRepository;
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public LoginResponse login(final String email, final String password) {
+		UserEntity user = userEntityRepository.findByEmail(email)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
+
+		if (!passwordEncoder.matches(password, user.getPassword())) {
+			throw new AppException(ErrorCode.USER_PASSWORD_MISMATCH_EXCEPTION);
+		}
+
+		Token token = jwtTokenProvider.createToken(user);
+
+		return LoginResponse.from(token);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/JwtTokenProvider.java
@@ -1,0 +1,65 @@
+package hanium.modic.backend.domain.auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import hanium.modic.backend.common.property.property.TokenProperty;
+import hanium.modic.backend.domain.auth.dto.Token;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+	private static final String ACCESS_TOKEN = "accessToken";
+
+	private static final String REFRESH_TOKEN = "refreshToken";
+
+	private final TokenProperty tokenProperty;
+
+	public Token createToken(final UserEntity user) {
+		return new Token(
+			generateAccessToken(user),
+			generateRefreshToken(user)
+		);
+	}
+
+	private String generateAccessToken(final UserEntity user) {
+		Claims claims = Jwts.claims();
+		claims.put("id", user.getId());
+		claims.put("type", ACCESS_TOKEN);
+
+		SecretKey key = Keys.hmacShaKeyFor(tokenProperty.getSecretKey().getBytes(StandardCharsets.UTF_8));
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getAccessExpirationTime()))
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	private String generateRefreshToken(final UserEntity user) {
+		Claims claims = Jwts.claims();
+		claims.put("id", user.getId());
+		claims.put("type", REFRESH_TOKEN);
+
+		SecretKey key = Keys.hmacShaKeyFor(tokenProperty.getSecretKey().getBytes(StandardCharsets.UTF_8));
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getRefreshExpirationTime()))
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/util/CookieUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/util/CookieUtil.java
@@ -1,0 +1,19 @@
+package hanium.modic.backend.domain.auth.util;
+
+import jakarta.servlet.http.Cookie;
+
+public class CookieUtil {
+
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+	private static final int COOKIE_MAX_AGE = 60 * 60 * 24 * 3;
+
+	public static Cookie createRefreshCookie(final String refreshToken) {
+		Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		// cookie.setSecure(true); // Todo: https://github.com/Modic-2025/modic_backend/issues/39
+		cookie.setMaxAge(COOKIE_MAX_AGE);
+		return cookie;
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/user/repository/UserEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/user/repository/UserEntityRepository.java
@@ -1,9 +1,13 @@
 package hanium.modic.backend.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
 public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
 	boolean existsByEmail(String email);
+
+	Optional<UserEntity> findByEmail(String email);
 }

--- a/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
+++ b/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
@@ -1,0 +1,36 @@
+package hanium.modic.backend.web.auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hanium.modic.backend.common.response.ApiResponse;
+import hanium.modic.backend.domain.auth.service.AuthService;
+import hanium.modic.backend.domain.auth.util.CookieUtil;
+import hanium.modic.backend.web.auth.dto.LoginRequest;
+import hanium.modic.backend.web.auth.dto.LoginResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/login")
+	public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+		LoginResponse loginResponse = authService.login(request.email(), request.password());
+
+		response.addHeader("Authorization", "Bearer " + loginResponse.accessToken());
+		Cookie refreshTokenCookie = CookieUtil.createRefreshCookie(loginResponse.refreshToken());
+		response.addCookie(refreshTokenCookie);
+
+		return ResponseEntity.ok(ApiResponse.ok(loginResponse));
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
+++ b/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
@@ -21,13 +21,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
+	private static final String AUTH_HEADER = "Authorization";
+
+	private static final String BEARER_TOKEN = "Bearer ";
+
 	private final AuthService authService;
 
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
 		LoginResponse loginResponse = authService.login(request.email(), request.password());
 
-		response.addHeader("Authorization", "Bearer " + loginResponse.accessToken());
+		response.addHeader(AUTH_HEADER, BEARER_TOKEN + loginResponse.accessToken());
 		Cookie refreshTokenCookie = CookieUtil.createRefreshCookie(loginResponse.refreshToken());
 		response.addCookie(refreshTokenCookie);
 

--- a/src/main/java/hanium/modic/backend/web/auth/dto/LoginRequest.java
+++ b/src/main/java/hanium/modic/backend/web/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package hanium.modic.backend.web.auth.dto;
+
+import hanium.modic.backend.common.validator.Password;
+import jakarta.validation.constraints.Email;
+
+public record LoginRequest(
+	@Email(message = "유효하지 않은 이메일 형식입니다.")
+	String email,
+	@Password(message = "비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다.")
+	String password
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/auth/dto/LoginRequest.java
+++ b/src/main/java/hanium/modic/backend/web/auth/dto/LoginRequest.java
@@ -2,9 +2,11 @@ package hanium.modic.backend.web.auth.dto;
 
 import hanium.modic.backend.common.validator.Password;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
 	@Email(message = "유효하지 않은 이메일 형식입니다.")
+	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
 	String email,
 	@Password(message = "비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다.")
 	String password

--- a/src/main/java/hanium/modic/backend/web/auth/dto/LoginResponse.java
+++ b/src/main/java/hanium/modic/backend/web/auth/dto/LoginResponse.java
@@ -1,0 +1,15 @@
+package hanium.modic.backend.web.auth.dto;
+
+import hanium.modic.backend.domain.auth.dto.Token;
+
+public record LoginResponse(
+	String accessToken,
+	String refreshToken
+) {
+	public static LoginResponse from(Token token) {
+		return new LoginResponse(
+			token.accessToken(),
+			token.refreshToken()
+		);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,8 @@ springdoc:
 
 swagger:
   url: ${SWAGGER_URL}
+
+jwt:
+  secretKey: ${JWT_SECRET}
+  accessExpiration: ${JWT_ACCESS_EXPIRATION}
+  refreshExpiration: ${JWT_REFRESH_EXPIRATION}

--- a/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,84 @@
+package hanium.modic.backend.domain.auth.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.auth .dto.Token;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.auth.dto.LoginResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Mock
+	private UserEntityRepository userEntityRepository;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private BCryptPasswordEncoder passwordEncoder;
+
+	@Test
+	@DisplayName("로그인 테스트 - 성공 케이스")
+	void loginSuccess () {
+		// given
+		UserEntity user = mock(UserEntity.class);
+
+		when(userEntityRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+		when(jwtTokenProvider.createToken(any())).thenReturn(new Token("accessToken", "refreshToken"));
+		when(passwordEncoder.matches(any(), any())).thenReturn(true);
+
+		// when
+		LoginResponse login = authService.login(user.getEmail(), user.getPassword());
+
+		// then
+		verify(passwordEncoder).matches(any(), any());
+		verify(jwtTokenProvider).createToken(user);
+	}
+
+	@Test
+	@DisplayName("로그인 테스트 - 실패 케이스 (사용자 없음)")
+	void loginFail () {
+		// given
+		final String email = "youth@cotato.kr";
+		final String password = "password";
+
+		when(userEntityRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+		// when & then
+		AppException appException = assertThrows(AppException.class, () -> authService.login(email, password));
+		assertEquals(appException.getErrorCode(), ErrorCode.USER_NOT_FOUND_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("로그인 테스트 - 실패 케이스 (비밀번호 불일치)")
+	void loginFailByPassword() {
+		// given
+		UserEntity user = mock(UserEntity.class);
+		final String password = "password";
+		when(user.getPassword()).thenReturn(password);
+		when(userEntityRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(false);
+
+		// when & then
+		AppException appException = assertThrows(AppException.class, () -> authService.login(user.getEmail(), password));
+		assertEquals(appException.getErrorCode(), ErrorCode.USER_PASSWORD_MISMATCH_EXCEPTION);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
@@ -1,0 +1,54 @@
+package hanium.modic.backend.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.property.property.TokenProperty;
+import hanium.modic.backend.domain.auth.dto.Token;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.factory.UserFactory;
+
+@ExtendWith(MockitoExtension.class)
+class JwtTokenProviderTest {
+
+	private final String SECRET_KEY = "thisisaverysecuresecretkey123456!";
+
+	private final long ACCESS_EXPIRE = 1000 * 60 * 60;
+	private final long REFRESH_EXPIRE = 1000 * 60 * 60 * 24 * 14;
+
+	@InjectMocks
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private TokenProperty tokenProperty;
+
+	@BeforeEach
+	void setUp() {
+		when(tokenProperty.getSecretKey()).thenReturn(SECRET_KEY);
+		when(tokenProperty.getAccessExpirationTime()).thenReturn(ACCESS_EXPIRE);
+		when(tokenProperty.getRefreshExpirationTime()).thenReturn(REFRESH_EXPIRE);
+	}
+
+	@Test
+	@DisplayName("토큰 생성 테스트")
+	void createTokenTest() {
+		// given
+		UserEntity user = UserFactory.createMockUser(1L);
+
+		// when
+		Token token = jwtTokenProvider.createToken(user);
+
+		// then
+		assertThat(token).isNotNull();
+		assertThat(token.accessToken()).isNotBlank();
+		assertThat(token.refreshToken()).isNotBlank();
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/user/factory/UserFactory.java
+++ b/src/test/java/hanium/modic/backend/domain/user/factory/UserFactory.java
@@ -1,0 +1,20 @@
+package hanium.modic.backend.domain.user.factory;
+
+import static org.mockito.Mockito.*;
+
+import org.mockito.Mockito;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+
+public class UserFactory {
+
+	public static UserEntity createMockUser(final Long userId) {
+		UserEntity user = UserEntity.builder()
+			.email("test" + userId + "@example.com")
+			.password("password" + userId)
+			.build();
+		UserEntity spyUser = Mockito.spy(user);
+		when(spyUser.getId()).thenReturn(userId);
+		return spyUser;
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
@@ -1,0 +1,52 @@
+package hanium.modic.backend.web.auth.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.auth.dto.LoginRequest;
+
+public class AuthControllerIntegrationTest extends BaseIntegrationTest {
+
+	@Autowired
+	private UserEntityRepository userEntityRepository;
+
+	@Autowired
+	private BCryptPasswordEncoder passwordEncoder;
+
+	@BeforeEach
+	void setUp() {
+		userEntityRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("로그인 API 테스트")
+	void loginApiSuccessTest() throws Exception {
+		// given
+		final String email = "test@test.kr";
+		final String originPassword = "qwer1234@#!";
+		String encoded = passwordEncoder.encode(originPassword);
+		UserEntity user = UserEntity.builder().email(email).password(encoded).build();
+
+		userEntityRepository.save(user);
+
+		LoginRequest request = new LoginRequest(email, originPassword);
+
+		// when, then
+		mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+			.andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
@@ -1,0 +1,112 @@
+package hanium.modic.backend.web.auth.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hanium.modic.backend.domain.auth.service.AuthService;
+import hanium.modic.backend.web.auth.dto.LoginRequest;
+import hanium.modic.backend.web.auth.dto.LoginResponse;
+import jakarta.servlet.http.Cookie;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private AuthService authService;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	@DisplayName("로그인 컨트롤러 테스트")
+	void loginSuccess() throws Exception {
+		// given
+		final String email = "youth@youth.kr";
+		final String password = "password123@#!";
+		LoginRequest request = new LoginRequest(email, password);
+
+		when(authService.login(email, password))
+			.thenReturn(new LoginResponse("accessToken", "refreshToken"));
+
+		// when
+		MvcResult result = mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+			.andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+			.andExpect(header().string("Authorization", "Bearer accessToken"))
+			.andReturn();
+
+		// then
+		MockHttpServletResponse servletResponse = result.getResponse();
+		Cookie[] cookies = servletResponse.getCookies();
+
+		boolean hasRefreshCookie = Arrays.stream(cookies)
+			.anyMatch(cookie -> "refreshToken".equals(cookie.getName()) && cookie.getValue().equals("refreshToken"));
+
+		assertThat(hasRefreshCookie).isTrue();
+	}
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@MethodSource("invalidLoginRequests")
+	@DisplayName("로그인 실패 테스트")
+	void loginFail(String description, LoginRequest request, String expectedErrorMessage) throws Exception {
+		// given
+		when(authService.login(request.email(), request.password()))
+			.thenThrow(new RuntimeException(expectedErrorMessage));
+
+		// when + then
+		mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.reason[0]").value(expectedErrorMessage)); // ✔ 여기를 수정
+	}
+
+	private static Stream<Arguments> invalidLoginRequests() {
+		return Stream.of(
+			Arguments.of(
+				"이메일이 빈 문자열인 경우",
+				new LoginRequest("", "password123@#!"),
+				"이메일은 필수 입력 항목입니다."
+			),
+			Arguments.of(
+				"이메일 형식이 잘못된 경우",
+				new LoginRequest("not-an-email", "password123@#!"),
+				"유효하지 않은 이메일 형식입니다."
+			),
+			Arguments.of(
+				"비밀번호가 null인 경우",
+				new LoginRequest("youth@youth.kr", null),
+				"비밀번호는 8자 이상 20자 이하, 영문, 숫자, 특수문자를 포함해야 합니다."
+			)
+		);
+	}
+
+
+}


### PR DESCRIPTION
## 개요

회원가입한 유저가 이메일로 로그인 할 수 있도록 하자


## 작업사항

- [x] JWT TokenProvider를 통한 토큰 생성
- [x] 로그인 API
- [x] 통합 테스트

resolve: https://github.com/Modic-2025/modic_backend/issues/11 