### PR TITLE
Feature: 토큰 검증 JWT 필터 구현

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       # ✅ 공통 application-common.yml, ci.yml 생성
       - run: |
           touch ./src/main/resources/application-test.yml
-          echo -e "${{ secrets.PP_TEST_YML }}" > ./src/main/resources/application-test.yml
+          echo -e "${{ secrets.PR_TEST_YML }}" | base64 -d > ./src/main/resources/application-test.yml
 
       # ✅ 테스트 실행 (컴파일 포함)
       - name: Run tests (includes compilation)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       # ✅ 공통 application-common.yml, ci.yml 생성
       - run: |
           touch ./src/main/resources/application-test.yml
-          echo -e "${{ secrets.TEST_YML }}" > ./src/main/resources/application-test.yml
+          echo -e "${{ secrets.PP_TEST_YML }}" > ./src/main/resources/application-test.yml
 
       # ✅ 테스트 실행 (컴파일 포함)
       - name: Run tests (includes compilation)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       # ✅ 공통 application-common.yml, ci.yml 생성
       - run: |
           touch ./src/main/resources/application-test.yml
-          echo -e "${{ secrets.PR_TEST_YML }}" | base64 -d > ./src/main/resources/application-test.yml
+           echo -e "${{ secrets.TEST_YML }}" > ./src/main/resources/application-test.yml
 
       # ✅ 테스트 실행 (컴파일 포함)
       - name: Run tests (includes compilation)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,20 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'temurin'
+
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
 
       - name: Grant permission for gradlew
         run: chmod +x ./gradlew
 
-      # ✅ application-test.yml 복원
-      - name: Restore application-test.yml
-        env:
-          TEST_YML: ${{ secrets.PR_TEST_YML }}
-        run: |
-          echo "$TEST_YML" | base64 -d > ./src/main/resources/application-test.yml
+      # ✅ 공통 application-common.yml, ci.yml 생성
+      - run: |
+          touch ./src/main/resources/application-test.yml
+          echo -e "${{ secrets.TEST_YML }}" > ./src/main/resources/application-test.yml
 
       # ✅ 테스트 실행 (컴파일 포함)
       - name: Run tests (includes compilation)

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
 	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
 	runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.3'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/hanium/modic/backend/common/config/RedisConfig.java
+++ b/src/main/java/hanium/modic/backend/common/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package hanium.modic.backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import hanium.modic.backend.common.property.property.RedisProperty;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	private final RedisProperty redisProperty;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisProperty.getHost(), redisProperty.getPort());
+	}
+
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate() {
+		RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 	USER_INPUT_EXCEPTION(HttpStatus.BAD_REQUEST, "C-001", "사용자 입력 오류"),
 	USER_ROLE_EXCEPTION(HttpStatus.FORBIDDEN, "C-002", "유저 권한 오류"),
 	AUTHENTICATION_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-003", "공통 권한 에러(필터)"),
+	JWT_AUTH_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-004", "JWT 인증 에러"),
 
 	// User
 	USER_EMAIL_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, "U-001", "이미 사용중인 이메일입니다."),

--- a/src/main/java/hanium/modic/backend/common/jwt/BlackList.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/BlackList.java
@@ -1,0 +1,20 @@
+package hanium.modic.backend.common.jwt;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@RedisHash(value = "blackList")
+public class BlackList {
+
+	private String id;
+
+	@TimeToLive(unit = TimeUnit.DAYS)
+	private Long ttl = 7L;
+}

--- a/src/main/java/hanium/modic/backend/common/jwt/BlackListRepository.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/BlackListRepository.java
@@ -1,0 +1,8 @@
+package hanium.modic.backend.common.jwt;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlackListRepository extends CrudRepository<BlackList, String> {
+}

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package hanium.modic.backend.common.jwt;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.response.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+
+		log.info("Unauthorized error: {}", authException.getMessage());
+		response.setStatus(ErrorCode.JWT_AUTH_EXCEPTION.getStatus().value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.JWT_AUTH_EXCEPTION, List.of(authException.getMessage()));
+
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package hanium.modic.backend.common.jwt;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import hanium.modic.backend.domain.auth.constant.AuthConstant;
+import hanium.modic.backend.domain.auth.service.JwtTokenProvider;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws IOException {
+
+		try {
+			final String authorizationHeader = request.getHeader(AuthConstant.AUTHORIZATION);
+			final String bearerToken = getBearerToken(authorizationHeader);
+
+			jwtTokenProvider.validateToken(bearerToken);
+			setAuthentication(bearerToken);
+
+			filterChain.doFilter(request, response);
+		} catch (Exception e) {
+			jwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException("Invalid JWT token", e));
+		}
+	}
+
+	private void setAuthentication(String accessToken) {
+		UserEntity user = jwtTokenProvider.getUser(accessToken).orElseThrow(() -> new BadCredentialsException("Invalid JWT token: User not found"));
+		Authentication authenticationToken = new UsernamePasswordAuthenticationToken(user, "", List.of());
+		// Todo https://github.com/Modic-2025/modic_backend/issues/42
+
+		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+	}
+
+	private String getBearerToken(String authorizationHeader) {
+		if (authorizationHeader == null || !authorizationHeader.startsWith(AuthConstant.BEARER)) {
+			throw new BadCredentialsException("Authorization header is missing or does not start with Bearer");
+		}
+		return authorizationHeader.replace(AuthConstant.BEARER, "");
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
@@ -12,7 +12,6 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import hanium.modic.backend.domain.auth.constant.AuthConstant;
-import hanium.modic.backend.domain.auth.service.JwtTokenProvider;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
@@ -8,11 +8,13 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import hanium.modic.backend.domain.auth.constant.AuthConstant;
 import hanium.modic.backend.domain.auth.service.JwtTokenProvider;
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,13 +25,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+	private static final String AUTH_PATH = "/api/auth";
+
+	private static final String JOIN_PATH = "/api/users";
+
 	private final JwtTokenProvider jwtTokenProvider;
 
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-		FilterChain filterChain) throws IOException {
+		FilterChain filterChain) throws IOException, ServletException {
 
 		try {
 			final String authorizationHeader = request.getHeader(AuthConstant.AUTHORIZATION);
@@ -39,13 +45,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			setAuthentication(bearerToken);
 
 			filterChain.doFilter(request, response);
-		} catch (Exception e) {
-			jwtAuthenticationEntryPoint.commence(request, response, new BadCredentialsException("Invalid JWT token", e));
+		} catch (BadCredentialsException | JwtException e) {
+			jwtAuthenticationEntryPoint.commence(request, response,
+				new BadCredentialsException("Invalid JWT token", e));
 		}
 	}
 
 	private void setAuthentication(String accessToken) {
-		UserEntity user = jwtTokenProvider.getUser(accessToken).orElseThrow(() -> new BadCredentialsException("Invalid JWT token: User not found"));
+		UserEntity user = jwtTokenProvider.getUser(accessToken)
+			.orElseThrow(() -> new BadCredentialsException("Invalid JWT token: User not found"));
 		Authentication authenticationToken = new UsernamePasswordAuthenticationToken(user, "", List.of());
 		// Todo https://github.com/Modic-2025/modic_backend/issues/42
 
@@ -57,5 +65,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			throw new BadCredentialsException("Authorization header is missing or does not start with Bearer");
 		}
 		return authorizationHeader.replace(AuthConstant.BEARER, "");
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+		final AntPathMatcher matcher = new AntPathMatcher();
+		return request.getRequestURI().startsWith(AUTH_PATH) || matcher.match(JOIN_PATH, request.getRequestURI());
 	}
 }

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package hanium.modic.backend.domain.auth.service;
+package hanium.modic.backend.common.jwt;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -9,7 +9,6 @@ import javax.crypto.SecretKey;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 
-import hanium.modic.backend.common.jwt.BlackListRepository;
 import hanium.modic.backend.common.property.property.TokenProperty;
 import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtTokenProvider.java
@@ -50,7 +50,7 @@ public class JwtTokenProvider {
 		return Jwts.builder()
 			.setClaims(claims)
 			.setIssuedAt(new Date())
-			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getAccessExpirationTime()))
+			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getAccessExpiration()))
 			.signWith(key, SignatureAlgorithm.HS256)
 			.compact();
 	}
@@ -65,7 +65,7 @@ public class JwtTokenProvider {
 		return Jwts.builder()
 			.setClaims(claims)
 			.setIssuedAt(new Date())
-			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getRefreshExpirationTime()))
+			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getRefreshExpiration()))
 			.signWith(key, SignatureAlgorithm.HS256)
 			.compact();
 	}

--- a/src/main/java/hanium/modic/backend/common/property/config/PropertyConfig.java
+++ b/src/main/java/hanium/modic/backend/common/property/config/PropertyConfig.java
@@ -6,13 +6,15 @@ import org.springframework.context.annotation.Configuration;
 import hanium.modic.backend.common.property.property.S3Properties;
 import hanium.modic.backend.common.property.property.SwaggerProperties;
 import hanium.modic.backend.common.property.property.TokenProperty;
+import hanium.modic.backend.common.property.property.RedisProperty;
 
 // 전역적으로 사용되는 상수
 @Configuration
 @EnableConfigurationProperties(value = {
 	S3Properties.class,
 	SwaggerProperties.class,
-	TokenProperty.class
+	TokenProperty.class,
+	RedisProperty.class
 })
 public class PropertyConfig {
 }

--- a/src/main/java/hanium/modic/backend/common/property/property/RedisProperty.java
+++ b/src/main/java/hanium/modic/backend/common/property/property/RedisProperty.java
@@ -1,0 +1,16 @@
+package hanium.modic.backend.common.property.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperty {
+
+	private String host;
+
+	private int port;
+}

--- a/src/main/java/hanium/modic/backend/common/property/property/TokenProperty.java
+++ b/src/main/java/hanium/modic/backend/common/property/property/TokenProperty.java
@@ -12,7 +12,7 @@ public class TokenProperty {
 
 	private String secretKey;
 
-	private long accessExpirationTime;
+	private long accessExpiration;
 
-	private long refreshExpirationTime;
+	private long refreshExpiration;
 }

--- a/src/main/java/hanium/modic/backend/common/security/SecurityConfig.java
+++ b/src/main/java/hanium/modic/backend/common/security/SecurityConfig.java
@@ -6,9 +6,19 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import hanium.modic.backend.common.jwt.JwtAuthenticationEntryPoint;
+import hanium.modic.backend.common.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -18,6 +28,8 @@ public class SecurityConfig {
 				.anyRequest().permitAll())
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 }

--- a/src/main/java/hanium/modic/backend/common/security/principal/UserPrincipal.java
+++ b/src/main/java/hanium/modic/backend/common/security/principal/UserPrincipal.java
@@ -1,0 +1,55 @@
+package hanium.modic.backend.common.security.principal;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import lombok.Data;
+
+@Data
+public class UserPrincipal implements UserDetails {
+
+	private final UserEntity user;
+
+	public UserPrincipal(UserEntity user) {
+		this.user = user;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/constant/AuthConstant.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/constant/AuthConstant.java
@@ -1,0 +1,8 @@
+package hanium.modic.backend.domain.auth.constant;
+
+public final class AuthConstant {
+
+	public static final String AUTHORIZATION = "Authorization";
+
+	public static final String BEARER = "Bearer ";
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.jwt.JwtTokenProvider;
 import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;

--- a/src/main/java/hanium/modic/backend/domain/auth/service/JwtTokenProvider.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/JwtTokenProvider.java
@@ -2,14 +2,18 @@ package hanium.modic.backend.domain.auth.service;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Optional;
 
 import javax.crypto.SecretKey;
 
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Component;
 
+import hanium.modic.backend.common.jwt.BlackListRepository;
 import hanium.modic.backend.common.property.property.TokenProperty;
 import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -20,11 +24,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-	private static final String ACCESS_TOKEN = "accessToken";
+	private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
 
-	private static final String REFRESH_TOKEN = "refreshToken";
+	private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
 
 	private final TokenProperty tokenProperty;
+
+	private final BlackListRepository blackListRepository;
+
+	private final UserEntityRepository userEntityRepository;
 
 	public Token createToken(final UserEntity user) {
 		return new Token(
@@ -61,5 +69,36 @@ public class JwtTokenProvider {
 			.setExpiration(new Date(System.currentTimeMillis() + tokenProperty.getRefreshExpirationTime()))
 			.signWith(key, SignatureAlgorithm.HS256)
 			.compact();
+	}
+
+	public void validateToken(final String accessToken) {
+		if (accessToken == null || !getType(accessToken).equals(ACCESS_TOKEN)) {
+			throw new BadCredentialsException("Type is not access token");
+		}
+		if (blackListRepository.existsById(accessToken)) {
+			throw new BadCredentialsException("Token is blacklisted");
+		}
+	}
+
+	public String getType(String token) {
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(Keys.hmacShaKeyFor(tokenProperty.getSecretKey().getBytes(StandardCharsets.UTF_8)))
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		return claims.get("type", String.class);
+	}
+
+	public Optional<UserEntity> getUser(String token) {
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKey(Keys.hmacShaKeyFor(tokenProperty.getSecretKey().getBytes(StandardCharsets.UTF_8)))
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		final Long userId = claims.get("id", Long.class);
+
+		return userEntityRepository.findById(userId);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Table(name = "user")
+@Table(name = "users")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
+++ b/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.response.ApiResponse;
+import hanium.modic.backend.domain.auth.constant.AuthConstant;
 import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.domain.auth.util.CookieUtil;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
@@ -21,17 +22,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
-	private static final String AUTH_HEADER = "Authorization";
-
-	private static final String BEARER_TOKEN = "Bearer ";
-
 	private final AuthService authService;
 
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
 		LoginResponse loginResponse = authService.login(request.email(), request.password());
 
-		response.addHeader(AUTH_HEADER, BEARER_TOKEN + loginResponse.accessToken());
+		response.addHeader(AuthConstant.AUTHORIZATION, AuthConstant.BEARER + loginResponse.accessToken());
 		Cookie refreshTokenCookie = CookieUtil.createRefreshCookie(loginResponse.refreshToken());
 		response.addCookie(refreshTokenCookie);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
     show-sql: true
     open-in-view: false
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
 cloud:
   aws:
     s3:

--- a/src/test/java/hanium/modic/backend/BackendApplicationTests.java
+++ b/src/test/java/hanium/modic/backend/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package hanium.modic.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
 	@Test

--- a/src/test/java/hanium/modic/backend/base/BaseControllerTest.java
+++ b/src/test/java/hanium/modic/backend/base/BaseControllerTest.java
@@ -1,0 +1,15 @@
+package hanium.modic.backend.base;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import hanium.modic.backend.common.jwt.JwtAuthenticationEntryPoint;
+import hanium.modic.backend.common.jwt.JwtAuthenticationFilter;
+
+public class BaseControllerTest {
+
+	@MockitoBean
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@MockitoBean
+	private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+}

--- a/src/test/java/hanium/modic/backend/base/BaseIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/base/BaseIntegrationTest.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @Disabled
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles({"test"})
 @Import(TestUtils.class)
 public class BaseIntegrationTest {

--- a/src/test/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilterTest.java
@@ -19,9 +19,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import hanium.modic.backend.domain.auth.service.JwtTokenProvider;
 import hanium.modic.backend.domain.user.entity.UserEntity;
-import hanium.modic.backend.domain.user.factory.UserFactory;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 

--- a/src/test/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,96 @@
+package hanium.modic.backend.common.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import hanium.modic.backend.domain.auth.service.JwtTokenProvider;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.factory.UserFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+	@InjectMocks
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+	private MockFilterChain filterChain;
+
+	@BeforeEach
+	void setup() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		filterChain = new MockFilterChain();
+
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("유효한 JWT 토큰으로 인증 성공")
+	void filter_success() throws Exception {
+		// given
+		String token = "valid.jwt.token";
+		request.addHeader("Authorization", "Bearer " + token);
+
+		UserEntity user = UserEntity.builder()
+			.email("test@example.com")
+			.password("encrypted-password")
+			.build();
+
+		doNothing().when(jwtTokenProvider).validateToken(token);
+		when(jwtTokenProvider.getUser(token)).thenReturn(Optional.of(user));
+
+		// when
+		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+		// then
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		assertThat(auth).isNotNull();
+		assertThat(auth.getPrincipal()).isEqualTo(user);
+		assertThat(auth.isAuthenticated()).isTrue();
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 JWT 토큰일 경우 EntryPoint 호출")
+	void filter_invalidToken_callsEntryPoint() throws Exception {
+		// given
+		String token = "invalid.token";
+		request.addHeader("Authorization", "Bearer " + token);
+
+		doThrow(new BadCredentialsException("Token invalid")).when(jwtTokenProvider).validateToken(any());
+
+		// when
+		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+		// then
+		verify(jwtAuthenticationEntryPoint).commence(
+			any(HttpServletRequest.class),
+			any(HttpServletResponse.class),
+			argThat(e -> e instanceof BadCredentialsException && e.getMessage().contains("Invalid JWT token"))
+		);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.jwt.JwtTokenProvider;
 import hanium.modic.backend.domain.auth .dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;

--- a/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
@@ -58,8 +58,8 @@ class JwtTokenProviderTest {
 		// given
 		UserEntity user = UserFactory.createMockUser(1L);
 
-		when(tokenProperty.getAccessExpirationTime()).thenReturn(ACCESS_EXPIRE);
-		when(tokenProperty.getRefreshExpirationTime()).thenReturn(REFRESH_EXPIRE);
+		when(tokenProperty.getAccessExpiration()).thenReturn(ACCESS_EXPIRE);
+		when(tokenProperty.getRefreshExpiration()).thenReturn(REFRESH_EXPIRE);
 
 		// when
 		Token token = jwtTokenProvider.createToken(user);

--- a/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
@@ -3,6 +3,11 @@ package hanium.modic.backend.domain.auth.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import javax.crypto.SecretKey;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,10 +16,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import hanium.modic.backend.common.jwt.BlackListRepository;
 import hanium.modic.backend.common.property.property.TokenProperty;
 import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 
 @ExtendWith(MockitoExtension.class)
 class JwtTokenProviderTest {
@@ -30,11 +40,15 @@ class JwtTokenProviderTest {
 	@Mock
 	private TokenProperty tokenProperty;
 
+	@Mock
+	private BlackListRepository blackListRepository;
+
+	@Mock
+	private UserEntityRepository userEntityRepository;
+
 	@BeforeEach
 	void setUp() {
 		when(tokenProperty.getSecretKey()).thenReturn(SECRET_KEY);
-		when(tokenProperty.getAccessExpirationTime()).thenReturn(ACCESS_EXPIRE);
-		when(tokenProperty.getRefreshExpirationTime()).thenReturn(REFRESH_EXPIRE);
 	}
 
 	@Test
@@ -43,6 +57,9 @@ class JwtTokenProviderTest {
 		// given
 		UserEntity user = UserFactory.createMockUser(1L);
 
+		when(tokenProperty.getAccessExpirationTime()).thenReturn(ACCESS_EXPIRE);
+		when(tokenProperty.getRefreshExpirationTime()).thenReturn(REFRESH_EXPIRE);
+
 		// when
 		Token token = jwtTokenProvider.createToken(user);
 
@@ -50,5 +67,67 @@ class JwtTokenProviderTest {
 		assertThat(token).isNotNull();
 		assertThat(token.accessToken()).isNotBlank();
 		assertThat(token.refreshToken()).isNotBlank();
+	}
+
+	@Test
+	@DisplayName("토큰 유효성 검증 성공")
+	void validateToken_success() {
+		// given
+		SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+		final String validAccessToken = Jwts.builder()
+			.claim("type", "ACCESS_TOKEN")
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+
+		when(blackListRepository.existsById(validAccessToken)).thenReturn(false);
+
+		// when & then
+		assertThatCode(() -> jwtTokenProvider.validateToken(validAccessToken))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("토큰 타입 추출 성공")
+	void getType_success() {
+		// given
+		final Long userId = 1L;
+		SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+		final String validAccessToken = Jwts.builder()
+			.claim("id", userId)
+			.claim("type", "ACCESS_TOKEN")
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+
+		// when
+		String type = jwtTokenProvider.getType(validAccessToken);
+
+		// then
+		assertThat(type).isEqualTo("ACCESS_TOKEN");
+	}
+
+	@Test
+	@DisplayName("토큰에서 사용자 추출 성공")
+	void getUser_success() {
+		// given
+		final Long userId = 1L;
+		UserEntity mockUser = UserFactory.createMockUser(userId);
+		when(userEntityRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+		SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+
+		final String validAccessToken = Jwts.builder()
+			.claim("id", userId)
+			.claim("type", "ACCESS_TOKEN")
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+
+		// when
+		UserEntity user = jwtTokenProvider.getUser(validAccessToken).orElseThrow();
+
+		// then
+		verify(userEntityRepository).findById(userId);
+		assertThat(user).isNotNull();
+		assertThat(user.getId()).isEqualTo(1L);
+		assertThat(user.getEmail()).isEqualTo("test1@example.com");
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/JwtTokenProviderTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import hanium.modic.backend.common.jwt.BlackListRepository;
+import hanium.modic.backend.common.jwt.JwtTokenProvider;
 import hanium.modic.backend.common.property.property.TokenProperty;
 import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
@@ -31,7 +32,7 @@ import jakarta.servlet.http.Cookie;
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class AuthControllerTest {
+class AuthControllerTest extends BaseControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -26,8 +27,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.EntityNotFoundException;
+import hanium.modic.backend.common.jwt.JwtAuthenticationEntryPoint;
+import hanium.modic.backend.common.jwt.JwtAuthenticationFilter;
 import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.web.post.dto.request.CreatePostRequest;
@@ -36,7 +40,7 @@ import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 
 @WebMvcTest(controllers = PostController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class PostControllerTest {
+class PostControllerTest extends BaseControllerTest {
 
 	@MockitoBean
 	private PostService postService;

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.domain.post.service.PostImageService;
 import hanium.modic.backend.web.post.dto.request.CallbackImageSaveUrlRequest;
@@ -25,7 +26,7 @@ import hanium.modic.backend.web.post.dto.request.CreateImageSaveUrlRequest;
 
 @WebMvcTest(controllers = PostImageController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class PostImageControllerTest {
+class PostImageControllerTest extends BaseControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -20,12 +20,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.domain.user.service.UserService;
 import hanium.modic.backend.web.user.dto.UserCreateRequest;
 
 @WebMvcTest(controllers = UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class UserControllerTest {
+class UserControllerTest extends BaseControllerTest {
 
 	@MockitoBean
 	private UserService userService;


### PR DESCRIPTION
## 개요

사용자 인증을 위해선 jwt 토큰의 유효성 검사를 해야한다.
따라서, 요청마다 토큰의 유효성을 검증하기 위한 필터가 필요하다.

## 작업사항

- JWT 검증용 필터 구현
- JWT 에러 시 예외 처리 entry point 구현
- 차단된 토큰 관련 Redis repository 구현
- 컨트롤러 단위 테스트를 위한 base class 구현

### Todo
- [ ] : jwtTokenProvider 패키지 이동


resolve: #40
