### PR TITLE
Feature: 만료된 토큰 재발급

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
 	USER_ROLE_EXCEPTION(HttpStatus.FORBIDDEN, "C-002", "유저 권한 오류"),
 	AUTHENTICATION_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-003", "공통 권한 에러(필터)"),
 	JWT_AUTH_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-004", "JWT 인증 에러"),
+	TOKEN_BLACKLISTED_EXCEPTION(HttpStatus.BAD_REQUEST, "C-005", "차단된 토큰입니다."),
+	REFRESH_TOKEN_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "C-006", "해당 유저에게 발급된 리프레시 토큰이 존재하지 않습니다."),
+	REFRESH_TOKEN_MISMATCH_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-007", "리프레시 토큰이 일치하지 않습니다."),
 
 	// User
 	USER_EMAIL_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, "U-001", "이미 사용중인 이메일입니다."),

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
@@ -25,11 +25,15 @@ import lombok.RequiredArgsConstructor;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final String AUTH_PATH = "/api/auth";
-
 	private static final String JOIN_PATH = "/api/users";
 
-	private final JwtTokenProvider jwtTokenProvider;
+	private static final String SWAGGER_UI_HTML = "/swagger-ui.html";
+	private static final String API_DOCS = "/api-docs";
+	private static final String API_DOCS_ALL = "/api-docs/**";
+	private static final String SWAGGER_UI_ALL = "/swagger-ui/**";
+	private static final String V3_API_DOCS_ALL = "/v3/api-docs/**";
 
+	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 	@Override
@@ -54,8 +58,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		UserEntity user = jwtTokenProvider.getUser(accessToken)
 			.orElseThrow(() -> new BadCredentialsException("Invalid JWT token: User not found"));
 		Authentication authenticationToken = new UsernamePasswordAuthenticationToken(user, "", List.of());
-		// Todo https://github.com/Modic-2025/modic_backend/issues/42
-
 		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 	}
 
@@ -67,8 +69,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+	protected boolean shouldNotFilter(HttpServletRequest request) {
 		final AntPathMatcher matcher = new AntPathMatcher();
-		return request.getRequestURI().startsWith(AUTH_PATH) || matcher.match(JOIN_PATH, request.getRequestURI());
+		final String uri = request.getRequestURI();
+
+		return uri.startsWith(AUTH_PATH)
+			|| matcher.match(JOIN_PATH, uri)
+			|| matcher.match(SWAGGER_UI_HTML, uri)
+			|| matcher.match(API_DOCS, uri)
+			|| matcher.match(API_DOCS_ALL, uri)
+			|| matcher.match(SWAGGER_UI_ALL, uri)
+			|| matcher.match(V3_API_DOCS_ALL, uri);
 	}
 }

--- a/src/main/java/hanium/modic/backend/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtTokenProvider.java
@@ -100,4 +100,10 @@ public class JwtTokenProvider {
 
 		return userEntityRepository.findById(userId);
 	}
+
+	public void setBlackList(final String refreshToken) {
+		BlackList blackList = BlackList.builder().id(refreshToken)
+			.build();
+		blackListRepository.save(blackList);
+	}
 }

--- a/src/main/java/hanium/modic/backend/common/jwt/RefreshToken.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/RefreshToken.java
@@ -1,0 +1,26 @@
+package hanium.modic.backend.common.jwt;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14)
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+
+	@Id
+	private Long userId;
+
+	private String refreshToken;
+
+	public void updateRefreshToken(final String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/hanium/modic/backend/common/jwt/RefreshToken.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/RefreshToken.java
@@ -1,8 +1,9 @@
 package hanium.modic.backend.common.jwt;
 
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
-import jakarta.persistence.Id;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/hanium/modic/backend/common/jwt/RefreshTokenRepository.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package hanium.modic.backend.common.jwt;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
+import hanium.modic.backend.web.auth.dto.ReissueResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -43,5 +44,30 @@ public class AuthService {
 		refreshTokenRepository.save(refreshToken);
 
 		return LoginResponse.from(token);
+	}
+
+	public ReissueResponse reissue(final String refreshToken) {
+		if (blackListRepository.existsById(refreshToken)) {
+			throw new AppException(ErrorCode.TOKEN_BLACKLISTED_EXCEPTION);
+		}
+
+		UserEntity user = jwtTokenProvider.getUser(refreshToken)
+			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
+
+		RefreshToken savedRefreshToken = refreshTokenRepository.findById(user.getId())
+			.orElseThrow(() -> new AppException(ErrorCode.REFRESH_TOKEN_NOT_FOUND_EXCEPTION));
+
+		if (!savedRefreshToken.getRefreshToken().equals(refreshToken)) {
+			throw new AppException(ErrorCode.REFRESH_TOKEN_MISMATCH_EXCEPTION);
+		}
+
+		jwtTokenProvider.setBlackList(refreshToken);
+
+		Token token = jwtTokenProvider.createToken(user);
+		savedRefreshToken.updateRefreshToken(token.refreshToken());
+
+		refreshTokenRepository.save(savedRefreshToken);
+
+		return ReissueResponse.from(token);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
@@ -5,7 +5,10 @@ import org.springframework.stereotype.Service;
 
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.jwt.BlackListRepository;
 import hanium.modic.backend.common.jwt.JwtTokenProvider;
+import hanium.modic.backend.common.jwt.RefreshToken;
+import hanium.modic.backend.common.jwt.RefreshTokenRepository;
 import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
@@ -22,6 +25,10 @@ public class AuthService {
 
 	private final JwtTokenProvider jwtTokenProvider;
 
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	private final BlackListRepository blackListRepository;
+
 	public LoginResponse login(final String email, final String password) {
 		UserEntity user = userEntityRepository.findByEmail(email)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
@@ -31,6 +38,9 @@ public class AuthService {
 		}
 
 		Token token = jwtTokenProvider.createToken(user);
+
+		RefreshToken refreshToken = RefreshToken.builder().userId(user.getId()).refreshToken(token.refreshToken()).build();
+		refreshTokenRepository.save(refreshToken);
 
 		return LoginResponse.from(token);
 	}

--- a/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
+++ b/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package hanium.modic.backend.web.auth.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.domain.auth.util.CookieUtil;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
+import hanium.modic.backend.web.auth.dto.ReissueResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -33,5 +35,16 @@ public class AuthController {
 		response.addCookie(refreshTokenCookie);
 
 		return ResponseEntity.ok(ApiResponse.ok(loginResponse));
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResponse<Void>> reissue(@CookieValue(name = "refreshToken") String refreshToken,  HttpServletResponse response) {
+		ReissueResponse reissueResponse = authService.reissue(refreshToken);
+
+		response.addHeader(AuthConstant.AUTHORIZATION, AuthConstant.BEARER + reissueResponse.accessToken());
+		Cookie refreshTokenCookie = CookieUtil.createRefreshCookie(reissueResponse.refreshToken());
+		response.addCookie(refreshTokenCookie);
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/auth/dto/ReissueResponse.java
+++ b/src/main/java/hanium/modic/backend/web/auth/dto/ReissueResponse.java
@@ -1,0 +1,12 @@
+package hanium.modic.backend.web.auth.dto;
+
+import hanium.modic.backend.domain.auth.dto.Token;
+
+public record ReissueResponse(
+	String accessToken,
+	String refreshToken
+) {
+	public static ReissueResponse from(Token token) {
+		return new ReissueResponse(token.accessToken(), token.refreshToken());
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
@@ -15,10 +15,13 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.jwt.BlackListRepository;
 import hanium.modic.backend.common.jwt.JwtTokenProvider;
+import hanium.modic.backend.common.jwt.RefreshToken;
 import hanium.modic.backend.common.jwt.RefreshTokenRepository;
-import hanium.modic.backend.domain.auth .dto.Token;
+import hanium.modic.backend.domain.auth.dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
 
@@ -40,9 +43,12 @@ class AuthServiceTest {
 	@Mock
 	private RefreshTokenRepository refreshTokenRepository;
 
+	@Mock
+	private BlackListRepository blackListRepository;
+
 	@Test
 	@DisplayName("로그인 테스트 - 성공 케이스")
-	void loginSuccess () {
+	void loginSuccess() {
 		// given
 		UserEntity user = mock(UserEntity.class);
 
@@ -61,7 +67,7 @@ class AuthServiceTest {
 
 	@Test
 	@DisplayName("로그인 테스트 - 실패 케이스 (사용자 없음)")
-	void loginFail () {
+	void loginFail() {
 		// given
 		final String email = "youth@cotato.kr";
 		final String password = "password";
@@ -84,7 +90,100 @@ class AuthServiceTest {
 		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(false);
 
 		// when & then
-		AppException appException = assertThrows(AppException.class, () -> authService.login(user.getEmail(), password));
+		AppException appException = assertThrows(AppException.class,
+			() -> authService.login(user.getEmail(), password));
 		assertEquals(appException.getErrorCode(), ErrorCode.USER_PASSWORD_MISMATCH_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 - 성공 케이스")
+	void reissueSuccess() {
+		// given
+		final String oldRefreshToken = "oldRefreshToken";
+		final String newAccessToken = "newAccessToken";
+		final String newRefreshToken = "newRefreshToken";
+
+		UserEntity user = mock(UserEntity.class);
+
+		RefreshToken refreshToken = mock(RefreshToken.class);
+		when(refreshToken.getRefreshToken()).thenReturn(oldRefreshToken);
+
+		when(blackListRepository.existsById(any())).thenReturn(false);
+		when(jwtTokenProvider.getUser(oldRefreshToken)).thenReturn(Optional.of(user));
+		when(refreshTokenRepository.findById(any())).thenReturn(Optional.of(refreshToken));
+		when(jwtTokenProvider.createToken(any())).thenReturn(new Token(newAccessToken, newRefreshToken));
+
+		// when
+		var reissueResponse = authService.reissue(oldRefreshToken);
+
+		// then
+		assertNotNull(reissueResponse);
+		verify(jwtTokenProvider).getUser(oldRefreshToken);
+		verify(refreshTokenRepository).findById(any());
+		verify(jwtTokenProvider).setBlackList(oldRefreshToken);
+		verify(jwtTokenProvider).createToken(user);
+		verify(refreshTokenRepository).save(refreshToken);
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 - 실패 케이스 (블랙리스트에 존재하는 토큰)")
+	void reissueFail_BlackList() {
+		// given
+		final String refreshToken = "refreshToken";
+
+		when(blackListRepository.existsById(refreshToken)).thenReturn(true);
+
+		// when, then
+		AppException appException = assertThrows(AppException.class, () -> authService.reissue(refreshToken));
+
+		assertEquals(appException.getErrorCode(), ErrorCode.TOKEN_BLACKLISTED_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 - 실패 케이스 (사용자 없음)")
+	void reissueFail_TokenClaimException() {
+		// given
+		final String refreshToken = "refreshToken";
+
+		when(blackListRepository.existsById(refreshToken)).thenReturn(false);
+		when(jwtTokenProvider.getUser(refreshToken)).thenReturn(Optional.empty());
+
+		// when, then
+		AppException appException = assertThrows(AppException.class, () -> authService.reissue(refreshToken));
+		assertEquals(appException.getErrorCode(), ErrorCode.USER_NOT_FOUND_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 - 실패 케이스 (리프레시 토큰이 존재하지 않음)")
+	void reissueFail_RefreshTokenNotFound() {
+		// given
+		final String refreshToken = "refreshToken";
+		UserEntity user = UserFactory.createMockUser(1L);
+
+		when(blackListRepository.existsById(refreshToken)).thenReturn(false);
+		when(jwtTokenProvider.getUser(refreshToken)).thenReturn(Optional.of(user));
+		when(refreshTokenRepository.findById(user.getId())).thenReturn(Optional.empty());
+
+		// when, then
+		AppException appException = assertThrows(AppException.class, () -> authService.reissue(refreshToken));
+		assertEquals(appException.getErrorCode(), ErrorCode.REFRESH_TOKEN_NOT_FOUND_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 - 실패 케이스 (리프레시 토큰 불일치)")
+	void reissueFail_RefreshTokenMisMatch() {
+		// given
+		final String oldRefreshToken = "refreshToken";
+		UserEntity user = UserFactory.createMockUser(1L);
+		RefreshToken refreshToken = mock(RefreshToken.class);
+		when(refreshToken.getRefreshToken()).thenReturn("differentRefreshToken");
+
+		when(blackListRepository.existsById(oldRefreshToken)).thenReturn(false);
+		when(jwtTokenProvider.getUser(oldRefreshToken)).thenReturn(Optional.of(user));
+		when(refreshTokenRepository.findById(user.getId())).thenReturn(Optional.of(refreshToken));
+
+		// when, then
+		AppException appException = assertThrows(AppException.class, () -> authService.reissue(oldRefreshToken));
+		assertEquals(appException.getErrorCode(), ErrorCode.REFRESH_TOKEN_MISMATCH_EXCEPTION);
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
@@ -118,11 +118,13 @@ class AuthServiceTest {
 
 		// then
 		assertNotNull(reissueResponse);
-		verify(jwtTokenProvider).getUser(oldRefreshToken);
-		verify(refreshTokenRepository).findById(any());
+
 		verify(jwtTokenProvider).setBlackList(oldRefreshToken);
 		verify(jwtTokenProvider).createToken(user);
 		verify(refreshTokenRepository).save(refreshToken);
+
+		assertEquals(newAccessToken, reissueResponse.accessToken());
+		assertEquals(newRefreshToken, reissueResponse.refreshToken());
 	}
 
 	@Test

--- a/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.common.jwt.JwtTokenProvider;
+import hanium.modic.backend.common.jwt.RefreshTokenRepository;
 import hanium.modic.backend.domain.auth .dto.Token;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
@@ -36,6 +37,9 @@ class AuthServiceTest {
 	@Mock
 	private BCryptPasswordEncoder passwordEncoder;
 
+	@Mock
+	private RefreshTokenRepository refreshTokenRepository;
+
 	@Test
 	@DisplayName("로그인 테스트 - 성공 케이스")
 	void loginSuccess () {
@@ -52,6 +56,7 @@ class AuthServiceTest {
 		// then
 		verify(passwordEncoder).matches(any(), any());
 		verify(jwtTokenProvider).createToken(user);
+		verify(refreshTokenRepository).save(any());
 	}
 
 	@Test

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
@@ -11,9 +11,15 @@ import org.springframework.http.MediaType;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.common.jwt.JwtTokenProvider;
+import hanium.modic.backend.common.jwt.RefreshToken;
+import hanium.modic.backend.common.jwt.RefreshTokenRepository;
+import hanium.modic.backend.domain.auth.dto.Token;
+import hanium.modic.backend.domain.auth.util.CookieUtil;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
+import jakarta.servlet.http.Cookie;
 
 public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 
@@ -22,6 +28,12 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 
 	@Autowired
 	private BCryptPasswordEncoder passwordEncoder;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -48,5 +60,29 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.accessToken").isNotEmpty())
 			.andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 API 테스트")
+	void reissueApiSuccess() throws Exception {
+		// given
+		UserEntity user = UserEntity.builder().email("youth@cotato.kr").password("password").build();
+		userEntityRepository.save(user);
+
+		Token token = jwtTokenProvider.createToken(user);
+		RefreshToken refreshToken = RefreshToken.builder()
+			.userId(user.getId())
+			.refreshToken(token.refreshToken())
+			.build();
+		refreshTokenRepository.save(refreshToken);
+
+		Cookie refreshCookie = CookieUtil.createRefreshCookie(token.refreshToken());
+
+		// when, then
+		mockMvc.perform(post("/api/auth/reissue")
+				.cookie(refreshCookie))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Authorization", "Bearer " + token.accessToken()))
+			.andExpect(cookie().value("refreshToken", token.refreshToken()));
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package hanium.modic.backend.web.auth.controller;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -21,6 +22,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.bind.MissingRequestCookieException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,6 +30,7 @@ import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
+import hanium.modic.backend.web.auth.dto.ReissueResponse;
 import jakarta.servlet.http.Cookie;
 
 @WebMvcTest(AuthController.class)
@@ -109,5 +112,31 @@ class AuthControllerTest extends BaseControllerTest {
 		);
 	}
 
+	@Test
+	@DisplayName("리프레시 토큰 재발급 테스트")
+	void reissueSuccess() throws Exception {
+		// given
+		String oldRefreshToken = "oldRefreshToken";
+		String newAccessToken = "newAccessToken";
+		String newRefreshToken = "newRefreshToken";
 
+		ReissueResponse mockResponse = new ReissueResponse(newAccessToken, newRefreshToken);
+
+		when(authService.reissue(oldRefreshToken)).thenReturn(mockResponse);
+
+		// when, then
+		mockMvc.perform(post("/api/auth/reissue")
+				.cookie(new Cookie("refreshToken", oldRefreshToken)))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Authorization", "Bearer " + newAccessToken))
+			.andExpect(cookie().value("refreshToken", newRefreshToken));
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 API - 실패 케이스 (쿠키 누락)")
+	void reissue_fail_missing_cookie() throws Exception {
+		mockMvc.perform(post("/api/auth/reissue"))
+			.andExpect(status().isBadRequest())
+			.andExpect(result -> assertInstanceOf(MissingRequestCookieException.class, result.getResolvedException()));
+	}
 }


### PR DESCRIPTION
## 개요

사용 중인 access token이 만료되면 리프레시 토큰을 통해 재발급을 받아야한다.
이때 refreshtoken도 블랙리스트로 저장하고 새로 발급해 토큰 탈취 문제를 해결한다.

resolve: #43 

## 작업사항

- 리프레시 토큰 재발급
- 로그인 시 발급한 리프레시 토큰 레디스에 저장

