### PR TITLE
Feature: 회원 가입 이메일 인증 코드 발송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,56 +1,58 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'hanium.modic'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//s3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
-	runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.3'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+    runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.3'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
 	REFRESH_TOKEN_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "C-006", "해당 유저에게 발급된 리프레시 토큰이 존재하지 않습니다."),
 	REFRESH_TOKEN_MISMATCH_EXCEPTION(HttpStatus.UNAUTHORIZED, "C-007", "리프레시 토큰이 일치하지 않습니다."),
 
+	// Auth
+	EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A-001", "이메일 전송 중 에러가 발생하였습니다."),
+
 	// User
 	USER_EMAIL_DUPLICATED_EXCEPTION(HttpStatus.CONFLICT, "U-001", "이미 사용중인 이메일입니다."),
 	USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "U-002", "해당 유저를 찾을 수 없습니다."),

--- a/src/main/java/hanium/modic/backend/common/property/config/PropertyConfig.java
+++ b/src/main/java/hanium/modic/backend/common/property/config/PropertyConfig.java
@@ -3,10 +3,11 @@ package hanium.modic.backend.common.property.config;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import hanium.modic.backend.common.property.property.EmailProperty;
+import hanium.modic.backend.common.property.property.RedisProperty;
 import hanium.modic.backend.common.property.property.S3Properties;
 import hanium.modic.backend.common.property.property.SwaggerProperties;
 import hanium.modic.backend.common.property.property.TokenProperty;
-import hanium.modic.backend.common.property.property.RedisProperty;
 
 // 전역적으로 사용되는 상수
 @Configuration
@@ -14,7 +15,8 @@ import hanium.modic.backend.common.property.property.RedisProperty;
 	S3Properties.class,
 	SwaggerProperties.class,
 	TokenProperty.class,
-	RedisProperty.class
+	RedisProperty.class,
+	EmailProperty.class
 })
 public class PropertyConfig {
 }

--- a/src/main/java/hanium/modic/backend/common/property/property/EmailProperty.java
+++ b/src/main/java/hanium/modic/backend/common/property/property/EmailProperty.java
@@ -1,0 +1,16 @@
+package hanium.modic.backend.common.property.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "spring.mail")
+public class EmailProperty {
+
+	public static final String AUTH_PERSONAL = "TEAM MODIC";
+
+	private String username;
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/repository/AuthCodeRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/repository/AuthCodeRepository.java
@@ -1,0 +1,17 @@
+package hanium.modic.backend.domain.auth.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthCodeRepository {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void saveCode(final String email, final String code) {
+		redisTemplate.opsForValue().set(email, code);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/AuthService.java
@@ -10,6 +10,9 @@ import hanium.modic.backend.common.jwt.JwtTokenProvider;
 import hanium.modic.backend.common.jwt.RefreshToken;
 import hanium.modic.backend.common.jwt.RefreshTokenRepository;
 import hanium.modic.backend.domain.auth.dto.Token;
+import hanium.modic.backend.domain.auth.service.component.CodeManager;
+import hanium.modic.backend.domain.auth.service.component.EmailSender;
+import hanium.modic.backend.domain.auth.service.dto.EmailDto;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
@@ -30,6 +33,10 @@ public class AuthService {
 
 	private final BlackListRepository blackListRepository;
 
+	private final CodeManager codeManager;
+
+	private final EmailSender emailSender;
+
 	public LoginResponse login(final String email, final String password) {
 		UserEntity user = userEntityRepository.findByEmail(email)
 			.orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
@@ -40,7 +47,10 @@ public class AuthService {
 
 		Token token = jwtTokenProvider.createToken(user);
 
-		RefreshToken refreshToken = RefreshToken.builder().userId(user.getId()).refreshToken(token.refreshToken()).build();
+		RefreshToken refreshToken = RefreshToken.builder()
+			.userId(user.getId())
+			.refreshToken(token.refreshToken())
+			.build();
 		refreshTokenRepository.save(refreshToken);
 
 		return LoginResponse.from(token);
@@ -69,5 +79,16 @@ public class AuthService {
 		refreshTokenRepository.save(savedRefreshToken);
 
 		return ReissueResponse.from(token);
+	}
+
+	public void sendEmailVerification(final String email) {
+		if (userEntityRepository.existsByEmail(email)) {
+			throw new AppException(ErrorCode.USER_EMAIL_DUPLICATED_EXCEPTION);
+		}
+
+		final String randomCode = codeManager.generateRandomCode(email);
+
+		EmailDto emailDto = EmailDto.signup(email, randomCode);
+		emailSender.sendEmail(emailDto);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/auth/service/component/CodeManager.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/component/CodeManager.java
@@ -1,0 +1,34 @@
+package hanium.modic.backend.domain.auth.service.component;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Component;
+
+import hanium.modic.backend.domain.auth.repository.AuthCodeRepository;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CodeManager {
+
+	private static final int CODE_LENGTH = 4;
+
+	private static final int CODE_BOUNDARY = 10;
+
+	private final AuthCodeRepository authCodeRepository;
+
+	public String generateRandomCode(final String email) {
+		final String verificationCode = getRandomCode();
+		authCodeRepository.saveCode(email, verificationCode);
+		return verificationCode;
+	}
+
+	private String getRandomCode() {
+		final ThreadLocalRandom random = ThreadLocalRandom.current();
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < CODE_LENGTH; i++) {
+			builder.append(random.nextInt(CODE_BOUNDARY));
+		}
+		return String.valueOf(builder);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/component/EmailSender.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/component/EmailSender.java
@@ -1,0 +1,50 @@
+package hanium.modic.backend.domain.auth.service.component;
+
+import java.io.UnsupportedEncodingException;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.property.property.EmailProperty;
+import hanium.modic.backend.domain.auth.service.dto.EmailDto;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+
+	private final EmailProperty emailProperty;
+
+	private final JavaMailSender javaMailSender;
+
+	public void sendEmail(final EmailDto emailDto) {
+		try {
+			MimeMessage message = javaMailSender.createMimeMessage();
+
+			message.addRecipients(Message.RecipientType.TO, emailDto.getReceiverEmail());
+			message.setSubject(emailDto.getSubject());
+			message.setText(emailDto.getContent(), "utf-8", "html");
+			message.setFrom(getInternetAddress());
+			javaMailSender.send(message);
+			log.info("이메일 전송 완료");
+		} catch (MessagingException e) {
+			throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
+		}
+	}
+
+	private InternetAddress getInternetAddress() {
+		try {
+			return new InternetAddress(emailProperty.getUsername(), EmailProperty.AUTH_PERSONAL);
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/auth/service/component/EmailSender.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/component/EmailSender.java
@@ -44,7 +44,7 @@ public class EmailSender {
 		try {
 			return new InternetAddress(emailProperty.getUsername(), EmailProperty.AUTH_PERSONAL);
 		} catch (UnsupportedEncodingException e) {
-			throw new RuntimeException(e);
+			throw new AppException(ErrorCode.EMAIL_SEND_ERROR);
 		}
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/auth/service/dto/EmailDto.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/service/dto/EmailDto.java
@@ -1,0 +1,31 @@
+package hanium.modic.backend.domain.auth.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailDto {
+
+	private static final String AUTH_CODE_SUBJECT = "MODIC 회원가입 인증 코드";
+
+	private static final String AUTH_CODE_CONTENT = "<h1>MODIC 회원가입 인증 코드</h1><p>인증 코드는 %s 입니다.</p>";
+
+	private String receiverEmail;
+
+	private String subject;
+
+	private String content;
+
+	public static EmailDto signup(final String receiverEmail, final String code) {
+		return EmailDto.builder()
+			.receiverEmail(receiverEmail)
+			.subject(AUTH_CODE_SUBJECT)
+			.content(String.format(AUTH_CODE_CONTENT, code))
+			.build();
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
+++ b/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import hanium.modic.backend.domain.auth.util.CookieUtil;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
 import hanium.modic.backend.web.auth.dto.ReissueResponse;
+import hanium.modic.backend.web.auth.dto.SendEmailRequest;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -27,7 +28,8 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/login")
-	public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+	public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request,
+		HttpServletResponse response) {
 		LoginResponse loginResponse = authService.login(request.email(), request.password());
 
 		response.addHeader(AuthConstant.AUTHORIZATION, AuthConstant.BEARER + loginResponse.accessToken());
@@ -38,13 +40,20 @@ public class AuthController {
 	}
 
 	@PostMapping("/reissue")
-	public ResponseEntity<ApiResponse<Void>> reissue(@CookieValue(name = "refreshToken") String refreshToken,  HttpServletResponse response) {
+	public ResponseEntity<ApiResponse<Void>> reissue(@CookieValue(name = "refreshToken") String refreshToken,
+		HttpServletResponse response) {
 		ReissueResponse reissueResponse = authService.reissue(refreshToken);
 
 		response.addHeader(AuthConstant.AUTHORIZATION, AuthConstant.BEARER + reissueResponse.accessToken());
 		Cookie refreshTokenCookie = CookieUtil.createRefreshCookie(reissueResponse.refreshToken());
 		response.addCookie(refreshTokenCookie);
 
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping(value = "/email/verification", params = "type=sign-up")
+	public ResponseEntity<ApiResponse<Void>> sendEmailVerification(@RequestBody @Valid SendEmailRequest request) {
+		authService.sendEmailVerification(request.email());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/auth/dto/SendEmailRequest.java
+++ b/src/main/java/hanium/modic/backend/web/auth/dto/SendEmailRequest.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record SendEmailRequest(
-	@Email(message = "이메일 형식이 아닙니다.")
-	@NotBlank(message = "값을 입력해주세요.")
+	@Email(message = "유효하지 않은 이메일 형식입니다.")
+	@NotBlank(message = "이메일은 필수 입력 항목입니다.")
 	String email
 ) {
 }

--- a/src/main/java/hanium/modic/backend/web/auth/dto/SendEmailRequest.java
+++ b/src/main/java/hanium/modic/backend/web/auth/dto/SendEmailRequest.java
@@ -1,0 +1,11 @@
+package hanium.modic.backend.web.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SendEmailRequest(
+	@Email(message = "이메일 형식이 아닙니다.")
+	@NotBlank(message = "값을 입력해주세요.")
+	String email
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,23 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${SENDER_EMAIL}
+    password: ${SENDER_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connection-timeout: 5000
+          timeout: 5000
+          write timeout: 5000
+    auth-code-expiration-millis: 1800000
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,7 @@ spring:
             required: true
           connection-timeout: 5000
           timeout: 5000
-          write timeout: 5000
-    auth-code-expiration-millis: 1800000
+          write-timeout: 5000
 
 cloud:
   aws:

--- a/src/test/java/hanium/modic/backend/domain/auth/repository/AuthCodeRepositoryTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/repository/AuthCodeRepositoryTest.java
@@ -1,0 +1,41 @@
+package hanium.modic.backend.domain.auth.repository;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class AuthCodeRepositoryTest {
+
+	@InjectMocks
+	private AuthCodeRepository authCodeRepository;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Test
+	@DisplayName("회원 가입 이메일 인증 코드 저장")
+	void saveJoinAuthCode() {
+		// given
+		final String email = "youth@email.com";
+		final String code = "1234";
+
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+		// when
+		authCodeRepository.saveCode(email, code);
+
+		// then
+		verify(valueOperations).set(email, code);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.domain.auth.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -20,6 +21,9 @@ import hanium.modic.backend.common.jwt.JwtTokenProvider;
 import hanium.modic.backend.common.jwt.RefreshToken;
 import hanium.modic.backend.common.jwt.RefreshTokenRepository;
 import hanium.modic.backend.domain.auth.dto.Token;
+import hanium.modic.backend.domain.auth.service.component.CodeManager;
+import hanium.modic.backend.domain.auth.service.component.EmailSender;
+import hanium.modic.backend.domain.auth.service.dto.EmailDto;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
@@ -45,6 +49,12 @@ class AuthServiceTest {
 
 	@Mock
 	private BlackListRepository blackListRepository;
+
+	@Mock
+	private CodeManager codeManager;
+
+	@Mock
+	private EmailSender emailSender;
 
 	@Test
 	@DisplayName("로그인 테스트 - 성공 케이스")
@@ -187,5 +197,35 @@ class AuthServiceTest {
 		// when, then
 		AppException appException = assertThrows(AppException.class, () -> authService.reissue(oldRefreshToken));
 		assertEquals(appException.getErrorCode(), ErrorCode.REFRESH_TOKEN_MISMATCH_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("회원 가입 인증 코드 발송")
+	void sendEmailVerificationCode() {
+		// given
+		final String email = "youth@youth.kr";
+
+		when(userEntityRepository.existsByEmail(email)).thenReturn(false);
+		when(codeManager.generateRandomCode(email)).thenReturn("1234");
+
+		// when
+		authService.sendEmailVerification(email);
+
+		// then
+		verify(emailSender).sendEmail(any(EmailDto.class));
+	}
+
+	@Test
+	@DisplayName("회원 가입 인증 코드 발송 - 실패 케이스 (이메일 중복)")
+	void sendEmailVerificationCode_duplicateEmail() {
+		// given
+		final String email = "youth@youth.kr";
+
+		when(userEntityRepository.existsByEmail(email)).thenReturn(true);
+
+		// when, then
+		AppException appException = assertThrows(AppException.class, () -> authService.sendEmailVerification(email));
+		assertThat(appException.getErrorCode()).isEqualTo(ErrorCode.USER_EMAIL_DUPLICATED_EXCEPTION);
+		verifyNoInteractions(emailSender);
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/auth/service/component/CodeManagerTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/component/CodeManagerTest.java
@@ -1,0 +1,37 @@
+package hanium.modic.backend.domain.auth.service.component;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.domain.auth.repository.AuthCodeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CodeManagerTest {
+
+	@InjectMocks
+	private CodeManager codeManager;
+
+	@Mock
+	private AuthCodeRepository authCodeRepository;
+
+	@Test
+	@DisplayName("회원가입 이메일 인증 코드 생성")
+	void generateAuthJoinCode() {
+		// given
+		final String email = "youth@youth.kr";
+
+		// when
+		String code = codeManager.generateRandomCode(email);
+
+		// then
+		assertThat(code).hasSize(4).matches("\\d{4}");
+		verify(authCodeRepository).saveCode(email, code);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/auth/service/component/EmailSenderTest.java
+++ b/src/test/java/hanium/modic/backend/domain/auth/service/component/EmailSenderTest.java
@@ -1,0 +1,75 @@
+package hanium.modic.backend.domain.auth.service.component;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.property.property.EmailProperty;
+import hanium.modic.backend.domain.auth.service.dto.EmailDto;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+@ExtendWith(MockitoExtension.class)
+class EmailSenderTest {
+
+	@InjectMocks
+	private EmailSender emailSender;
+
+	@Mock
+	private JavaMailSender javaMailSender;
+
+	@Mock
+	private MimeMessage mimeMessage;
+
+	@Mock
+	private EmailProperty emailProperty;
+
+	@Test
+	@DisplayName("이메일 인증 코드 전송")
+	void sendAuthEmailCode() throws Exception {
+		// given
+		final String receiver = "youth@youth.kr";
+		final String code = "1234";
+		final EmailDto emailDto = EmailDto.signup(receiver, code);
+
+		given(javaMailSender.createMimeMessage()).willReturn(mimeMessage);
+		given(emailProperty.getUsername()).willReturn("modic@gmail.com");
+
+		// when
+		emailSender.sendEmail(emailDto);
+
+		// then
+		verify(javaMailSender).createMimeMessage();
+		verify(mimeMessage).addRecipients(Message.RecipientType.TO, receiver);
+		verify(mimeMessage).setSubject(emailDto.getSubject());
+		verify(mimeMessage).setText(emailDto.getContent(), "utf-8", "html");
+		verify(mimeMessage).setFrom(any(InternetAddress.class));
+		verify(javaMailSender).send(mimeMessage);
+	}
+
+	@Test
+	@DisplayName("이메일 전송 실패 시 AppException 발생")
+	void throwAppExceptionWhenSendEmailFails() throws Exception {
+		// given
+		EmailDto emailDto = EmailDto.signup("youth@youth.kr", "1234");
+
+		given(javaMailSender.createMimeMessage()).willReturn(mimeMessage);
+		doThrow(new MessagingException()).when(mimeMessage).setFrom(any(InternetAddress.class));
+
+		// when & then
+		assertThatThrownBy(() -> emailSender.sendEmail(emailDto))
+			.isInstanceOf(AppException.class)
+			.hasMessage(ErrorCode.EMAIL_SEND_ERROR.getMessage());
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
@@ -91,17 +91,13 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("회원 인증 이메일 코드 발송 API")
 	void sendEmailSignupCodeApiSuccess() throws Exception {
 		// given
-		SendEmailRequest request = new SendEmailRequest("boysoeng@naver.com");
+		SendEmailRequest request = new SendEmailRequest("test@test.kr");
 
 		// when, then
-		try {
-			mockMvc.perform(post("/api/auth/email/verification")
-					.param("type", "sign-up")
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isOk());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		mockMvc.perform(post("/api/auth/email/verification")
+				.param("type", "sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk());
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import hanium.modic.backend.domain.auth.util.CookieUtil;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
+import hanium.modic.backend.web.auth.dto.SendEmailRequest;
 import jakarta.servlet.http.Cookie;
 
 public class AuthControllerIntegrationTest extends BaseIntegrationTest {
@@ -84,5 +85,23 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(header().string("Authorization", "Bearer " + token.accessToken()))
 			.andExpect(cookie().value("refreshToken", token.refreshToken()));
+	}
+
+	@Test
+	@DisplayName("회원 인증 이메일 코드 발송 API")
+	void sendEmailSignupCodeApiSuccess() throws Exception {
+		// given
+		SendEmailRequest request = new SendEmailRequest("boysoeng@naver.com");
+
+		// when, then
+		try {
+			mockMvc.perform(post("/api/auth/email/verification")
+					.param("type", "sign-up")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
@@ -168,7 +168,7 @@ class AuthControllerTest extends BaseControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.reason[0]").value(expectedErrorMessage)); // ✔ 여기를 수정
+			.andExpect(jsonPath("$.reason[0]").value(expectedErrorMessage));
 	}
 
 	static Stream<Arguments> invalidEmailRequests() {

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerTest.java
@@ -31,6 +31,7 @@ import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.web.auth.dto.LoginRequest;
 import hanium.modic.backend.web.auth.dto.LoginResponse;
 import hanium.modic.backend.web.auth.dto.ReissueResponse;
+import hanium.modic.backend.web.auth.dto.SendEmailRequest;
 import jakarta.servlet.http.Cookie;
 
 @WebMvcTest(AuthController.class)
@@ -138,5 +139,50 @@ class AuthControllerTest extends BaseControllerTest {
 		mockMvc.perform(post("/api/auth/reissue"))
 			.andExpect(status().isBadRequest())
 			.andExpect(result -> assertInstanceOf(MissingRequestCookieException.class, result.getResolvedException()));
+	}
+
+	@Test
+	@DisplayName("이메일 인증 코드 전송 테스트")
+	void sendSignupEmailVerificationCode() throws Exception {
+		// given
+		final String email = "youth@youth.kr";
+
+		SendEmailRequest request = new SendEmailRequest(email);
+
+		// when, then
+		mockMvc.perform(post("/api/auth/email/verification?type=sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk());
+	}
+
+	@ParameterizedTest(name = "[{index}] {0}")
+	@MethodSource("invalidEmailRequests")
+	@DisplayName("이메일 인증 코드 전송 실패 테스트")
+	void sendSignupEmailVerificationCodeFail(String description, SendEmailRequest request,
+		String expectedErrorMessage) throws Exception {
+		// given
+
+		// when, then
+		mockMvc.perform(post("/api/auth/email/verification?type=sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.reason[0]").value(expectedErrorMessage)); // ✔ 여기를 수정
+	}
+
+	static Stream<Arguments> invalidEmailRequests() {
+		return Stream.of(
+			Arguments.of(
+				"이메일이 빈 문자열인 경우",
+				new SendEmailRequest(""),
+				"이메일은 필수 입력 항목입니다."
+			),
+			Arguments.of(
+				"이메일 형식이 잘못된 경우",
+				new SendEmailRequest("not-an-email"),
+				"유효하지 않은 이메일 형식입니다."
+			)
+		);
 	}
 }


### PR DESCRIPTION
## 개요

회원 가입 시 이메일 인증 코드를 발송해야한다.

## 작업사항

- [x] : Java Mail Sender를 통한 이메일 인증 코드 발송
- [x] : 4자리 인증 코드 생성
- [x] : 이메일 인증 코드 발급 후 캐시(레디스)에 저장
- [x] : 통합 API 테스트 
<img width="512" alt="스크린샷 2025-06-13 오후 2 05 56" src="https://github.com/user-attachments/assets/c11201c1-4914-46d3-8a3b-65bc156968af" />

resolve: #50 


### 요구사항
- 급하게 짠거라 적극적인 리뷰 부탁드립니다 ㅎㅎ;
- 추후에 비밀번호 인증 코드 작업할 때 키랑 요청 구분을 해야할?듯 합니다.
