### PR TITLE
[FIX] CORS 문제 해결

### DIFF
--- a/src/main/java/hanium/modic/backend/common/cors/CorsConfig.java
+++ b/src/main/java/hanium/modic/backend/common/cors/CorsConfig.java
@@ -1,18 +1,32 @@
 package hanium.modic.backend.common.cors;
 
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
-public class CorsConfig implements WebMvcConfigurer {
+public class CorsConfig {
 
-	@Override
-	public void addCorsMappings(CorsRegistry registry) {
-		registry
-			.addMapping("/**")
-			.allowedHeaders("*")
-			.allowedOrigins("http://localhost:3000")
-			.allowedMethods("*");
+	private static final String[] ORIGINS = {
+		"http://localhost:3000"
+	};
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+
+		config.setAllowCredentials(true);
+		config.setAllowedOrigins(List.of(ORIGINS));
+		config.addAllowedHeader("*");
+		config.addAllowedMethod("*");
+		config.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
 	}
 }

--- a/src/main/java/hanium/modic/backend/common/security/SecurityConfig.java
+++ b/src/main/java/hanium/modic/backend/common/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 import hanium.modic.backend.common.jwt.JwtAuthenticationEntryPoint;
 import hanium.modic.backend.common.jwt.JwtAuthenticationFilter;
@@ -20,9 +21,12 @@ public class SecurityConfig {
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+	private final CorsConfigurationSource corsConfigurationSource;
+
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http.csrf(AbstractHttpConfigurer::disable)
+			.cors(cors -> cors.configurationSource(corsConfigurationSource))
 			.formLogin(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
 				.anyRequest().permitAll())


### PR DESCRIPTION
## 개요
Preflight 요청에 대해 CORS가 허용되지 않는 문제 해결

Spring Security CORS: Security Filter Chain에서 처리 (더 빠른 단계)
WebMVC CORS: DispatcherServlet 이후 Controller 레벨에서 처리

preflight 요청 처리는 Security CORS에서 처리되기 때문에 기존 방식에서 필터 단에서 CORS 문제 터진 것으로 보임

## 작업사항
Security Cors로 변경