### PR TITLE
[FIX, TEST] AuthControllerIntegrationTest 토큰 재발급 테스트

### DIFF
--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.web.auth.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -88,8 +89,8 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 		mockMvc.perform(post("/api/auth/reissue")
 				.cookie(refreshCookie))
 			.andExpect(status().isOk())
-			.andExpect(header().string("Authorization", "Bearer " + token.accessToken()))
-			.andExpect(cookie().value("refreshToken", token.refreshToken()));
+			.andExpect(header().string("Authorization", startsWith("Bearer ")))
+			.andExpect(cookie().exists("refreshToken"));
 	}
 
 	@Test


### PR DESCRIPTION

## 개요

기존 로직에서 토큰 재발급 후 기존 토큰의 값과 재발급 후 토큰의 값이 같은지를 검증하는 오류 존재

## 작업사항

토큰의 발급이 잘 됐는지 확인하는 코드로 수정

resolved #72 