### PR TITLE
테스트 코드의 BeforeEach 개선 및 @WithCustomUser 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.google.guava:guava:30.1.1-jre'
 
     //s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -28,15 +28,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    testImplementation 'org.springframework.security:spring-security-test'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.google.guava:guava:30.1.1-jre'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/test/java/hanium/modic/backend/base/BaseIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/base/BaseIntegrationTest.java
@@ -1,5 +1,8 @@
 package hanium.modic.backend.base;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -23,4 +26,11 @@ public class BaseIntegrationTest {
 	protected ObjectMapper objectMapper;
 	@Autowired
 	protected TestUtils testUtils;
+	@Autowired
+	protected DatabaseCleanUp databaseCleanUp;
+
+	@AfterEach
+	public void cleanUp() {
+		databaseCleanUp.execute(); // 각 테스트 후 데이터베이스 정리
+	}
 }

--- a/src/test/java/hanium/modic/backend/base/BaseIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/base/BaseIntegrationTest.java
@@ -1,8 +1,6 @@
 package hanium.modic.backend.base;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -17,7 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Disabled
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles({"test"})
-@Import(TestUtils.class)
+@Import(TestUtil.class)
 public class BaseIntegrationTest {
 
 	@Autowired
@@ -25,7 +23,7 @@ public class BaseIntegrationTest {
 	@Autowired
 	protected ObjectMapper objectMapper;
 	@Autowired
-	protected TestUtils testUtils;
+	protected TestUtil testUtil;
 	@Autowired
 	protected DatabaseCleanUp databaseCleanUp;
 

--- a/src/test/java/hanium/modic/backend/base/DatabaseCleanUp.java
+++ b/src/test/java/hanium/modic/backend/base/DatabaseCleanUp.java
@@ -40,13 +40,10 @@ public class DatabaseCleanUp implements InitializingBean {
 	@Transactional
 	public void execute() {
 		entityManager.flush();
-		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
 		for (String tableName : tableNames) {
 			entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
 			entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
 		}
-
-		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
 	}
 }

--- a/src/test/java/hanium/modic/backend/base/DatabaseCleanUp.java
+++ b/src/test/java/hanium/modic/backend/base/DatabaseCleanUp.java
@@ -1,0 +1,52 @@
+package hanium.modic.backend.base;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.google.common.base.CaseFormat;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+
+@Service
+public class DatabaseCleanUp implements InitializingBean {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	private List<String> tableNames;
+
+	@Override
+	public void afterPropertiesSet() {
+		tableNames = entityManager.getMetamodel().getEntities().stream()
+			.map(type -> type.getJavaType())
+			.filter(clazz -> clazz.getAnnotation(Entity.class) != null)
+			.map(clazz -> {
+				Table table = clazz.getAnnotation(Table.class);
+				if (table != null && !table.name().isBlank()) {
+					return table.name(); // 명시된 테이블 이름 사용
+				}
+				// 클래스명을 소문자 스네이크 케이스로 변환
+				return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, clazz.getSimpleName());
+			})
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public void execute() {
+		entityManager.flush();
+		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+		for (String tableName : tableNames) {
+			entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+			entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
+		}
+
+		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+	}
+}

--- a/src/test/java/hanium/modic/backend/base/TestUtil.java
+++ b/src/test/java/hanium/modic/backend/base/TestUtil.java
@@ -8,12 +8,12 @@
 	import com.fasterxml.jackson.databind.ObjectMapper;
 
 	@TestComponent
-	public class TestUtils {
+	public class TestUtil {
 
 		private final ObjectMapper objectMapper;
 
 		@Autowired
-		public TestUtils(ObjectMapper objectMapper) {
+		public TestUtil(ObjectMapper objectMapper) {
 			this.objectMapper = objectMapper;
 		}
 

--- a/src/test/java/hanium/modic/backend/base/login/ContextHolderUtil.java
+++ b/src/test/java/hanium/modic/backend/base/login/ContextHolderUtil.java
@@ -4,7 +4,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
-public class ContextHolderUtils {
+public class ContextHolderUtil {
 
 	// 현재 인증된 유저 정보를 SecurityContext에서 가져오기
 	public static UserEntity getCurrentUser() {

--- a/src/test/java/hanium/modic/backend/base/login/ContextHolderUtils.java
+++ b/src/test/java/hanium/modic/backend/base/login/ContextHolderUtils.java
@@ -1,0 +1,13 @@
+package hanium.modic.backend.base.login;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+
+public class ContextHolderUtils {
+
+	// 현재 인증된 유저 정보를 SecurityContext에서 가져오기
+	public static UserEntity getCurrentUser() {
+		return (UserEntity) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+	}
+}

--- a/src/test/java/hanium/modic/backend/base/login/WithCustomUserSecurityContextFactory.java
+++ b/src/test/java/hanium/modic/backend/base/login/WithCustomUserSecurityContextFactory.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.base.login;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -9,20 +10,24 @@ import org.springframework.security.test.context.support.WithSecurityContextFact
 import org.springframework.transaction.annotation.Transactional;
 
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 
 @TestComponent
 public class WithCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomUser> {
+
+	@Autowired
+	private UserEntityRepository userEntityRepository;
 
 	// SecurityContext 생성 및 UserEntity 저장
 	@Override
 	@Transactional
 	public SecurityContext createSecurityContext(WithCustomUser annotation) {
 		String email = annotation.email();
-		UserEntity user = UserEntity.builder()
+		UserEntity user = userEntityRepository.save(UserEntity.builder()
 			.email(email)
 			.password("password")
 			.name("Test User")
-			.build();
+			.build());
 		Authentication auth = new UsernamePasswordAuthenticationToken(user, "");
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
 		context.setAuthentication(auth);

--- a/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/auth/controller/AuthControllerIntegrationTest.java
@@ -42,11 +42,6 @@ public class AuthControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private AuthCodeRepository authCodeRepository;
 
-	@BeforeEach
-	void setUp() {
-		userEntityRepository.deleteAll();
-	}
-
 	@Test
 	@DisplayName("로그인 API 테스트")
 	void loginApiSuccessTest() throws Exception {

--- a/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
-import hanium.modic.backend.base.login.ContextHolderUtils;
+import hanium.modic.backend.base.login.ContextHolderUtil;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.domain.follow.dto.FollowType;
 import hanium.modic.backend.domain.follow.entity.FollowEntity;
@@ -42,7 +42,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void followSuccess() throws Exception {
 		// given: 인증된 사용자(user1)와 팔로우 대상(user2) 생성
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		UserEntity user2 = saveUser("User2");
 
 		// when: user1이 user2를 팔로우
@@ -64,7 +64,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void unfollowSuccess() throws Exception {
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		UserEntity user2 = saveUser("User2");
 
 		// 먼저 팔로우 관계 DB에 저장
@@ -90,7 +90,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void followTwiceNoError() throws Exception {
 		// given: user1이 user2를 이미 팔로우한 상태
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		UserEntity user2 = saveUser("User2");
 		followEntityRepository.save(FollowEntity.builder().me(user1).following(user2).build());
 
@@ -113,7 +113,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void followSelfFail() throws Exception {
 		// given: user1이 로그인된 상태
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		// when: user1이 자기 자신을 팔로우 요청
 		ResultActions result = mockMvc.perform(post("/api/follows")
@@ -129,7 +129,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("TEST5: 존재하지 않는 유저 팔로우 시 예외 발생")
 	@WithCustomUser(email = "user1@test.com")
 	void followNonExistentUser() throws Exception {
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		// when: 존재하지 않는 유저 ID로 팔로우 요청
 		ResultActions result = mockMvc.perform(post("/api/follows")
@@ -146,7 +146,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void getMyFollowingsPaginationSuccess() throws Exception {
 		// given: user1이 3명의 유저를 팔로우한 상태
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		List<UserEntity> followedUsers = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {
 			UserEntity u = saveUser("Followed" + i);
@@ -173,7 +173,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void getMyFollowersPaginationSuccess() throws Exception {
 		// given: 3명의 유저가 user1을 팔로우함
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		List<UserEntity> followers = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {
 			UserEntity follower = saveUser("Follower" + i);
@@ -232,7 +232,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "viewer@test.com")
 	void getFollowersOfOtherUserSuccess() throws Exception {
 		// given: 유저 생성
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		// given: 3명의 유저가 targetUser를 팔로우함
 		UserEntity targetUser = saveUser("TargetUser");
@@ -264,7 +264,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "viewer@test.com")
 	void getFollowingsOfOtherUserSuccess() throws Exception {
 		// given: targetUser가 3명을 팔로우함
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		UserEntity targetUser = saveUser("TargetUser");
 		List<UserEntity> followed = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {

--- a/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
@@ -31,12 +31,6 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private FollowEntityRepository followEntityRepository;
 
-	@BeforeEach
-	void setUp() {
-		followEntityRepository.deleteAll();
-		userEntityRepository.deleteAll();
-	}
-
 	// 공통 테스트 유저 저장 메서드
 	private UserEntity saveUser(String name) {
 		return userEntityRepository.save(

--- a/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
@@ -7,14 +7,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.ResultActions;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.base.login.ContextHolderUtils;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.domain.follow.dto.FollowType;
 import hanium.modic.backend.domain.follow.entity.FollowEntity;
@@ -38,17 +37,12 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 		);
 	}
 
-	// 컨텍스트에서 유저 정보 조회
-	private UserEntity getCurrentUser() {
-		return (UserEntity)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-	}
-
 	@Test
 	@DisplayName("TEST1: 팔로우 성공")
 	@WithCustomUser(email = "user1@test.com")
 	void followSuccess() throws Exception {
 		// given: 인증된 사용자(user1)와 팔로우 대상(user2) 생성
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		UserEntity user2 = saveUser("User2");
 
 		// when: user1이 user2를 팔로우
@@ -70,7 +64,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void unfollowSuccess() throws Exception {
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		UserEntity user2 = saveUser("User2");
 
 		// 먼저 팔로우 관계 DB에 저장
@@ -96,7 +90,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void followTwiceNoError() throws Exception {
 		// given: user1이 user2를 이미 팔로우한 상태
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		UserEntity user2 = saveUser("User2");
 		followEntityRepository.save(FollowEntity.builder().me(user1).following(user2).build());
 
@@ -119,7 +113,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void followSelfFail() throws Exception {
 		// given: user1이 로그인된 상태
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		// when: user1이 자기 자신을 팔로우 요청
 		ResultActions result = mockMvc.perform(post("/api/follows")
@@ -135,7 +129,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("TEST5: 존재하지 않는 유저 팔로우 시 예외 발생")
 	@WithCustomUser(email = "user1@test.com")
 	void followNonExistentUser() throws Exception {
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		// when: 존재하지 않는 유저 ID로 팔로우 요청
 		ResultActions result = mockMvc.perform(post("/api/follows")
@@ -152,7 +146,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void getMyFollowingsPaginationSuccess() throws Exception {
 		// given: user1이 3명의 유저를 팔로우한 상태
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		List<UserEntity> followedUsers = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {
 			UserEntity u = saveUser("Followed" + i);
@@ -179,7 +173,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void getMyFollowersPaginationSuccess() throws Exception {
 		// given: 3명의 유저가 user1을 팔로우함
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		List<UserEntity> followers = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {
 			UserEntity follower = saveUser("Follower" + i);
@@ -238,7 +232,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "viewer@test.com")
 	void getFollowersOfOtherUserSuccess() throws Exception {
 		// given: 유저 생성
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		// given: 3명의 유저가 targetUser를 팔로우함
 		UserEntity targetUser = saveUser("TargetUser");
@@ -270,7 +264,7 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "viewer@test.com")
 	void getFollowingsOfOtherUserSuccess() throws Exception {
 		// given: targetUser가 3명을 팔로우함
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		UserEntity targetUser = saveUser("TargetUser");
 		List<UserEntity> followed = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
@@ -50,13 +50,6 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private UserEntityRepository userEntityRepository;
 
-	@BeforeEach
-	void setUp() {
-		postEntityRepository.deleteAll();
-		postImageEntityRepository.deleteAll();
-		userEntityRepository.deleteAll();
-	}
-
 	// 컨텍스트에서 유저 정보 조회
 	private UserEntity getCurrentUser() {
 		return (UserEntity)SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
-import hanium.modic.backend.base.login.ContextHolderUtils;
+import hanium.modic.backend.base.login.ContextHolderUtil;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.property.property.S3Properties;
@@ -54,7 +54,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void createPost_ValidRequest_ShouldReturn200AndPersistData() throws Exception {
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		// PostImage 미리 저장
 		PostImageEntity image1 = postImageEntityRepository.save(PostImageEntity.builder()
@@ -109,7 +109,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void deletePost_ValidRequest_ShouldReturn200AndDeleteData() throws Exception {
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		PostEntity post = postEntityRepository.save(PostFactory.createMockPost(user1));
 		postImageEntityRepository.save(ImageFactory.createMockPostImage(post));
@@ -128,7 +128,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void updatePost_ValidRequest_ShouldReturn200AndUpdateData() throws Exception {
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		final PostEntity post = postEntityRepository.save(PostFactory.createMockPost(user1));
 		final List<Long> postImageIds = postImageEntityRepository.saveAll(ImageFactory.createMockPostImages(post, 2))
@@ -166,7 +166,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void updatePost_ValidRequest_ShouldReturn400AndThrowException() throws Exception {
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 		UserEntity user2 = userEntityRepository.save(UserFactory.createMockUserWithoutId("user2"));
 
 		// 다른 사람의 게시글
@@ -204,7 +204,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 		// 특정 포스트에 2개의 이미지가 존재할 때, 하나만 남기면 나머지가 삭제되는지 테스트
 
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		// 기존에 존재하느 포스트
 		PostEntity post = postEntityRepository.save(PostFactory.createMockPost(user1));

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
@@ -7,19 +7,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.ByteArrayInputStream;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.base.login.ContextHolderUtils;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.property.property.S3Properties;
@@ -50,17 +49,12 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private UserEntityRepository userEntityRepository;
 
-	// 컨텍스트에서 유저 정보 조회
-	private UserEntity getCurrentUser() {
-		return (UserEntity)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-	}
-
 	@Test
 	@DisplayName("게시물 등록 요청 API")
 	@WithCustomUser(email = "user1@test.com")
 	void createPost_ValidRequest_ShouldReturn200AndPersistData() throws Exception {
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		// PostImage 미리 저장
 		PostImageEntity image1 = postImageEntityRepository.save(PostImageEntity.builder()
@@ -115,7 +109,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void deletePost_ValidRequest_ShouldReturn200AndDeleteData() throws Exception {
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		PostEntity post = postEntityRepository.save(PostFactory.createMockPost(user1));
 		postImageEntityRepository.save(ImageFactory.createMockPostImage(post));
@@ -134,7 +128,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void updatePost_ValidRequest_ShouldReturn200AndUpdateData() throws Exception {
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		final PostEntity post = postEntityRepository.save(PostFactory.createMockPost(user1));
 		final List<Long> postImageIds = postImageEntityRepository.saveAll(ImageFactory.createMockPostImages(post, 2))
@@ -172,7 +166,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	void updatePost_ValidRequest_ShouldReturn400AndThrowException() throws Exception {
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 		UserEntity user2 = userEntityRepository.save(UserFactory.createMockUserWithoutId("user2"));
 
 		// 다른 사람의 게시글
@@ -210,7 +204,7 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 		// 특정 포스트에 2개의 이미지가 존재할 때, 하나만 남기면 나머지가 삭제되는지 테스트
 
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		// 기존에 존재하느 포스트
 		PostEntity post = postEntityRepository.save(PostFactory.createMockPost(user1));

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -27,7 +27,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import hanium.modic.backend.base.BaseControllerTest;
-import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.common.response.PageResponse;
@@ -48,38 +47,6 @@ class PostControllerTest extends BaseControllerTest {
 	private MockMvc mockMvc;
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
-
-	@Test
-	@DisplayName("게시물 생성 요청 성공")
-	@WithCustomUser(email = "user1@email.com")
-	void createPost_ValidRequest_ShouldReturn200AndInvokeService() throws Exception {
-
-		// given
-		CreatePostRequest req = new CreatePostRequest(
-			"제목",
-			"설명",
-			10000L,
-			5000L,
-			List.of(1L)
-		);
-		String json = objectMapper.writeValueAsString(req);
-
-		// when
-		mockMvc.perform(post("/api/posts")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(json))
-			.andExpect(status().isCreated());
-
-		// then
-		verify(postService).createPost(
-			null, // TODO: 현재 구조상 1이 들어갈 수 없음. 수정 필요
-			"제목",
-			"설명",
-			10000L,
-			5000L,
-			List.of(1L)
-		);
-	}
 
 	@ParameterizedTest(name = "[{index}] {2}")
 	@MethodSource("invalidCreatePostRequests")

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.ByteArrayInputStream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +18,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
+import hanium.modic.backend.base.login.ContextHolderUtils;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.common.property.property.S3Properties;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
@@ -124,7 +124,7 @@ public class PostImageControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	public void createImageUrlCallbackFail() throws Exception {
 		// given
-		UserEntity user1 = userEntityRepository.save(getCurrentUser());
+		UserEntity user1 = ContextHolderUtils.getCurrentUser();
 
 		PostEntity post = PostFactory.createMockPostWithId(1L, user1);
 		PostImageEntity savedPostImage = ImageFactory.createMockPostImage(post);

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
-import hanium.modic.backend.base.login.ContextHolderUtils;
+import hanium.modic.backend.base.login.ContextHolderUtil;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.common.property.property.S3Properties;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
@@ -124,7 +124,7 @@ public class PostImageControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "user1@test.com")
 	public void createImageUrlCallbackFail() throws Exception {
 		// given
-		UserEntity user1 = ContextHolderUtils.getCurrentUser();
+		UserEntity user1 = ContextHolderUtil.getCurrentUser();
 
 		PostEntity post = PostFactory.createMockPostWithId(1L, user1);
 		PostImageEntity savedPostImage = ImageFactory.createMockPostImage(post);

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostImageControllerIntegrationTest.java
@@ -49,13 +49,6 @@ public class PostImageControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private UserEntityRepository userEntityRepository;
 
-	@BeforeEach
-	void setUp() {
-		postImageEntityRepository.deleteAll();
-		postEntityRepository.deleteAll();
-		userEntityRepository.deleteAll();
-	}
-
 	// 컨텍스트에서 유저 정보 조회
 	private UserEntity getCurrentUser() {
 		return (UserEntity)SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerIntegrationTest.java
@@ -3,11 +3,9 @@ package hanium.modic.backend.web.profile.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.ResultActions;
 
 import hanium.modic.backend.base.BaseIntegrationTest;
@@ -21,18 +19,10 @@ public class ProfileControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private UserEntityRepository userEntityRepository;
 
-	// 현재 인증된 유저 정보를 SecurityContext에서 가져오기
-	private UserEntity getCurrentUser() {
-		return (UserEntity) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-	}
-
 	@Test
 	@DisplayName("TEST1: 내 프로필 조회 성공")
 	@WithCustomUser(email = "me@test.com")
 	void getMyProfileSuccess() throws Exception {
-		// given: 로그인된 사용자 저장
-		userEntityRepository.save(getCurrentUser());
-
 		// when: 내 프로필 조회 요청
 		ResultActions result = mockMvc.perform(get("/api/profiles/me"));
 
@@ -72,9 +62,6 @@ public class ProfileControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("TEST3: 내 게시글 목록 조회 성공")
 	@WithCustomUser(email = "poster@test.com")
 	void getMyPostsSuccess() throws Exception {
-		// given: 사용자 저장
-		userEntityRepository.save(getCurrentUser());
-
 		// when: 내 게시글 목록 조회 요청
 		ResultActions result = mockMvc.perform(get("/api/profiles/me/posts")
 			.param("page", "0")

--- a/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerIntegrationTest.java
@@ -21,12 +21,6 @@ public class ProfileControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private UserEntityRepository userEntityRepository;
 
-	@BeforeEach
-	void setUp() {
-		// 테스트 실행 전 데이터 정리
-		userEntityRepository.deleteAll();
-	}
-
 	// 현재 인증된 유저 정보를 SecurityContext에서 가져오기
 	private UserEntity getCurrentUser() {
 		return (UserEntity) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
@@ -27,11 +27,6 @@ public class UserControllerIntegrationTest extends BaseIntegrationTest {
 	@Autowired
 	private JwtTokenProvider jwtTokenProvider;
 
-	@BeforeEach
-	void setUp() {
-		userEntityRepository.deleteAll();
-	}
-
 	@Test
 	@DisplayName("회원가입 API 테스트")
 	void createUserApiTest() throws Exception {


### PR DESCRIPTION
# 개요
- close #76 

# 작업사항
# 테스트 코드의 BeforeEach 개선
## 문제 상황

MockMVC 테스트를 진행 시 테스트 메서드에 `@Transactional` 이 붙으면, 내부 서비스 로직 테스트 동안에도 같은 트랜잭션이 적용된다.
이로 인해 실제 `@Transactional` 이 붙지 않은 insert 메서드 또한 정상적으로 테스트되나, 실제 서비스에서 에러가 나는 경우가 생겼다.
이를 해결하고자, `@Transactional` 을 제거하고 매 `@BeforeEach` 에서 데이터를 제거했으나,

1. AOP를 통해 데이터를 생성해도 `@BeforeEach` 로 인해 삭제됨.
2. BeforeEach에 사용한 모든 테이블 delete 문을 개발자가 의도적으로 명시해야 하므로, 실수가 발생.

이에 대한 해결책을 알아보던 중 다음과 같은 레퍼런스를 찾았다.
[[https://velog.io/@tmdgh0221/스프링-테스트-케이스에서의-Transactional-유의점](https://velog.io/@tmdgh0221/%EC%8A%A4%ED%94%84%EB%A7%81-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BC%80%EC%9D%B4%EC%8A%A4%EC%97%90%EC%84%9C%EC%9D%98-Transactional-%EC%9C%A0%EC%9D%98%EC%A0%90)](https://velog.io/@tmdgh0221/%EC%8A%A4%ED%94%84%EB%A7%81-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BC%80%EC%9D%B4%EC%8A%A4%EC%97%90%EC%84%9C%EC%9D%98-Transactional-%EC%9C%A0%EC%9D%98%EC%A0%90)

나와 마찬가지로 트랜잭션을 제거하나, `@AfterEach` 를 통해 DB 클리너를 호출한다.

## 해결
![image](https://github.com/user-attachments/assets/e1374156-815c-4dc2-a0e0-577f723fa034)
위와 같이 모든 테이블 명을 조회해온 후
이를 Truncate하는 메서드를 만들었다.

![image](https://github.com/user-attachments/assets/06da526d-b6b1-4a6c-9b4b-72633b12e4cd)
그리고 이를 모든 MockMVC 테스트에 사용되는 클래스에 적용했다.

![image](https://github.com/user-attachments/assets/6cd55488-9822-4a55-b87b-246b47e86d63)
이로 인해 불필요한 테스트 별 초기화 로직이 사라졌고,
Repository의 의존성도 없어졌다.


# @WithCustomUser 개선
![image](https://github.com/user-attachments/assets/372251e6-a4d4-462f-9716-ce73ad4af0ae)
기존 @WithCustomUser는 로그인된 User 엔티티를 저장해줘야 하나, @BeforeEach에서 매번 데이터를 비웠기 때문에
Factory에서 저장을 해도 BeforeEach에 의해 삭제되어 오류가 발생했다.

BeforeEach를 개선하면서 AfterEach로 변경했고, 이로 인해 Factory에서 저장해도 문제가 발생하지 않게 되었다.

![image](https://github.com/user-attachments/assets/f33115df-94d7-4ef2-8f70-35bb97724a2d)
그래서 위와 같이 팩터리에서 유저를 저장하고
![image](https://github.com/user-attachments/assets/816fa761-a607-4bc6-bfca-1661684a0ef6)
다음과 같은 util 클래스로 저장된 유저를 조회해올 수 있도록 했다.
