### PR TITLE
PermitUrl에 method체크기능 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import hanium.modic.backend.common.property.property.SecurityProperties;
+import hanium.modic.backend.common.security.noLoginUrl.PermitUrlMatcher;
 import hanium.modic.backend.domain.auth.constant.AuthConstant;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import io.jsonwebtoken.JwtException;
@@ -27,9 +28,9 @@ import lombok.RequiredArgsConstructor;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
-	private final SecurityProperties securityProperties;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final PermitUrlMatcher permitUrlMatcher;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -65,10 +66,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
-		final AntPathMatcher matcher = new AntPathMatcher();
-		final String uri = request.getRequestURI();
-
-		return Arrays.stream(securityProperties.getPermitUrls())
-			.anyMatch(permitUrl -> matcher.match(permitUrl, uri));
+		return permitUrlMatcher.matches(request);
 	}
 }

--- a/src/main/java/hanium/modic/backend/common/security/noLoginUrl/PermitUrlMatcher.java
+++ b/src/main/java/hanium/modic/backend/common/security/noLoginUrl/PermitUrlMatcher.java
@@ -1,0 +1,36 @@
+package hanium.modic.backend.common.security.noLoginUrl;
+
+import java.util.Arrays;
+
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+
+import hanium.modic.backend.common.property.property.SecurityProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PermitUrlMatcher implements RequestMatcher {
+
+	private final SecurityProperties securityProperties;
+	private final AntPathMatcher matcher = new AntPathMatcher();
+
+	@Override
+	public boolean matches(HttpServletRequest request) {
+		final String method = request.getMethod();
+		final String uri = request.getRequestURI();
+
+		return Arrays.stream(securityProperties.getPermitUrls())
+			.anyMatch(permitUrl -> {
+				// permitUrl에서 메소드와 패턴을 분리
+				String[] parts = permitUrl.split(":", 2);
+				if (parts.length != 2) return false;
+				String permitMethod = parts[0];
+				String permitPattern = parts[1];
+
+				return permitMethod.equalsIgnoreCase(method) && matcher.match(permitPattern, uri);
+			});
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
@@ -82,7 +82,7 @@ public class PostController {
 		return ResponseEntity.ok(AppResponse.ok(response));
 	}
 
-	@GetMapping("/list")
+	@GetMapping
 	@Operation(
 		summary = "게시글 목록 조회 API",
 		description = "게시글 목록을 조회합니다. 정렬 기준, 페이지 번호, 페이지 크기를 입력받습니다.",
@@ -120,8 +120,8 @@ public class PostController {
 
 	@PutMapping("/{id}")
 	@Operation(
-		summary = "게시글 삭제 API",
-		description = "게시글을 삭제합니다. 작성자만 삭제할 수 있습니다.",
+		summary = "게시글 수정 API",
+		description = "게시글을 수정합니다. 작성자만 수정할 수 있습니다.",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
 			@ApiResponse(responseCode = "403", description = "포스트에 대한 권한이 없습니다.[P-002]"),

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -184,7 +184,7 @@ class PostControllerTest extends BaseControllerTest {
 		when(postService.getPosts(any(String.class), anyInt(), anyInt())).thenReturn(pageResponse);
 
 		// when & then
-		mockMvc.perform(get("/api/posts/list")
+		mockMvc.perform(get("/api/posts")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.content").isArray())
@@ -211,7 +211,7 @@ class PostControllerTest extends BaseControllerTest {
 		when(postService.getPosts(sort, pageNumber, size)).thenReturn(pageResponse);
 
 		// when & then
-		mockMvc.perform(get("/api/posts/list")
+		mockMvc.perform(get("/api/posts")
 				.param("sort", sort)
 				.param("page", String.valueOf(pageNumber))
 				.param("size", String.valueOf(size))
@@ -238,7 +238,7 @@ class PostControllerTest extends BaseControllerTest {
 	@MethodSource("provideInvalidPagingParameters")
 	void getPosts_InvalidPagingParam(String paramName, String paramValue) throws Exception {
 		// when & then
-		mockMvc.perform(get("/api/posts/list")
+		mockMvc.perform(get("/api/posts")
 				.param(paramName, paramValue)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isBadRequest())


### PR DESCRIPTION
## 개요
- close #92 


## 작업사항
### 기존 url 기반 체크에서 method도 함께 체크하도록 변경했습니다.
![image](https://github.com/user-attachments/assets/0a0efb5c-927c-4e2f-87a9-bab18dd6a4b6)
기존에 properties에서 `/api/posts` 등으로 url을 받았다면 이제 `POST:/api/posts` 등으로 받게 수정했습니다.
또한 method는 대소문자 구분하지 않도록 해뒀습니다.

## 기타 
- dev, test, local properties 수정했습니다.