### PR TITLE
[FEATURE] AI 이미지 유저 권한 체크 기능 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/common/annotation/user/CurrentUser.java
+++ b/src/main/java/hanium/modic/backend/common/annotation/user/CurrentUser.java
@@ -5,7 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface CurrentUser {
 }

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -69,6 +69,8 @@ public enum ErrorCode {
 
 	// AI Image Permission
 	AI_IMAGE_PERMISSION_NOT_FOUND(HttpStatus.FORBIDDEN, "AI-003", "AI 이미지 생성 권한이 없습니다."),
+	AI_IMAGE_PERMISSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "AI-004", "이미 AI 이미지 생성 권한이 존재합니다."),
+	AI_IMAGE_PERMISSION_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-005", "해당 AI 이미지 생성 권한을 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -66,6 +66,9 @@ public enum ErrorCode {
 	// AI
 	AI_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "A-001", "해당 AI 요청을 찾을 수 없습니다."),
 	CREATED_AI_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "A-002", "생성된 AI 이미지를 찾을 수 없습니다."),
+
+	// AI Image Permission
+	AI_IMAGE_PERMISSION_NOT_FOUND(HttpStatus.FORBIDDEN, "AI-003", "AI 이미지 생성 권한이 없습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/hanium/modic/backend/domain/ai/domain/AiImagePermissionEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/domain/AiImagePermissionEntity.java
@@ -1,0 +1,66 @@
+package hanium.modic.backend.domain.ai.entity;
+
+import hanium.modic.backend.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "ai_image_permissions")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiImagePermissionEntity extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "post_id", nullable = false)
+	private Long postId;
+
+	@Column(name = "remaining_generations", nullable = false)
+	private Integer remainingGenerations;
+
+	@Column(name = "is_active", nullable = false)
+	private Boolean isActive = true;
+
+	@Builder
+	private AiImagePermissionEntity(Long userId, Long postId, Integer remainingGenerations, Boolean isActive) {
+		this.userId = userId;
+		this.postId = postId;
+		this.remainingGenerations = remainingGenerations;
+		this.isActive = isActive != null ? isActive : true;
+	}
+
+	public void decreaseRemainingGenerations() {
+		if (this.remainingGenerations > 0) {
+			this.remainingGenerations--;
+		}
+	}
+
+	public void deactivate() {
+		this.isActive = false;
+	}
+
+	public void activate() {
+		this.isActive = true;
+	}
+
+	public boolean hasRemainingGenerations() {
+		return this.remainingGenerations > 0;
+	}
+
+	public boolean isPermissionValid() {
+		return this.isActive && hasRemainingGenerations();
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/domain/AiRequestEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/domain/AiRequestEntity.java
@@ -38,6 +38,12 @@ public class AiRequestEntity extends Image {
 	@Column(nullable = false)
 	private AiImageStatus status = AiImageStatus.PENDING;
 
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "post_id", nullable = false)
+	private Long postId;
+
 	@Builder
 	public AiRequestEntity(
 		String imagePath,
@@ -47,10 +53,14 @@ public class AiRequestEntity extends Image {
 		ImageExtension extension,
 		ImagePrefix imagePurpose,
 		String requestId,
-		AiImageStatus status) {
+		AiImageStatus status,
+		Long userId,
+		Long postId) {
 		super(imagePath, imageUrl, fullImageName, imageName, extension, imagePurpose);
 		this.requestId = requestId;
 		this.status = status != null ? status : AiImageStatus.PENDING;
+		this.userId = userId;
+		this.postId = postId;
 	}
 
 	public void updateStatus(AiImageStatus status) {

--- a/src/main/java/hanium/modic/backend/domain/ai/repository/AiImagePermissionRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/repository/AiImagePermissionRepository.java
@@ -1,0 +1,63 @@
+package hanium.modic.backend.domain.ai.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import hanium.modic.backend.domain.ai.entity.AiImagePermissionEntity;
+
+@Repository
+public interface AiImagePermissionRepository extends JpaRepository<AiImagePermissionEntity, Long> {
+
+	/**
+	 * 사용자 ID와 포스트 ID를 통해 권한 정보 조회
+	 */
+	Optional<AiImagePermissionEntity> findByUserIdAndPostId(Long userId, Long postId);
+
+	/**
+	 * 사용자 ID와 포스트 ID를 통해 활성화된 권한 정보 조회
+	 */
+	@Query("SELECT p FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true")
+	Optional<AiImagePermissionEntity> findByUserIdAndPostIdAndIsActiveTrue(@Param("userId") Long userId,
+		@Param("postId") Long postId);
+
+	/**
+	 * 사용자 ID를 통해 모든 권한 정보 조회
+	 */
+	List<AiImagePermissionEntity> findAllByUserId(Long userId);
+
+	/**
+	 * 사용자 ID를 통해 활성화된 모든 권한 정보 조회
+	 */
+	@Query("SELECT p FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.isActive = true")
+	List<AiImagePermissionEntity> findAllByUserIdAndIsActiveTrue(@Param("userId") Long userId);
+
+	/**
+	 * 포스트 ID를 통해 모든 권한 정보 조회
+	 */
+	List<AiImagePermissionEntity> findAllByPostId(Long postId);
+
+	/**
+	 * 사용자 ID와 포스트 ID를 통해 유효한 권한(활성화 + 남은 횟수 > 0) 조회
+	 */
+	@Query("SELECT p FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true AND p.remainingGenerations > 0")
+	Optional<AiImagePermissionEntity> findValidPermissionByUserIdAndPostId(@Param("userId") Long userId,
+		@Param("postId") Long postId);
+
+	/**
+	 * 권한 존재 여부 확인
+	 */
+	boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+	/**
+	 * 유효한 권한 존재 여부 확인
+	 */
+	@Query("SELECT COUNT(p) > 0 FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true AND p.remainingGenerations > 0")
+	boolean existsValidPermissionByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
+
+	boolean existsByUserIdAndImageId(Long userId, Long imageId);
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/repository/AiImagePermissionRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/repository/AiImagePermissionRepository.java
@@ -58,6 +58,4 @@ public interface AiImagePermissionRepository extends JpaRepository<AiImagePermis
 	 */
 	@Query("SELECT COUNT(p) > 0 FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true AND p.remainingGenerations > 0")
 	boolean existsValidPermissionByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
-
-	boolean existsByUserIdAndImageId(Long userId, Long imageId);
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/repository/AiImagePermissionRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/repository/AiImagePermissionRepository.java
@@ -4,8 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import hanium.modic.backend.domain.ai.entity.AiImagePermissionEntity;
@@ -21,9 +19,7 @@ public interface AiImagePermissionRepository extends JpaRepository<AiImagePermis
 	/**
 	 * 사용자 ID와 포스트 ID를 통해 활성화된 권한 정보 조회
 	 */
-	@Query("SELECT p FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true")
-	Optional<AiImagePermissionEntity> findByUserIdAndPostIdAndIsActiveTrue(@Param("userId") Long userId,
-		@Param("postId") Long postId);
+	Optional<AiImagePermissionEntity> findByUserIdAndPostIdAndIsActiveTrue(Long userId, Long postId);
 
 	/**
 	 * 사용자 ID를 통해 모든 권한 정보 조회
@@ -33,8 +29,7 @@ public interface AiImagePermissionRepository extends JpaRepository<AiImagePermis
 	/**
 	 * 사용자 ID를 통해 활성화된 모든 권한 정보 조회
 	 */
-	@Query("SELECT p FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.isActive = true")
-	List<AiImagePermissionEntity> findAllByUserIdAndIsActiveTrue(@Param("userId") Long userId);
+	List<AiImagePermissionEntity> findAllByUserIdAndIsActiveTrue(Long userId);
 
 	/**
 	 * 포스트 ID를 통해 모든 권한 정보 조회
@@ -43,10 +38,10 @@ public interface AiImagePermissionRepository extends JpaRepository<AiImagePermis
 
 	/**
 	 * 사용자 ID와 포스트 ID를 통해 유효한 권한(활성화 + 남은 횟수 > 0) 조회
+	 * (메서드 이름 기반 쿼리로 변경)
 	 */
-	@Query("SELECT p FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true AND p.remainingGenerations > 0")
-	Optional<AiImagePermissionEntity> findValidPermissionByUserIdAndPostId(@Param("userId") Long userId,
-		@Param("postId") Long postId);
+	Optional<AiImagePermissionEntity> findByUserIdAndPostIdAndIsActiveTrueAndRemainingGenerationsGreaterThan(
+		Long userId, Long postId, int generations);
 
 	/**
 	 * 권한 존재 여부 확인
@@ -56,6 +51,6 @@ public interface AiImagePermissionRepository extends JpaRepository<AiImagePermis
 	/**
 	 * 유효한 권한 존재 여부 확인
 	 */
-	@Query("SELECT COUNT(p) > 0 FROM AiImagePermissionEntity p WHERE p.userId = :userId AND p.postId = :postId AND p.isActive = true AND p.remainingGenerations > 0")
-	boolean existsValidPermissionByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
+	boolean existsByUserIdAndPostIdAndIsActiveTrueAndRemainingGenerationsGreaterThan(Long userId, Long postId,
+		int generations);
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/repository/AiRequestRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/repository/AiRequestRepository.java
@@ -10,4 +10,8 @@ public interface AiRequestRepository extends JpaRepository<AiRequestEntity, Long
 	Optional<AiRequestEntity> findByRequestId(String requestId);
 
 	boolean existsByImagePath(String imagePath);
+
+	boolean existsByIdAndUserId(Long imageId, Long userId);
+
+	boolean existsByRequestIdAndUserId(String requestId, Long userId);
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -59,13 +59,13 @@ public class AiImageGenerationService {
 
 	public String createImageGetUrl(Long imageId, Long userId) {
 		// 생성 전 이미지 조회 권한 검증
-		validateImageOwner(imageId, userId);
+		validateImageOwnerByImageId(imageId, userId);
 		return aiImageService.createImageGetUrl(imageId);
 	}
 
 	public AiImageStatus getAiImageStatus(Long userId, String requestId) {
 		// AI 이미지 상태 조회 권한 검증
-		validateImageOwner(requestId, userId);
+		validateImageOwnerByRequestId(requestId, userId);
 		AiRequestEntity request = aiRequestRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
 		return request.getStatus();
@@ -73,7 +73,7 @@ public class AiImageGenerationService {
 
 	public String createAiImageGetUrl(String requestId, Long userId) {
 		// 생성 후 AI 이미지 생성 조회 검증
-		validateImageOwner(requestId, userId);
+		validateImageOwnerByRequestId(requestId, userId);
 		CreatedAiImageEntity createdAiImageEntity = createdAiImageRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
 
@@ -88,14 +88,14 @@ public class AiImageGenerationService {
 	}
 
 	// imageId를 통해 AI 이미지 소유자 검증(조회용)
-	private void validateImageOwner(Long imageId, Long userId) {
+	private void validateImageOwnerByImageId(Long imageId, Long userId) {
 		if (!aiRequestRepository.existsByIdAndUserId(imageId, userId)) {
 			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
 		}
 	}
 
 	// requestId를 통해 AI 이미지 소유자 검증(조회용)
-	private void validateImageOwner(String requestId, Long userId) {
+	private void validateImageOwnerByRequestId(String requestId, Long userId) {
 		if (!aiRequestRepository.existsByRequestIdAndUserId(requestId, userId)) {
 			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
 		}

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -10,6 +10,7 @@ import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
 import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.repository.AiImagePermissionRepository;
 import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
 import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
@@ -30,12 +31,13 @@ public class AiImageGenerationService {
 	private final AiRequestRepository aiRequestRepository;
 	private final CreatedAiImageRepository createdAiImageRepository;
 	private final CreatedAiImageService createdAiImageService;
+	private final AiImagePermissionRepository aiImagePermissionRepository;
 
 	@Transactional
 	public RequestAiImageGenerationResponse processImageGeneration(ImagePrefix imageUsagePurpose, String fileName,
-		String imagePath, Long postId) {
-		// ToDO: 인증 로직 추가되면 userId를 통해 검증 예정
-		// validateUserPermission(userId);
+		String imagePath, Long postId, Long userId) {
+		// 사용자 권한 검증
+		validateAiRequestPermission(userId, postId);
 
 		List<String> styleImageUrls = postImageEntityRepository.findAllByPostId(postId)
 			.stream()
@@ -43,7 +45,8 @@ public class AiImageGenerationService {
 			.toList();
 
 		// 이미지 저장 및 ID 반환
-		AiRequestEntity aiRequestEntity = aiImageService.saveImage(imageUsagePurpose, fileName, imagePath);
+		AiRequestEntity aiRequestEntity = aiImageService.saveImage(imageUsagePurpose, fileName, imagePath, userId,
+			postId);
 
 		// MQ에 이미지 생성 요청 전송
 		messageQueueService.sendImageGenerationRequest(
@@ -54,30 +57,47 @@ public class AiImageGenerationService {
 		return RequestAiImageGenerationResponse.from(aiRequestEntity);
 	}
 
-	public String createImageGetUrl(Long imageId) {
-		/**
-		 * ToDo: 이미지 조회 권한 검증
-		 */
+	public String createImageGetUrl(Long imageId, Long userId) {
+		// 생성 전 이미지 조회 권한 검증
+		validateImageOwner(userId, imageId);
 		return aiImageService.createImageGetUrl(imageId);
 	}
 
-	public AiImageStatus getAiImageStatus(String requestId) {
+	public AiImageStatus getAiImageStatus(Long userId, String requestId) {
+		// AI 이미지 상태 조회 권한 검증
+		validateImageOwner(userId, requestId);
 		AiRequestEntity request = aiRequestRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
 		return request.getStatus();
 	}
 
-	public String createAiImageGetUrl(String requestId) {
-		/**
-		 * ToDo: AI 이미지 조회 권한 검증
-		 */
+	public String createAiImageGetUrl(String requestId, Long userId) {
+		// 생성 후 AI 이미지 생성 조회 검증
+		validateImageOwner(userId, requestId);
 		CreatedAiImageEntity createdAiImageEntity = createdAiImageRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
 
 		return createdAiImageService.createImageGetUrl(createdAiImageEntity.getId());
 	}
 
-	private void validateUserPermission(Long userId) {
-		// 사용자 권한 검증 로직
+	// 해당 Post에 대한 AI 이미지 생성 권한 검증
+	private void validateAiRequestPermission(Long userId, Long postId) {
+		if (!aiImagePermissionRepository.existsByUserIdAndPostId(userId, postId)) {
+			throw new AppException(ErrorCode.AI_IMAGE_PERMISSION_NOT_FOUND);
+		}
+	}
+
+	// imageId를 통해 AI 이미지 소유자 검증(조회용)
+	private void validateImageOwner(Long userId, Long imageId) {
+		if (!aiRequestRepository.existsByIdAndUserId(userId, imageId)) {
+			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
+		}
+	}
+
+	// requestId를 통해 AI 이미지 소유자 검증(조회용)
+	private void validateImageOwner(Long userId, String requestId) {
+		if (!aiRequestRepository.existsByRequestIdAndUserId(requestId, userId)) {
+			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
+		}
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageGenerationService.java
@@ -59,13 +59,13 @@ public class AiImageGenerationService {
 
 	public String createImageGetUrl(Long imageId, Long userId) {
 		// 생성 전 이미지 조회 권한 검증
-		validateImageOwner(userId, imageId);
+		validateImageOwner(imageId, userId);
 		return aiImageService.createImageGetUrl(imageId);
 	}
 
 	public AiImageStatus getAiImageStatus(Long userId, String requestId) {
 		// AI 이미지 상태 조회 권한 검증
-		validateImageOwner(userId, requestId);
+		validateImageOwner(requestId, userId);
 		AiRequestEntity request = aiRequestRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
 		return request.getStatus();
@@ -73,7 +73,7 @@ public class AiImageGenerationService {
 
 	public String createAiImageGetUrl(String requestId, Long userId) {
 		// 생성 후 AI 이미지 생성 조회 검증
-		validateImageOwner(userId, requestId);
+		validateImageOwner(requestId, userId);
 		CreatedAiImageEntity createdAiImageEntity = createdAiImageRepository.findByRequestId(requestId)
 			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
 
@@ -88,14 +88,14 @@ public class AiImageGenerationService {
 	}
 
 	// imageId를 통해 AI 이미지 소유자 검증(조회용)
-	private void validateImageOwner(Long userId, Long imageId) {
-		if (!aiRequestRepository.existsByIdAndUserId(userId, imageId)) {
+	private void validateImageOwner(Long imageId, Long userId) {
+		if (!aiRequestRepository.existsByIdAndUserId(imageId, userId)) {
 			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
 		}
 	}
 
 	// requestId를 통해 AI 이미지 소유자 검증(조회용)
-	private void validateImageOwner(Long userId, String requestId) {
+	private void validateImageOwner(String requestId, Long userId) {
 		if (!aiRequestRepository.existsByRequestIdAndUserId(requestId, userId)) {
 			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
 		}

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImagePermissionService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImagePermissionService.java
@@ -1,0 +1,93 @@
+// hanium.modic.backend.domain.ai.service.AiImagePermissionService.java
+package hanium.modic.backend.domain.ai.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.entity.AiImagePermissionEntity;
+import hanium.modic.backend.domain.ai.repository.AiImagePermissionRepository;
+import hanium.modic.backend.web.ai.dto.response.AiImagePermissionListResponse;
+import hanium.modic.backend.web.ai.dto.response.AiImagePermissionResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiImagePermissionService {
+
+	private static final Integer DEFAULT_GENERATIONS = 100;
+
+	private final AiImagePermissionRepository aiImagePermissionRepository;
+
+	/**
+	 * AI 이미지 생성 권한 추가
+	 */
+	@Transactional
+	public AiImagePermissionResponse createPermission(Long userId, Long postId) {
+		// 중복 권한 체크
+		if (aiImagePermissionRepository.existsByUserIdAndPostId(userId, postId)) {
+			throw new AppException(ErrorCode.AI_IMAGE_PERMISSION_ALREADY_EXISTS);
+		}
+
+		// 새 권한 생성
+		AiImagePermissionEntity permission = AiImagePermissionEntity.builder()
+			.userId(userId)
+			.postId(postId)
+			.remainingGenerations(DEFAULT_GENERATIONS)
+			.isActive(true)
+			.build();
+
+		AiImagePermissionEntity savedPermission = aiImagePermissionRepository.save(permission);
+
+		return convertToResponse(savedPermission);
+	}
+
+	/**
+	 * 사용자별 권한 조회 (자신의 모든 권한)
+	 */
+	public AiImagePermissionListResponse getMyPermissions(Long userId) {
+		List<AiImagePermissionEntity> permissions = aiImagePermissionRepository.findAllByUserId(userId);
+
+		List<AiImagePermissionResponse> responses = permissions.stream()
+			.map(this::convertToResponse)
+			.collect(Collectors.toList());
+
+		return new AiImagePermissionListResponse(responses, responses.size());
+	}
+
+	/**
+	 * 권한 비활성화
+	 */
+	@Transactional
+	public AiImagePermissionResponse deactivatePermission(Long userId, Long postId) {
+		AiImagePermissionEntity permission = aiImagePermissionRepository
+			.findByUserIdAndPostId(userId, postId)
+			.orElseThrow(() -> new AppException(ErrorCode.AI_IMAGE_PERMISSION_ENTITY_NOT_FOUND));
+
+		permission.deactivate();
+		AiImagePermissionEntity savedPermission = aiImagePermissionRepository.save(permission);
+
+		return convertToResponse(savedPermission);
+	}
+
+	/**
+	 * Entity를 Response DTO로 변환
+	 */
+	private AiImagePermissionResponse convertToResponse(AiImagePermissionEntity entity) {
+		return new AiImagePermissionResponse(
+			entity.getId(),
+			entity.getUserId(),
+			entity.getPostId(),
+			entity.getRemainingGenerations(),
+			entity.getIsActive(),
+			entity.getCreateAt(),
+			entity.getUpdateAt()
+		);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageService.java
@@ -11,6 +11,7 @@ import hanium.modic.backend.common.util.KeyGenerator;
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
+import hanium.modic.backend.domain.image.domain.Image;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.image.service.ImageService;
@@ -56,10 +57,19 @@ public class AiImageService extends ImageService {
 		imageUtil.deleteImage(image.getImagePath());
 	}
 
+	@Override
+	@Deprecated
+	// userId, postId를 포함하지 않는 이미지 저장 메서드(Deprecated)
+	public Image saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath) {
+		throw new UnsupportedOperationException(
+			"Use saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath, Long userId, Long postId) instead.");
+	}
+
 	// AI 요청 이미지 저장
 	@Override
 	@Transactional
-	public AiRequestEntity saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath) {
+	public AiRequestEntity saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath,
+		Long userId, Long postId) {
 		imageValidationService.validateImageSaved(imagePath, imagePrefix);
 		imageValidationService.validateFullFileName(fullFileName);
 		validateDuplicatedImagePath(imagePath);
@@ -79,6 +89,8 @@ public class AiImageService extends ImageService {
 				.imagePath(imagePath)
 				.requestId(requestId)
 				.status(AiImageStatus.PENDING)
+				.userId(userId)
+				.postId(postId)
 				.build());
 	}
 

--- a/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
@@ -27,4 +27,11 @@ public abstract class ImageService {
 
 	// 이미지 저장
 	public abstract Image saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath);
+
+	// userId, postId를 포함한 이미지 저장 메서드
+	public Image saveImage(ImagePrefix imagePrefix, String fullFileName, String imagePath,
+		Long userId, Long postId) {
+		// 기본 구현: 기존 메서드 위임
+		return saveImage(imagePrefix, fullFileName, imagePath);
+	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -10,11 +10,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import hanium.modic.backend.common.annotation.user.CurrentUser;
 import hanium.modic.backend.common.response.AppResponse;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
+import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
 import hanium.modic.backend.web.ai.dto.response.AiRequestStatusResponse;
 import hanium.modic.backend.web.ai.dto.response.RequestAiImageGenerationResponse;
@@ -51,9 +53,6 @@ public class AiImageController {
 	public ResponseEntity<AppResponse<CreateImageSaveUrlResponse>> createImageSaveUrl(
 		@Parameter(description = "이미지 저장 요청 정보", required = true)
 		@RequestBody @Valid CreateImageSaveUrlRequest request) {
-		/*
-		 * ToDo: AiImageGenerationService 에서 이미지 생성 권한 검증
-		 */
 		CreateImageSaveUrlDto dto = aiImageService.createImageSaveUrl(
 			request.imageUsagePurpose(),
 			request.fileName());
@@ -70,17 +69,20 @@ public class AiImageController {
 		responses = {
 			@ApiResponse(responseCode = "404", description = "해당 포스트를 찾을 수 없습니다.[P-001]"),
 			@ApiResponse(responseCode = "400", description = "잘못된 이미지 파일 경로입니다.[I-004]"),
-			@ApiResponse(responseCode = "400", description = "이미지가 저장되지 않았습니다.[I-001]")
+			@ApiResponse(responseCode = "400", description = "이미지가 저장되지 않았습니다.[I-001]"),
+			@ApiResponse(responseCode = "403", description = "AI 이미지 생성 권한이 없습니다.[AI-003]"),
 		}
 	)
 	public ResponseEntity<AppResponse<RequestAiImageGenerationResponse>> requestAiImageGeneration(
-		@RequestBody @Valid AiImageGenerationRequest request) {
+		@RequestBody @Valid AiImageGenerationRequest request,
+		@CurrentUser UserEntity userEntity) {
 
 		RequestAiImageGenerationResponse response = aiImageGenerationService.processImageGeneration(
 			request.imageUsagePurpose(),
 			request.fileName(),
 			request.imagePath(),
-			request.postId()
+			request.postId(),
+			userEntity.getId()
 		);
 
 		return ResponseEntity.status(CREATED)
@@ -99,11 +101,9 @@ public class AiImageController {
 		}
 	)
 	public ResponseEntity<AppResponse<CreateImageGetUrlResponse>> createImageGetUrl(
-		@PathVariable Long imageId) {
-		/*
-		 * ToDo: AiImageGenerationService 에서 이미지 조회 권한 검증
-		 */
-		String imageGetUrl = aiImageGenerationService.createImageGetUrl(imageId);
+		@PathVariable Long imageId,
+		@CurrentUser UserEntity userEntity) {
+		String imageGetUrl = aiImageGenerationService.createImageGetUrl(imageId, userEntity.getId());
 
 		return ResponseEntity.ok(AppResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
 	}
@@ -120,11 +120,9 @@ public class AiImageController {
 		}
 	)
 	public ResponseEntity<AppResponse<CreateImageGetUrlResponse>> createAiImageGetUrl(
-		@PathVariable String requestId) {
-		/*
-		 * ToDo: AiImageGenerationService 에서 이미지 조회 권한 검증
-		 */
-		String imageGetUrl = aiImageGenerationService.createAiImageGetUrl(requestId);
+		@PathVariable String requestId,
+		@CurrentUser UserEntity userEntity) {
+		String imageGetUrl = aiImageGenerationService.createAiImageGetUrl(requestId, userEntity.getId());
 
 		return ResponseEntity.ok(AppResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
 	}
@@ -135,12 +133,14 @@ public class AiImageController {
 		summary = "AI 이미지 생성 상태 조회",
 		description = "AI 이미지 생성 요청에 대한 현재 상태를 조회합니다.",
 		responses = {
-			@ApiResponse(responseCode = "404", description = "해당 AI 요청을 찾을 수 없습니다.[A-001]")
+			@ApiResponse(responseCode = "404", description = "해당 AI 요청을 찾을 수 없습니다.[A-001]"),
+			@ApiResponse(responseCode = "400", description = "이미지를 훔칠 수 없습니다.[I-006]")
 		}
 	)
 	public ResponseEntity<AppResponse<AiRequestStatusResponse>> getAiRequestStatus(
-		@PathVariable String requestId) {
-		AiImageStatus status = aiImageGenerationService.getAiImageStatus(requestId);
+		@PathVariable String requestId,
+		@CurrentUser UserEntity userEntity) {
+		AiImageStatus status = aiImageGenerationService.getAiImageStatus(userEntity.getId(), requestId);
 		return ResponseEntity.ok(AppResponse.ok(new AiRequestStatusResponse(status)));
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImagePermissionController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImagePermissionController.java
@@ -1,0 +1,89 @@
+package hanium.modic.backend.web.ai.controller;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hanium.modic.backend.common.annotation.user.CurrentUser;
+import hanium.modic.backend.common.response.AppResponse;
+import hanium.modic.backend.domain.ai.service.AiImagePermissionService;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.web.ai.dto.response.AiImagePermissionListResponse;
+import hanium.modic.backend.web.ai.dto.response.AiImagePermissionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "AI 이미지 권한 관리 API", description = "AI 이미지 생성 권한 관리 API")
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping("/api/ai/permissions")
+public class AiImagePermissionController {
+
+	private final AiImagePermissionService aiImagePermissionService;
+
+	@PostMapping("/posts/{postId}")
+	@Operation(
+		summary = "AI 이미지 생성 권한 추가",
+		description = "현재 사용자에게 특정 게시글에 대한 AI 이미지 생성 권한을 부여합니다. 기본 100회 생성 가능합니다.",
+		responses = {
+			@ApiResponse(responseCode = "409", description = "이미 AI 이미지 생성 권한이 존재합니다.[AI-004]")
+		}
+	)
+	public ResponseEntity<AppResponse<AiImagePermissionResponse>> createPermission(
+		@Parameter(description = "게시글 ID", required = true)
+		@PathVariable Long postId,
+		@CurrentUser UserEntity userEntity) {
+
+		AiImagePermissionResponse response = aiImagePermissionService.createPermission(
+			userEntity.getId(),
+			postId
+		);
+
+		return ResponseEntity.status(CREATED)
+			.body(AppResponse.created(response));
+	}
+
+	@GetMapping("/my")
+	@Operation(
+		summary = "내 권한 조회",
+		description = "현재 사용자의 모든 AI 이미지 생성 권한을 조회합니다."
+	)
+	public ResponseEntity<AppResponse<AiImagePermissionListResponse>> getMyPermissions(
+		@CurrentUser UserEntity userEntity) {
+
+		AiImagePermissionListResponse response = aiImagePermissionService.getMyPermissions(userEntity.getId());
+
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+
+	@DeleteMapping("/posts/{postId}")
+	@Operation(
+		summary = "권한 비활성화",
+		description = "현재 사용자의 특정 게시글에 대한 AI 이미지 생성 권한을 비활성화합니다.",
+		responses = {
+			@ApiResponse(responseCode = "404", description = "해당 AI 이미지 생성 권한을 찾을 수 없습니다.[AI-005]")
+		}
+	)
+	public ResponseEntity<AppResponse<AiImagePermissionResponse>> deactivatePermission(
+		@Parameter(description = "게시글 ID", required = true)
+		@PathVariable Long postId,
+		@CurrentUser UserEntity userEntity) {
+
+		AiImagePermissionResponse response = aiImagePermissionService.deactivatePermission(
+			userEntity.getId(),
+			postId
+		);
+
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionListResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionListResponse.java
@@ -1,0 +1,9 @@
+package hanium.modic.backend.web.ai.dto.response;
+
+import java.util.List;
+
+public record AiImagePermissionListResponse(
+	List<AiImagePermissionResponse> permissions,
+	Integer totalCount
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionResponse.java
@@ -1,0 +1,14 @@
+package hanium.modic.backend.web.ai.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AiImagePermissionResponse(
+	Long id,
+	Long userId,
+	Long postId,
+	Integer remainingGenerations,
+	Boolean isActive,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/profile/controller/ProfileController.java
+++ b/src/main/java/hanium/modic/backend/web/profile/controller/ProfileController.java
@@ -1,4 +1,4 @@
-package hanium.modic.backend.web.user.controller;
+package hanium.modic.backend.web.profile.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/src/test/java/hanium/modic/backend/base/BaseControllerTest.java
+++ b/src/test/java/hanium/modic/backend/base/BaseControllerTest.java
@@ -21,17 +21,21 @@ public class BaseControllerTest {
 	@MockitoBean
 	private CurrentUserArgumentResolver currentUserArgumentResolver;
 
-	// 테스트용 사용자 생성 메서드
-	protected static UserEntity createTestUser() {
-		return UserEntity.builder()
-			.email("test@test.com")
-			.name("Test User")
-			.password("password")
-			.build();
-	}
+	@MockitoBean
+	protected UserEntity testUser;
 
 	protected void setupCurrentUserMocking() {
-		UserEntity testUser = createTestUser();
+		setupCurrentUserMocking(1L); // 기본값으로 1L 사용
+	}
+
+	protected void setupCurrentUserMocking(Long userId) {
+		// UserEntity를 mock으로 생성
+		testUser = mock(UserEntity.class);
+
+		// mock 객체의 메서드들을 모킹
+		when(testUser.getId()).thenReturn(userId);
+		when(testUser.getEmail()).thenReturn("test@test.com");
+		when(testUser.getName()).thenReturn("Test User");
 
 		when(currentUserArgumentResolver.supportsParameter(any())).thenReturn(true);
 		when(currentUserArgumentResolver.resolveArgument(any(), any(), any(), any()))

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiImageGenerationServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiImageGenerationServiceTest.java
@@ -1,0 +1,246 @@
+package hanium.modic.backend.domain.ai.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
+import hanium.modic.backend.domain.ai.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.repository.AiImagePermissionRepository;
+import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
+import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
+import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.post.entity.PostImageEntity;
+import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.web.ai.dto.response.RequestAiImageGenerationResponse;
+
+@ExtendWith(MockitoExtension.class)
+class AiImageGenerationServiceTest {
+
+	@InjectMocks
+	private AiImageGenerationService aiImageGenerationService;
+
+	@Mock
+	private AiImageService aiImageService;
+	@Mock
+	private MessageQueueService messageQueueService;
+	@Mock
+	private PostImageEntityRepository postImageEntityRepository;
+	@Mock
+	private AiRequestRepository aiRequestRepository;
+	@Mock
+	private CreatedAiImageRepository createdAiImageRepository;
+	@Mock
+	private CreatedAiImageService createdAiImageService;
+	@Mock
+	private AiImagePermissionRepository aiImagePermissionRepository;
+
+	private static final Long TEST_USER_ID = 1L;
+	private static final Long TEST_POST_ID = 1L;
+	private static final Long TEST_IMAGE_ID = 1L;
+	private static final String TEST_REQUEST_ID = "test-request-id";
+	private static final String TEST_FILE_NAME = "test-image.jpg";
+	private static final String TEST_IMAGE_PATH = "/test/path";
+	private static final String TEST_IMAGE_URL = "https://test.com/image.jpg";
+	private static final String TEST_GENERATED_URL = "https://test.com/generated-url";
+
+	@Test
+	@DisplayName("processImageGeneration - 성공: 정상적인 이미지 생성 요청 처리")
+	void processImageGeneration_Success() {
+		// given
+		ImagePrefix imageUsagePurpose = ImagePrefix.AI_REQUEST;
+		AiRequestEntity mockAiRequest = createTestAiRequestEntity();
+		List<PostImageEntity> mockPostImages = List.of(createTestPostImageEntity());
+		List<String> expectedStyleUrls = List.of(TEST_IMAGE_URL);
+
+		when(aiImagePermissionRepository.existsByUserIdAndPostId(TEST_USER_ID, TEST_POST_ID)).thenReturn(true);
+		when(postImageEntityRepository.findAllByPostId(TEST_POST_ID)).thenReturn(mockPostImages);
+		when(aiImageService.saveImage(imageUsagePurpose, TEST_FILE_NAME, TEST_IMAGE_PATH, TEST_USER_ID, TEST_POST_ID))
+			.thenReturn(mockAiRequest);
+
+		// when
+		RequestAiImageGenerationResponse result = aiImageGenerationService.processImageGeneration(
+			imageUsagePurpose, TEST_FILE_NAME, TEST_IMAGE_PATH, TEST_POST_ID, TEST_USER_ID);
+
+		// then
+		assertEquals(TEST_IMAGE_ID, result.imageId());
+		assertEquals(TEST_REQUEST_ID, result.requestId());
+		verify(messageQueueService).sendImageGenerationRequest(TEST_REQUEST_ID, TEST_IMAGE_URL, expectedStyleUrls);
+	}
+
+	@Test
+	@DisplayName("processImageGeneration - 실패: 권한이 없는 사용자")
+	void processImageGeneration_Fail_NoPermission() {
+		// given
+		when(aiImagePermissionRepository.existsByUserIdAndPostId(TEST_USER_ID, TEST_POST_ID)).thenReturn(false);
+
+		// when & then
+		AppException exception = assertThrows(AppException.class, () ->
+			aiImageGenerationService.processImageGeneration(
+				ImagePrefix.AI_REQUEST, TEST_FILE_NAME, TEST_IMAGE_PATH, TEST_POST_ID, TEST_USER_ID));
+
+		assertEquals(ErrorCode.AI_IMAGE_PERMISSION_NOT_FOUND, exception.getErrorCode());
+		verify(messageQueueService, never()).sendImageGenerationRequest(anyString(), anyString(), anyList());
+	}
+
+	@Test
+	@DisplayName("createImageGetUrl - 성공: 정상적인 이미지 URL 생성")
+	void createImageGetUrl_Success() {
+		// given
+		when(aiRequestRepository.existsByIdAndUserId(TEST_USER_ID, TEST_IMAGE_ID)).thenReturn(true);
+		when(aiImageService.createImageGetUrl(TEST_IMAGE_ID)).thenReturn(TEST_GENERATED_URL);
+
+		// when
+		String result = aiImageGenerationService.createImageGetUrl(TEST_IMAGE_ID, TEST_USER_ID);
+
+		// then
+		assertEquals(TEST_GENERATED_URL, result);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideImageOwnerValidationTestCases")
+	@DisplayName("이미지 소유자 검증 실패 테스트 (imageId 기반)")
+	void validateImageOwner_ById_Fail(String testName, boolean existsResult) {
+		// given
+		when(aiRequestRepository.existsByIdAndUserId(TEST_USER_ID, TEST_IMAGE_ID)).thenReturn(existsResult);
+
+		// when & then
+		AppException exception = assertThrows(AppException.class, () ->
+			aiImageGenerationService.createImageGetUrl(TEST_IMAGE_ID, TEST_USER_ID));
+
+		assertEquals(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION, exception.getErrorCode());
+	}
+
+	@ParameterizedTest
+	@EnumSource(AiImageStatus.class)
+	@DisplayName("getAiImageStatus - 성공: 모든 상태값 조회")
+	void getAiImageStatus_Success_AllStatuses(AiImageStatus status) {
+		// given
+		AiRequestEntity mockRequest = createTestAiRequestEntityWithStatus(status);
+		when(aiRequestRepository.existsByRequestIdAndUserId(TEST_REQUEST_ID, TEST_USER_ID)).thenReturn(true);
+		when(aiRequestRepository.findByRequestId(TEST_REQUEST_ID)).thenReturn(Optional.of(mockRequest));
+
+		// when
+		AiImageStatus result = aiImageGenerationService.getAiImageStatus(TEST_USER_ID, TEST_REQUEST_ID);
+
+		// then
+		assertEquals(status, result);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideRequestIdOwnerValidationTestCases")
+	@DisplayName("이미지 소유자 검증 실패 테스트 (requestId 기반)")
+	void validateImageOwner_ByRequestId_Fail(String testName, boolean existsResult) {
+		// given
+		when(aiRequestRepository.existsByRequestIdAndUserId(TEST_REQUEST_ID, TEST_USER_ID)).thenReturn(existsResult);
+
+		// when & then
+		AppException exception = assertThrows(AppException.class, () ->
+			aiImageGenerationService.getAiImageStatus(TEST_USER_ID, TEST_REQUEST_ID));
+
+		assertEquals(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("getAiImageStatus - 실패: 존재하지 않는 requestId")
+	void getAiImageStatus_Fail_RequestNotFound() {
+		// given
+		when(aiRequestRepository.existsByRequestIdAndUserId(TEST_REQUEST_ID, TEST_USER_ID)).thenReturn(true);
+		when(aiRequestRepository.findByRequestId(TEST_REQUEST_ID)).thenReturn(Optional.empty());
+
+		// when & then
+		AppException exception = assertThrows(AppException.class, () ->
+			aiImageGenerationService.getAiImageStatus(TEST_USER_ID, TEST_REQUEST_ID));
+
+		assertEquals(ErrorCode.AI_REQUEST_NOT_FOUND, exception.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("createAiImageGetUrl - 성공: 정상적인 생성된 AI 이미지 URL 조회")
+	void createAiImageGetUrl_Success() {
+		// given
+		CreatedAiImageEntity mockCreatedImage = createTestCreatedAiImageEntity();
+		when(aiRequestRepository.existsByRequestIdAndUserId(TEST_REQUEST_ID, TEST_USER_ID)).thenReturn(true);
+		when(createdAiImageRepository.findByRequestId(TEST_REQUEST_ID)).thenReturn(Optional.of(mockCreatedImage));
+		when(createdAiImageService.createImageGetUrl(TEST_IMAGE_ID)).thenReturn(TEST_GENERATED_URL);
+
+		// when
+		String result = aiImageGenerationService.createAiImageGetUrl(TEST_REQUEST_ID, TEST_USER_ID);
+
+		// then
+		assertEquals(TEST_GENERATED_URL, result);
+	}
+
+	@Test
+	@DisplayName("createAiImageGetUrl - 실패: 존재하지 않는 생성된 이미지")
+	void createAiImageGetUrl_Fail_CreatedImageNotFound() {
+		// given
+		when(aiRequestRepository.existsByRequestIdAndUserId(TEST_REQUEST_ID, TEST_USER_ID)).thenReturn(true);
+		when(createdAiImageRepository.findByRequestId(TEST_REQUEST_ID)).thenReturn(Optional.empty());
+
+		// when & then
+		AppException exception = assertThrows(AppException.class, () ->
+			aiImageGenerationService.createAiImageGetUrl(TEST_REQUEST_ID, TEST_USER_ID));
+
+		assertEquals(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND, exception.getErrorCode());
+	}
+
+	// 테스트 데이터 생성 메서드들
+	private AiRequestEntity createTestAiRequestEntity() {
+		AiRequestEntity entity = Mockito.mock(AiRequestEntity.class);
+		when(entity.getId()).thenReturn(TEST_IMAGE_ID);
+		when(entity.getRequestId()).thenReturn(TEST_REQUEST_ID);
+		when(entity.getImageUrl()).thenReturn(TEST_IMAGE_URL);
+		return entity;
+	}
+
+	private AiRequestEntity createTestAiRequestEntityWithStatus(AiImageStatus status) {
+		AiRequestEntity entity = Mockito.mock(AiRequestEntity.class);
+		when(entity.getStatus()).thenReturn(status);
+		return entity;
+	}
+
+	private PostImageEntity createTestPostImageEntity() {
+		PostImageEntity entity = Mockito.mock(PostImageEntity.class);
+		when(entity.getImageUrl()).thenReturn(TEST_IMAGE_URL);
+		return entity;
+	}
+
+	private CreatedAiImageEntity createTestCreatedAiImageEntity() {
+		CreatedAiImageEntity entity = Mockito.mock(CreatedAiImageEntity.class);
+		when(entity.getId()).thenReturn(TEST_IMAGE_ID);
+		return entity;
+	}
+
+	// Parameterized Test 데이터 제공 메서드들
+	private static Stream<Arguments> provideImageOwnerValidationTestCases() {
+		return Stream.of(
+			Arguments.of("소유자가 아닌 사용자", false)
+		);
+	}
+
+	private static Stream<Arguments> provideRequestIdOwnerValidationTestCases() {
+		return Stream.of(
+			Arguments.of("소유자가 아닌 사용자", false)
+		);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiImageGenerationServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiImageGenerationServiceTest.java
@@ -106,7 +106,7 @@ class AiImageGenerationServiceTest {
 	@DisplayName("createImageGetUrl - 성공: 정상적인 이미지 URL 생성")
 	void createImageGetUrl_Success() {
 		// given
-		when(aiRequestRepository.existsByIdAndUserId(TEST_USER_ID, TEST_IMAGE_ID)).thenReturn(true);
+		when(aiRequestRepository.existsByIdAndUserId(TEST_IMAGE_ID, TEST_USER_ID)).thenReturn(true);
 		when(aiImageService.createImageGetUrl(TEST_IMAGE_ID)).thenReturn(TEST_GENERATED_URL);
 
 		// when
@@ -121,7 +121,7 @@ class AiImageGenerationServiceTest {
 	@DisplayName("이미지 소유자 검증 실패 테스트 (imageId 기반)")
 	void validateImageOwner_ById_Fail(String testName, boolean existsResult) {
 		// given
-		when(aiRequestRepository.existsByIdAndUserId(TEST_USER_ID, TEST_IMAGE_ID)).thenReturn(existsResult);
+		when(aiRequestRepository.existsByIdAndUserId(TEST_IMAGE_ID, TEST_USER_ID)).thenReturn(existsResult);
 
 		// when & then
 		AppException exception = assertThrows(AppException.class, () ->

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiImageGenerationServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiImageGenerationServiceTest.java
@@ -119,7 +119,7 @@ class AiImageGenerationServiceTest {
 	@ParameterizedTest
 	@MethodSource("provideImageOwnerValidationTestCases")
 	@DisplayName("이미지 소유자 검증 실패 테스트 (imageId 기반)")
-	void validateImageOwner_ById_Fail(String testName, boolean existsResult) {
+	void validateImageOwnerByImageId_Fail(String testName, boolean existsResult) {
 		// given
 		when(aiRequestRepository.existsByIdAndUserId(TEST_IMAGE_ID, TEST_USER_ID)).thenReturn(existsResult);
 
@@ -149,7 +149,7 @@ class AiImageGenerationServiceTest {
 	@ParameterizedTest
 	@MethodSource("provideRequestIdOwnerValidationTestCases")
 	@DisplayName("이미지 소유자 검증 실패 테스트 (requestId 기반)")
-	void validateImageOwner_ByRequestId_Fail(String testName, boolean existsResult) {
+	void validateImageOwnerByRequestId_Fail(String testName, boolean existsResult) {
 		// given
 		when(aiRequestRepository.existsByRequestIdAndUserId(TEST_REQUEST_ID, TEST_USER_ID)).thenReturn(existsResult);
 

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
@@ -128,7 +128,7 @@ class AiImageControllerTest extends BaseControllerTest {
 		// given
 		String requestId = "valid-request-id";
 		AiImageStatus expectedStatus = AiImageStatus.DONE;
-		given(aiImageGenerationService.getAiImageStatus(requestId)).willReturn(expectedStatus);
+		given(aiImageGenerationService.getAiImageStatus(testUser.getId(), requestId)).willReturn(expectedStatus);
 
 		// when + then
 		mockMvc.perform(get("/api/ai/images/requests/" + requestId + "/status")

--- a/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.domain.profile.service.ProfileService;
-import hanium.modic.backend.web.user.controller.ProfileController;
 
 @WebMvcTest(controllers = ProfileController.class)
 @AutoConfigureMockMvc(addFilters = false)


### PR DESCRIPTION
## 개요
close #48 
올리다가 머지를 잘못눌러서 같은 내용의 커밋이 2번 반복 되네요..허허 무시해주세용

## 작업사항
### 이미지 생성 권한 체크
`AiImagePermissionEntity`를 생성했습니다.
유저가 이미지를 생성할 수 있는 `post`에 대해 `userId`를 매핑하는 테이블입니다.
이미지 생성권을 구매하면 이 테이블에 추가됩니다.

### 이미지 조회 권한 체크
조회 권한의 경우, 이미 생성한 이미지의 `imageId` 혹은 `requestId`를 통해 조회하는 로직이 있습니다.
따라서 (`imageId`, `userId`), (`requestId`, `userId`)가 매칭되는지를 확인하는 방식으로 권한을 검증했습니다.

### ImageService 문제
이미지 서비스의 `saveImage()`에서 `userId`, `postId`를 넘겨줘야 저장이 가능한데 넘겨줄 수 있는 마땅한 방법이 떠오르지 않아서 `saveImage()`의 필드를 오버로딩하는 방식으로 구현했습니다.. 뭔가 `ImageService`에 대한 인터페이스 분리 원칙이 깨진 것 같아요.. 리팩토링이 필요해 보입니다..! 혹시 좋은 의견이 있으면 말씀해주세용
<img width="984" alt="Screenshot 2025-07-03 at 2 06 28 PM" src="https://github.com/user-attachments/assets/1edf0d2d-5a31-4d90-ac89-5e40a754e700" />

### 권한 부여 API
권한 체크를 추가하고 나니, 권한이 없으면 프론트에서 테스트를 못할 것 같아,
임시로 권한 부여하는 API를 추가하였습니다.
추후에 구매 기능이 구현되면 삭제될 예정입니다.