### PR TITLE
refactor: 이메일 인증 Swagger에 param추가

### DIFF
--- a/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
+++ b/src/main/java/hanium/modic/backend/web/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.response.AppResponse;
@@ -75,13 +76,19 @@ public class AuthController {
 	@PostMapping(value = "/email/verification", params = "type=sign-up")
 	@Operation(
 		summary = "이메일 인증 코드 발송 API (회원가입)",
-		description = "회원가입 시 입력한 이메일로 인증 코드를 전송합니다.",
+		description = """
+			회원가입 시 입력한 이메일로 인증 코드를 전송합니다.
+			type = sign-up
+			""",
 		responses = {
 			@ApiResponse(responseCode = "409", description = "이미 사용중인 이메일입니다.[U-001]"),
 			@ApiResponse(responseCode = "500", description = "이메일 전송 중 에러가 발생하였습니다.[A-001]")
 		}
 	)
-	public ResponseEntity<AppResponse<Void>> sendEmailVerification(@RequestBody @Valid SendEmailRequest request) {
+	public ResponseEntity<AppResponse<Void>> sendEmailVerification(
+		@RequestParam(name = "type", required = true) String type,
+		@RequestBody @Valid SendEmailRequest request
+	) {
 		authService.sendEmailVerification(request.email());
 		return ResponseEntity.ok().build();
 	}
@@ -89,13 +96,18 @@ public class AuthController {
 	@PostMapping(value = "/email/verification/check", params = "type=sign-up")
 	@Operation(
 		summary = "이메일 인증 코드 검증 API (회원가입)",
-		description = "사용자가 입력한 이메일과 인증 코드가 일치하는지 확인합니다.",
+		description = """
+			사용자가 입력한 이메일과 인증 코드가 일치하는지 확인합니다.
+			type = sign-up
+			""",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "이메일 인증 코드가 일치하지 않습니다.[A-002]")
 		}
 	)
 	public ResponseEntity<AppResponse<VerifyEmailCodeResponse>> verifyEmailCode(
-		@RequestBody @Valid VerifyEmailCodeRequest request) {
+		@RequestParam(name = "type", required = true) String type,
+		@RequestBody @Valid VerifyEmailCodeRequest request
+	) {
 		return ResponseEntity.ok().body(AppResponse.ok(authService.verifyEmailCode(request.email(), request.code())));
 	}
 }


### PR DESCRIPTION

## 개요
- close #123 

## 작업사항
- swagger에 type 파라미터 들어가도록 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원가입 이메일 인증 및 인증 코드 확인 요청 시 "type" 쿼리 파라미터(예: type=sign-up) 입력이 필수로 변경되었습니다.

* **문서화**
  * 이메일 인증 관련 API 문서에 "type" 파라미터 사용법이 명확하게 안내되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->