### PR TITLE
feat: OAuth 사용자 임시 패스워드 생성 및 리다이렉트 URL 상수화

### DIFF
--- a/src/main/java/hanium/modic/backend/common/oauth/OAuth2Attribute.java
+++ b/src/main/java/hanium/modic/backend/common/oauth/OAuth2Attribute.java
@@ -65,6 +65,7 @@ public class OAuth2Attribute {
 			.email(email)
 			.uniqueId(uniqueId)
 			.name(name)
+			.password(null)
 			.build();
 	}
 }

--- a/src/main/java/hanium/modic/backend/common/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/hanium/modic/backend/common/oauth/OAuthSuccessHandler.java
@@ -48,6 +48,6 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 		response.addCookie(refreshTokenCookie);
 
 		// Todo: 리다이렉트 URL을 환경 변수로 관리
-		response.sendRedirect("http://localhost:3000");
+		response.sendRedirect(AuthConstant.LOCAL_OAUTH_REDIRECT_URI);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/auth/constant/AuthConstant.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/constant/AuthConstant.java
@@ -5,4 +5,6 @@ public final class AuthConstant {
 	public static final String AUTHORIZATION = "Authorization";
 
 	public static final String BEARER = "Bearer ";
+
+	public static final String LOCAL_OAUTH_REDIRECT_URI = "localhost:3000";
 }

--- a/src/main/java/hanium/modic/backend/domain/auth/constant/AuthConstant.java
+++ b/src/main/java/hanium/modic/backend/domain/auth/constant/AuthConstant.java
@@ -6,5 +6,5 @@ public final class AuthConstant {
 
 	public static final String BEARER = "Bearer ";
 
-	public static final String LOCAL_OAUTH_REDIRECT_URI = "localhost:3000";
+	public static final String LOCAL_OAUTH_REDIRECT_URI = "http://localhost:3000";
 }

--- a/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
@@ -54,10 +54,14 @@ public class UserEntity extends BaseEntity {
 	@Builder
 	private UserEntity(String email, String password, String name, String uniqueId) {
 		this.email = email;
-		this.password = password;
+		this.password = password != null ? password : generateTemporaryPassword();
 		this.name = name;
 		this.userRole = UserRole.USER;
 		this.uniqueId = uniqueId;
+	}
+
+	private String generateTemporaryPassword() {
+		return "OAUTH_" + java.util.UUID.randomUUID().toString().replace("-", "");
 	}
 
 	public void addCoin(Long coin) {


### PR DESCRIPTION
## Summary
- OAuth 로그인 사용자를 위한 임시 패스워드 자동 생성 기능 추가
- 하드코딩된 OAuth 리다이렉트 URL을 상수로 리팩토링하여 유지보수성 향상
- OAuth2Attribute에서 password를 null로 설정하여 UserEntity에서 자동 생성되도록 개선

## Changes
- `UserEntity.java`: OAuth 사용자 임시 패스워드 생성 로직 (`generateTemporaryPassword()`) 추가
- `OAuth2Attribute.java`: 사용자 생성 시 password를 null로 설정
- `OAuthSuccessHandler.java`: 하드코딩된 리다이렉트 URL을 `AuthConstant.LOCAL_OAUTH_REDIRECT_URI` 상수로 변경
- `AuthConstant.java`: `LOCAL_OAUTH_REDIRECT_URI` 상수 추가

## Test plan
- [ ] OAuth 로그인 테스트 (Google, Kakao 등)
- [ ] 임시 패스워드가 정상적으로 생성되는지 확인
- [ ] 리다이렉트 URL이 상수값으로 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * OAuth2를 통해 회원가입 시 비밀번호가 없는 경우 임시 비밀번호가 자동으로 생성되어 할당됩니다.

* **리팩토링**
  * OAuth 인증 성공 후 리다이렉트 주소를 상수로 관리하여 설정이 중앙화되었습니다.

* **기타**
  * 리다이렉트 URL 관련 상수가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->