### PR TITLE
feat: 비로그인 사용자를 위한 공개 게시글 조회 API 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -103,6 +103,29 @@ public class PostService {
 	}
 
 	@Transactional(readOnly = true)
+	public GetPostResponse getPostForPublic(final Long id) {
+		final PostEntity postEntity = postEntityRepository.findById(id)
+			.orElseThrow(() -> new AppException(POST_NOT_FOUND_EXCEPTION));
+		final UserEntity userEntity = userEntityRepository.findById(postEntity.getUserId())
+			.orElseThrow(() -> new AppException(USER_NOT_FOUND_EXCEPTION));
+		final String userName = userEntity.getName();
+		final String userImage = userEntity.getUserImageUrl();
+		final boolean hasUserImage = userImage != null;
+		final String userEmail = userEntity.getEmail();
+
+		List<PostImageEntity> postImages = postImageEntityRepository.findAllByPostId(id);
+
+		// 하트 수 조회 (통계 테이블 사용)
+		long likeCount = postLikeService.getLikeCount(id);
+
+		// 비로그인 사용자이므로 좋아요 여부는 null로 설정
+		Boolean isLikedByCurrentUser = false;
+
+		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
+			isLikedByCurrentUser);
+	}
+
+	@Transactional(readOnly = true)
 	public PageResponse<GetPostsResponse> getPosts(final String sort, final int page, final int size) {
 
 		// Todo: sort 기능 추가

--- a/src/main/java/hanium/modic/backend/web/post/controller/PublicPostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PublicPostController.java
@@ -1,6 +1,7 @@
 package hanium.modic.backend.web.post.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,21 +12,24 @@ import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.constraints.Positive;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @RequestMapping("/api/public/posts")
+@Validated
 public class PublicPostController {
 
 	private final PostService postService;
 
 	@GetMapping("/{id}")
-	@Operation(summary = "게시글 조회 API (비로그인)", description = "비로그인 사용자도 게시글을 조회할 수 있습니다. 좋아요 정보는 포함되지 않습니다.", responses = {
+	@Operation(summary = "게시글 조회 API (비로그인)", description = "비로그인 사용자도 게시글을 조회할 수 있습니다. 좋아요 개수(likeCount)는 포함되지만, 사용자별 좋아요 상태(isLikedByCurrentUser)는 항상 false로 고정됩니다.", responses = {
 		@ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
 		@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")})
-	public ResponseEntity<AppResponse<GetPostResponse>> getPost(@PathVariable Long id) {
+	public ResponseEntity<AppResponse<GetPostResponse>> getPost(@PathVariable @Positive Long id) {
 		GetPostResponse response = postService.getPostForPublic(id);
 		return ResponseEntity.ok(AppResponse.ok(response));
 	}

--- a/src/main/java/hanium/modic/backend/web/post/controller/PublicPostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PublicPostController.java
@@ -1,0 +1,32 @@
+package hanium.modic.backend.web.post.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hanium.modic.backend.common.response.AppResponse;
+import hanium.modic.backend.domain.post.service.PostService;
+import hanium.modic.backend.web.post.dto.response.GetPostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping("/api/public/posts")
+public class PublicPostController {
+
+	private final PostService postService;
+
+	@GetMapping("/{id}")
+	@Operation(summary = "게시글 조회 API (비로그인)", description = "비로그인 사용자도 게시글을 조회할 수 있습니다. 좋아요 정보는 포함되지 않습니다.", responses = {
+		@ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")})
+	public ResponseEntity<AppResponse<GetPostResponse>> getPost(@PathVariable Long id) {
+		GetPostResponse response = postService.getPostForPublic(id);
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -202,6 +202,67 @@ class PostServiceTest {
 	}
 
 	@Test
+	@DisplayName("공개 게시글 조회 성공 - 비로그인 사용자")
+	void getPostForPublic_Success_ShouldReturnPostWithFalseLikeStatus() {
+		// given
+		UserEntity mockUser = UserFactory.createMockUser(1L);
+		Long postId = 1L;
+		PostEntity mockPost = createMockPostWithId(postId, mockUser);
+		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost, 2);
+		List<GetPostResponse.ImageDto> expectedImages = mockImages.stream()
+			.map(image -> new GetPostResponse.ImageDto(image.getImageUrl(), image.getId()))
+			.toList();
+
+		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
+		when(userEntityRepository.findById(mockPost.getUserId())).thenReturn(Optional.of(mockUser));
+		when(postImageEntityRepository.findAllByPostId(postId)).thenReturn(mockImages);
+		when(postLikeService.getLikeCount(postId)).thenReturn(15L);
+
+		// when
+		GetPostResponse response = postService.getPostForPublic(postId);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.id()).isEqualTo(mockPost.getId());
+		assertThat(response.title()).isEqualTo(mockPost.getTitle());
+		assertThat(response.description()).isEqualTo(mockPost.getDescription());
+		assertThat(response.commercialPrice()).isEqualTo(mockPost.getCommercialPrice());
+		assertThat(response.nonCommercialPrice()).isEqualTo(mockPost.getNonCommercialPrice());
+		assertThat(response.likeCount()).isEqualTo(15L);
+		assertThat(response.isLikedByCurrentUser()).isFalse(); // 비로그인 사용자이므로 false
+		assertThat(response.images()).hasSize(expectedImages.size());
+		for (int i = 0; i < expectedImages.size(); i++) {
+			assertThat(response.images().get(i).getImageUrl()).isEqualTo(expectedImages.get(i).getImageUrl());
+			assertThat(response.images().get(i).getImageId()).isEqualTo(expectedImages.get(i).getImageId());
+		}
+
+		verify(postEntityRepository).findById(postId);
+		verify(userEntityRepository).findById(mockPost.getUserId());
+		verify(postImageEntityRepository).findAllByPostId(postId);
+		verify(postLikeService).getLikeCount(postId);
+		// isLikedByUser 메서드는 호출되지 않아야 함
+		verify(postLikeService, never()).isLikedByUser(any(), any());
+	}
+
+	@Test
+	@DisplayName("공개 게시글 조회 실패 - 존재하지 않는 게시글 ID")
+	void getPostForPublic_NonExistentPostId_ShouldThrowPostNotFoundException() {
+		// given
+		Long nonExistentPostId = 99L;
+		when(postEntityRepository.findById(nonExistentPostId)).thenReturn(Optional.empty());
+
+		// when & then
+		AppException exception = assertThrows(AppException.class,
+			() -> postService.getPostForPublic(nonExistentPostId));
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.POST_NOT_FOUND_EXCEPTION);
+		verify(postEntityRepository).findById(nonExistentPostId);
+		verify(postImageEntityRepository, never()).findAllByPostId(any());
+		verify(postLikeService, never()).getLikeCount(any());
+		verify(postLikeService, never()).isLikedByUser(any(), any());
+	}
+
+	@Test
 	@DisplayName("게시글 목록 조회 성공 - 하트 수 배치 조회 포함")
 	void getPosts_WithBatchLikeCountsAndImages_ShouldReturnOptimizedResults() {
 		// given

--- a/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
@@ -1,0 +1,126 @@
+package hanium.modic.backend.web.post.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import hanium.modic.backend.base.BaseControllerTest;
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.entityfactory.PostFactory;
+import hanium.modic.backend.domain.post.service.PostService;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.factory.UserFactory;
+import hanium.modic.backend.web.post.dto.response.GetPostResponse;
+
+@WebMvcTest(controllers = PublicPostController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PublicPostControllerTest extends BaseControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private PostService postService;
+
+	@Test
+	@DisplayName("공개 게시글 조회 성공 - 비로그인 사용자")
+	void getPost_Success_ShouldReturnPostWithoutAuthentication() throws Exception {
+		// given
+		Long postId = 1L;
+		UserEntity mockUser = UserFactory.createMockUser(1L);
+		PostEntity mockPost = PostFactory.createMockPostWithId(postId, mockUser);
+		
+		List<GetPostResponse.ImageDto> mockImages = List.of(
+			new GetPostResponse.ImageDto("http://example.com/image1.jpg", 1L),
+			new GetPostResponse.ImageDto("http://example.com/image2.jpg", 2L)
+		);
+
+		GetPostResponse mockResponse = new GetPostResponse(
+			mockUser.getName(),
+			mockUser.getUserImageUrl() != null,
+			mockUser.getUserImageUrl(),
+			mockUser.getEmail(),
+			mockPost.getId(),
+			mockPost.getUserId(),
+			mockPost.getTitle(),
+			mockPost.getDescription(),
+			mockPost.getCommercialPrice(),
+			mockPost.getNonCommercialPrice(),
+			mockImages,
+			10L, // likeCount
+			false
+		);
+
+		when(postService.getPostForPublic(postId)).thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/public/posts/{id}", postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.data.id").value(postId))
+			.andExpect(jsonPath("$.data.title").value(mockPost.getTitle()))
+			.andExpect(jsonPath("$.data.description").value(mockPost.getDescription()))
+			.andExpect(jsonPath("$.data.commercialPrice").value(mockPost.getCommercialPrice()))
+			.andExpect(jsonPath("$.data.nonCommercialPrice").value(mockPost.getNonCommercialPrice()))
+			.andExpect(jsonPath("$.data.likeCount").value(10))
+			.andExpect(jsonPath("$.data.isLikedByCurrentUser").value(false)) // null 값 확인
+			.andExpect(jsonPath("$.data.images").isArray())
+			.andExpect(jsonPath("$.data.images[0].imageUrl").value("http://example.com/image1.jpg"))
+			.andExpect(jsonPath("$.data.images[0].imageId").value(1))
+			.andExpect(jsonPath("$.data.images[1].imageUrl").value("http://example.com/image2.jpg"))
+			.andExpect(jsonPath("$.data.images[1].imageId").value(2))
+			.andExpect(jsonPath("$.data.userName").value(mockUser.getName()))
+			.andExpect(jsonPath("$.data.userEmail").value(mockUser.getEmail()));
+
+		verify(postService).getPostForPublic(postId);
+	}
+
+	@Test
+	@DisplayName("공개 게시글 조회 실패 - 존재하지 않는 게시글")
+	void getPost_PostNotFound_ShouldReturnNotFound() throws Exception {
+		// given
+		Long nonExistentPostId = 999L;
+		when(postService.getPostForPublic(nonExistentPostId))
+			.thenThrow(new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION));
+
+		// when & then
+		mockMvc.perform(get("/api/public/posts/{id}", nonExistentPostId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(404))
+			.andExpect(jsonPath("$.code").value(ErrorCode.POST_NOT_FOUND_EXCEPTION.getCode()))
+			.andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND_EXCEPTION.getMessage()));
+
+		verify(postService).getPostForPublic(nonExistentPostId);
+	}
+
+	@Test
+	@DisplayName("공개 게시글 조회 - 잘못된 경로 파라미터")
+	void getPost_InvalidPathParameter_ShouldReturnBadRequest() throws Exception {
+		// when & then
+		mockMvc.perform(get("/api/public/posts/invalid")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest());
+
+		verify(postService, never()).getPostForPublic(any());
+	}
+}


### PR DESCRIPTION
## Summary
Closes #130

GitHub Issue #130을 해결하기 위해 비로그인 사용자도 게시글을 조회할 수 있는 공개 API를 구현했습니다.

- **새로운 엔드포인트**: `/api/public/posts/{id}` GET 요청
- **기존 API 유지**: `/api/posts/{id}` - 로그인된 사용자용 (좋아요 정보 포함)
- **공개 API 특징**: 비로그인 사용자용 (좋아요 정보는 false로 고정)

## 구현 내용

### Backend Changes
- **PublicPostController**: 비로그인 사용자를 위한 새로운 컨트롤러 생성
- **PostService.getPostForPublic()**: 인증 없는 게시글 조회 메서드 추가
- **동일한 응답 구조**: 기존 GetPostResponse DTO 재사용

### 주요 차이점
| 기능 | 기존 API (`/api/posts/{id}`) | 새 공개 API (`/api/public/posts/{id}`) |
|------|------------------------------|---------------------------------------|
| 인증 | 필수 (JWT 토큰) | 불필요 |
| 좋아요 정보 | 사용자별 실제 값 (true/false) | 고정값 (false) |
| 사용 대상 | 로그인된 사용자 | 모든 사용자 (비로그인 포함) |

## Test Plan
- [x] PostService.getPostForPublic() 단위 테스트
  - [x] 정상 조회 시 게시글 정보 반환 및 isLikedByCurrentUser = false 확인
  - [x] 존재하지 않는 게시글 ID로 조회 시 예외 발생 확인
  - [x] PostLikeService.isLikedByUser() 메서드 호출되지 않음 확인
- [x] PublicPostController 통합 테스트  
  - [x] GET /api/public/posts/{id} 정상 응답 확인
  - [x] 존재하지 않는 게시글 조회 시 404 응답 확인
  - [x] 잘못된 경로 파라미터 시 400 응답 확인
- [x] 모든 테스트 통과 확인

## 추가 작업 필요
사용자는 `application.yml`에 다음 설정을 추가해야 합니다:
```yaml
security:
  permit-urls:
    - GET:/api/public/posts/**
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 비로그인(공개) 사용자가 게시글을 조회할 수 있는 공개 게시글 조회 API가 추가되었습니다.

* **테스트**
  * 공개 게시글 조회 서비스 및 컨트롤러에 대한 단위 테스트와 통합 테스트가 추가되었습니다.  
  * 정상 조회, 존재하지 않는 게시글 요청, 잘못된 경로 파라미터 등 다양한 케이스가 검증됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->