### PR TITLE
feat: 팔로워/팔로잉 목록 조회 API에 isFollowing 필드 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/follow/dto/FollowerWithStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/dto/FollowerWithStatus.java
@@ -1,0 +1,9 @@
+package hanium.modic.backend.domain.follow.dto;
+
+public interface FollowerWithStatus {
+	Long getId();
+	String getName();
+	String getEmail();
+	String getUserImageUrl();
+	Boolean getIsFollowing();
+}

--- a/src/main/java/hanium/modic/backend/domain/follow/dto/FollowingWithStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/dto/FollowingWithStatus.java
@@ -1,0 +1,9 @@
+package hanium.modic.backend.domain.follow.dto;
+
+public interface FollowingWithStatus {
+	Long getId();
+	String getName();
+	String getEmail();
+	String getUserImageUrl();
+	Boolean getIsFollowing();
+}

--- a/src/main/java/hanium/modic/backend/domain/follow/repository/FollowEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/repository/FollowEntityRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import hanium.modic.backend.domain.follow.dto.FollowerWithStatus;
+import hanium.modic.backend.domain.follow.dto.FollowingWithStatus;
 import hanium.modic.backend.domain.follow.entity.FollowEntity;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
@@ -58,6 +59,22 @@ public interface FollowEntityRepository extends JpaRepository<FollowEntity, Long
 		    ORDER BY f.createAt DESC
 		""")
 	Page<FollowerWithStatus> findFollowersWithStatusOrderByCreatedAt(
+		@Param("targetUserId") Long targetUserId,
+		@Param("currentUserId") Long currentUserId,
+		Pageable pageable
+	);
+
+	// 팔로잉 목록 조회 (팔로우 상태 포함)
+	@Query("""
+		    SELECT u.id as id, u.name as name, u.email as email, u.userImageUrl as userImageUrl,
+		           CASE WHEN f2.id IS NOT NULL THEN true ELSE false END as isFollowing
+		    FROM FollowEntity f
+		    JOIN UserEntity u ON f.followingId = u.id
+		    LEFT JOIN FollowEntity f2 ON f2.myId = :currentUserId AND f2.followingId = u.id
+		    WHERE f.myId = :targetUserId
+		    ORDER BY f.createAt DESC
+		""")
+	Page<FollowingWithStatus> findFollowingsWithStatusOrderByCreatedAt(
 		@Param("targetUserId") Long targetUserId,
 		@Param("currentUserId") Long currentUserId,
 		Pageable pageable

--- a/src/main/java/hanium/modic/backend/domain/follow/repository/FollowEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/repository/FollowEntityRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import hanium.modic.backend.domain.follow.dto.FollowerWithStatus;
 import hanium.modic.backend.domain.follow.entity.FollowEntity;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
@@ -45,4 +46,20 @@ public interface FollowEntityRepository extends JpaRepository<FollowEntity, Long
 			"VALUES (:myId, :followingId, now(), now())",
 		nativeQuery = true)
 	void insertFollowIfExist(@Param("myId") Long myId, @Param("followingId") Long followingId);
+
+	// 팔로워 목록 조회 (팔로우 상태 포함)
+	@Query("""
+		    SELECT u.id as id, u.name as name, u.email as email, u.userImageUrl as userImageUrl,
+		           CASE WHEN f2.id IS NOT NULL THEN true ELSE false END as isFollowing
+		    FROM FollowEntity f
+		    JOIN UserEntity u ON f.myId = u.id
+		    LEFT JOIN FollowEntity f2 ON f2.myId = :currentUserId AND f2.followingId = u.id
+		    WHERE f.followingId = :targetUserId
+		    ORDER BY f.createAt DESC
+		""")
+	Page<FollowerWithStatus> findFollowersWithStatusOrderByCreatedAt(
+		@Param("targetUserId") Long targetUserId,
+		@Param("currentUserId") Long currentUserId,
+		Pageable pageable
+	);
 }

--- a/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
@@ -16,6 +16,7 @@ import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersWithStatusResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
+import hanium.modic.backend.web.follow.dto.response.GetFollowingsWithStatusResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -61,6 +62,26 @@ public class FollowService {
 	}
 
 	// TODO : 정렬 기준 고려
+	// 내 팔로워 목록 조회 (인증 유저용 - 팔로우 상태 포함)
+	public Page<GetFollowersWithStatusResponse> getMyFollowers(final long userId, final int page, final int size) {
+		validateUserExists(userId);
+
+		return followRepository.findFollowersWithStatusOrderByCreatedAt(userId, userId, PageRequest.of(page, size))
+			.map(u -> {
+				final String userImageUrl = u.getUserImageUrl();
+				final boolean hasUserImage = userImageUrl != null;
+				return new GetFollowersWithStatusResponse(
+					u.getId(), 
+					hasUserImage, 
+					userImageUrl, 
+					u.getName(), 
+					u.getEmail(),
+					u.getIsFollowing()
+				);
+			});
+	}
+
+	// TODO : 정렬 기준 고려
 	// 팔로워 목록 조회 (인증 유저용 - 팔로우 상태 포함)
 	public Page<GetFollowersWithStatusResponse> getFollowersWithStatus(
 		final long currentUserId, 
@@ -86,7 +107,7 @@ public class FollowService {
 	}
 
 	// TODO : 정렬 기준 고려
-	// 팔로잉 목록 조회
+	// 팔로잉 목록 조회 (미인증 유저용)
 	public Page<GetFollowingsResponse> getFollowings(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
@@ -95,6 +116,51 @@ public class FollowService {
 				final String userImageUrl = u.getUserImageUrl();
 				final boolean hasUserImage = userImageUrl != null;
 				return new GetFollowingsResponse(u.getId(), hasUserImage, userImageUrl, u.getName(), u.getEmail());
+			});
+	}
+
+	// TODO : 정렬 기준 고려
+	// 내 팔로잉 목록 조회 (인증 유저용 - isFollowing 항상 true)
+	public Page<GetFollowingsWithStatusResponse> getMyFollowings(final long userId, final int page, final int size) {
+		validateUserExists(userId);
+
+		return followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size))
+			.map(u -> {
+				final String userImageUrl = u.getUserImageUrl();
+				final boolean hasUserImage = userImageUrl != null;
+				return new GetFollowingsWithStatusResponse(
+					u.getId(), 
+					hasUserImage, 
+					userImageUrl, 
+					u.getName(), 
+					u.getEmail(),
+					true // 내 팔로잉 목록이므로 항상 true
+				);
+			});
+	}
+
+	// TODO : 정렬 기준 고려
+	// 팔로잉 목록 조회 (인증 유저용 - 팔로우 상태 포함)
+	public Page<GetFollowingsWithStatusResponse> getFollowingsWithStatus(
+		final long currentUserId, 
+		final long targetUserId, 
+		final int page, 
+		final int size
+	) {
+		validateUserExists(targetUserId);
+
+		return followRepository.findFollowingsWithStatusOrderByCreatedAt(targetUserId, currentUserId, PageRequest.of(page, size))
+			.map(u -> {
+				final String userImageUrl = u.getUserImageUrl();
+				final boolean hasUserImage = userImageUrl != null;
+				return new GetFollowingsWithStatusResponse(
+					u.getId(), 
+					hasUserImage, 
+					userImageUrl, 
+					u.getName(), 
+					u.getEmail(),
+					u.getIsFollowing()
+				);
 			});
 	}
 

--- a/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
@@ -14,6 +14,7 @@ import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
+import hanium.modic.backend.web.follow.dto.response.GetFollowersWithStatusResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -47,7 +48,7 @@ public class FollowService {
 	}
 
 	// TODO : 정렬 기준 고려
-	// 팔로워 목록 조회
+	// 팔로워 목록 조회 (미인증 유저용)
 	public Page<GetFollowersResponse> getFollowers(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
@@ -56,6 +57,31 @@ public class FollowService {
 				final String userImageUrl = u.getUserImageUrl();
 				final boolean hasUserImage = userImageUrl != null;
 				return new GetFollowersResponse(u.getId(), hasUserImage, userImageUrl, u.getName(), u.getEmail());
+			});
+	}
+
+	// TODO : 정렬 기준 고려
+	// 팔로워 목록 조회 (인증 유저용 - 팔로우 상태 포함)
+	public Page<GetFollowersWithStatusResponse> getFollowersWithStatus(
+		final long currentUserId, 
+		final long targetUserId, 
+		final int page, 
+		final int size
+	) {
+		validateUserExists(targetUserId);
+
+		return followRepository.findFollowersWithStatusOrderByCreatedAt(targetUserId, currentUserId, PageRequest.of(page, size))
+			.map(u -> {
+				final String userImageUrl = u.getUserImageUrl();
+				final boolean hasUserImage = userImageUrl != null;
+				return new GetFollowersWithStatusResponse(
+					u.getId(), 
+					hasUserImage, 
+					userImageUrl, 
+					u.getName(), 
+					u.getEmail(),
+					u.getIsFollowing()
+				);
 			});
 	}
 

--- a/src/main/java/hanium/modic/backend/web/follow/controller/FollowController.java
+++ b/src/main/java/hanium/modic/backend/web/follow/controller/FollowController.java
@@ -17,6 +17,7 @@ import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersWithStatusResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
+import hanium.modic.backend.web.follow.dto.response.GetFollowingsWithStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.constraints.Max;
@@ -53,18 +54,18 @@ public class FollowController {
 
 	@GetMapping("/followers/me")
 	@Operation(
-		summary = "내 팔로워 목록 조회",
-		description = "팔로워 목록을 페이지네이션 형태로 반환합니다.",
+		summary = "내 팔로워 목록 조회 (인증)",
+		description = "내 팔로워 목록을 페이지네이션 형태로 반환합니다. 각 팔로워에 대한 내 팔로우 상태가 포함됩니다.",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "사용자 입력 오류(C-001)"),
 		}
 	)
-	public ResponseEntity<AppResponse<Page<GetFollowersResponse>>> getMyFollowers(
+	public ResponseEntity<AppResponse<Page<GetFollowersWithStatusResponse>>> getMyFollowers(
 		@CurrentUser UserEntity me,
 		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
 		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
 	) {
-		return ResponseEntity.ok(AppResponse.ok(followService.getFollowers(me.getId(), page, size)));
+		return ResponseEntity.ok(AppResponse.ok(followService.getMyFollowers(me.getId(), page, size)));
 	}
 
 	@GetMapping("/followers")
@@ -104,24 +105,24 @@ public class FollowController {
 
 	@GetMapping("/followings/me")
 	@Operation(
-		summary = "내 팔로잉 목록 조회",
-		description = "팔로잉 목록을 페이지네이션 형태로 반환합니다.",
+		summary = "내 팔로잉 목록 조회 (인증)",
+		description = "내 팔로잉 목록을 페이지네이션 형태로 반환합니다. isFollowing 필드는 항상 true입니다.",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "사용자 입력 오류(C-001)"),
 		}
 	)
-	public ResponseEntity<AppResponse<Page<GetFollowingsResponse>>> getMyFollowing(
+	public ResponseEntity<AppResponse<Page<GetFollowingsWithStatusResponse>>> getMyFollowing(
 		@CurrentUser UserEntity me,
 		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
 		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
 	) {
-		return ResponseEntity.ok(AppResponse.ok(followService.getFollowings(me.getId(), page, size)));
+		return ResponseEntity.ok(AppResponse.ok(followService.getMyFollowings(me.getId(), page, size)));
 	}
 
 	@GetMapping("/followings")
 	@Operation(
-		summary = "팔로잉 목록 조회",
-		description = "팔로잉 목록을 페이지네이션 형태로 반환합니다.",
+		summary = "팔로잉 목록 조회 (미인증)",
+		description = "팔로잉 목록을 페이지네이션 형태로 반환합니다. 팔로우 상태 정보는 포함되지 않습니다.",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "사용자 입력 오류(C-001)"),
 			@ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.(U-002)"),
@@ -133,5 +134,23 @@ public class FollowController {
 		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
 	) {
 		return ResponseEntity.ok(AppResponse.ok(followService.getFollowings(userId, page, size)));
+	}
+
+	@GetMapping("/followings/with-status")
+	@Operation(
+		summary = "팔로잉 목록 조회 (인증)",
+		description = "팔로잉 목록을 페이지네이션 형태로 반환합니다. 현재 로그인한 유저의 각 팔로잉에 대한 팔로우 상태가 포함됩니다.",
+		responses = {
+			@ApiResponse(responseCode = "400", description = "사용자 입력 오류(C-001)"),
+			@ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.(U-002)"),
+		}
+	)
+	public ResponseEntity<AppResponse<Page<GetFollowingsWithStatusResponse>>> getFollowingsWithStatus(
+		@CurrentUser UserEntity me,
+		@RequestParam(required = true) long userId,
+		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
+		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
+	) {
+		return ResponseEntity.ok(AppResponse.ok(followService.getFollowingsWithStatus(me.getId(), userId, page, size)));
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/follow/controller/FollowController.java
+++ b/src/main/java/hanium/modic/backend/web/follow/controller/FollowController.java
@@ -15,6 +15,7 @@ import hanium.modic.backend.domain.follow.dto.FollowType;
 import hanium.modic.backend.domain.follow.service.FollowService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
+import hanium.modic.backend.web.follow.dto.response.GetFollowersWithStatusResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -68,8 +69,8 @@ public class FollowController {
 
 	@GetMapping("/followers")
 	@Operation(
-		summary = "팔로워 목록 조회",
-		description = "팔로워 목록을 페이지네이션 형태로 반환합니다.",
+		summary = "팔로워 목록 조회 (미인증)",
+		description = "팔로워 목록을 페이지네이션 형태로 반환합니다. 팔로우 상태 정보는 포함되지 않습니다.",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "사용자 입력 오류(C-001)"),
 			@ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.(U-002)"),
@@ -81,6 +82,24 @@ public class FollowController {
 		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
 	) {
 		return ResponseEntity.ok(AppResponse.ok(followService.getFollowers(userId, page, size)));
+	}
+
+	@GetMapping("/followers/with-status")
+	@Operation(
+		summary = "팔로워 목록 조회 (인증)",
+		description = "팔로워 목록을 페이지네이션 형태로 반환합니다. 현재 로그인한 유저의 각 팔로워에 대한 팔로우 상태가 포함됩니다.",
+		responses = {
+			@ApiResponse(responseCode = "400", description = "사용자 입력 오류(C-001)"),
+			@ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.(U-002)"),
+		}
+	)
+	public ResponseEntity<AppResponse<Page<GetFollowersWithStatusResponse>>> getFollowersWithStatus(
+		@CurrentUser UserEntity me,
+		@RequestParam(required = true) long userId,
+		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
+		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
+	) {
+		return ResponseEntity.ok(AppResponse.ok(followService.getFollowersWithStatus(me.getId(), userId, page, size)));
 	}
 
 	@GetMapping("/followings/me")

--- a/src/main/java/hanium/modic/backend/web/follow/dto/response/GetFollowersWithStatusResponse.java
+++ b/src/main/java/hanium/modic/backend/web/follow/dto/response/GetFollowersWithStatusResponse.java
@@ -1,0 +1,16 @@
+package hanium.modic.backend.web.follow.dto.response;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(NON_NULL)
+public record GetFollowersWithStatusResponse(
+	Long userId,
+	boolean hasUserImage,
+	String userImageUrl,
+	String userName,
+	String userEmail,
+	boolean isFollowing
+) {
+}

--- a/src/main/java/hanium/modic/backend/web/follow/dto/response/GetFollowingsWithStatusResponse.java
+++ b/src/main/java/hanium/modic/backend/web/follow/dto/response/GetFollowingsWithStatusResponse.java
@@ -1,0 +1,16 @@
+package hanium.modic.backend.web.follow.dto.response;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(NON_NULL)
+public record GetFollowingsWithStatusResponse(
+	Long userId,
+	boolean hasUserImage,
+	String userImageUrl,
+	String userName,
+	String userEmail,
+	boolean isFollowing
+) {
+}

--- a/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
@@ -404,5 +404,169 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 		result.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.code").value("U-002"));
 	}
+
+	@Test
+	@DisplayName("TEST16: 내 팔로워 목록 조회 (팔로우 상태 포함) - 일부만 팔로우")
+	@WithCustomUser(email = "current@test.com")
+	void getMyFollowersWithStatusSuccess() throws Exception {
+		// given: 현재 로그인한 유저
+		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+
+		// given: 내 팔로워들 생성
+		UserEntity follower1 = saveUser("Follower1");
+		UserEntity follower2 = saveUser("Follower2");
+		UserEntity follower3 = saveUser("Follower3");
+
+		// 나를 팔로우하는 팔로워들 생성
+		followEntityRepository.save(FollowEntity.builder().me(follower1).following(currentUser).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(follower2).following(currentUser).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(follower3).following(currentUser).build());
+
+		// 내가 일부 팔로워를 역팔로우
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(follower1).build());
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(follower3).build());
+
+		// when: 내 팔로워 목록 조회 (팔로우 상태 포함)
+		ResultActions result = mockMvc.perform(get("/api/follows/followers/me")
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: 팔로워 목록과 내 팔로우 상태가 올바르게 반환됨
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(3))
+			.andExpect(jsonPath("$.data.content[0].userId").value(follower3.getId()))
+			.andExpect(jsonPath("$.data.content[0].isFollowing").value(true))
+			.andExpect(jsonPath("$.data.content[1].userId").value(follower2.getId()))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").value(false))
+			.andExpect(jsonPath("$.data.content[2].userId").value(follower1.getId()))
+			.andExpect(jsonPath("$.data.content[2].isFollowing").value(true));
+	}
+
+	@Test
+	@DisplayName("TEST17: 내 팔로잉 목록 조회 (isFollowing 항상 true)")
+	@WithCustomUser(email = "current@test.com")
+	void getMyFollowingsWithStatusSuccess() throws Exception {
+		// given: 현재 로그인한 유저
+		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+
+		// given: 내가 팔로우하는 사람들 생성
+		UserEntity following1 = saveUser("Following1");
+		UserEntity following2 = saveUser("Following2");
+		UserEntity following3 = saveUser("Following3");
+
+		// 내가 팔로우하는 관계 생성
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(following1).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(following2).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(following3).build());
+
+		// when: 내 팔로잉 목록 조회
+		ResultActions result = mockMvc.perform(get("/api/follows/followings/me")
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: 팔로잉 목록과 isFollowing이 모두 true로 반환됨
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(3))
+			.andExpect(jsonPath("$.data.content[0].userId").value(following3.getId()))
+			.andExpect(jsonPath("$.data.content[0].isFollowing").value(true))
+			.andExpect(jsonPath("$.data.content[1].userId").value(following2.getId()))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").value(true))
+			.andExpect(jsonPath("$.data.content[2].userId").value(following1.getId()))
+			.andExpect(jsonPath("$.data.content[2].isFollowing").value(true));
+	}
+
+	@Test
+	@DisplayName("TEST18: 다른 사람 팔로잉 목록 조회 (팔로우 상태 포함) - 일부만 팔로우")
+	@WithCustomUser(email = "current@test.com")
+	void getFollowingsWithStatusSuccess() throws Exception {
+		// given: 현재 로그인한 유저
+		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+
+		// given: targetUser와 그의 팔로잉들 생성
+		UserEntity targetUser = saveUser("TargetUser");
+		UserEntity following1 = saveUser("Following1");
+		UserEntity following2 = saveUser("Following2");
+		UserEntity following3 = saveUser("Following3");
+
+		// targetUser가 팔로우하는 관계 생성
+		followEntityRepository.save(FollowEntity.builder().me(targetUser).following(following1).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(targetUser).following(following2).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(targetUser).following(following3).build());
+
+		// 현재 유저가 일부 팔로잉을 팔로우
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(following1).build());
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(following3).build());
+
+		// when: 팔로우 상태가 포함된 팔로잉 목록 요청
+		ResultActions result = mockMvc.perform(get("/api/follows/followings/with-status")
+			.param("userId", String.valueOf(targetUser.getId()))
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: 팔로잉 목록과 팔로우 상태가 올바르게 반환됨
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(3))
+			.andExpect(jsonPath("$.data.content[0].userId").value(following3.getId()))
+			.andExpect(jsonPath("$.data.content[0].isFollowing").value(true))
+			.andExpect(jsonPath("$.data.content[1].userId").value(following2.getId()))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").value(false))
+			.andExpect(jsonPath("$.data.content[2].userId").value(following1.getId()))
+			.andExpect(jsonPath("$.data.content[2].isFollowing").value(true));
+	}
+
+	@Test
+	@DisplayName("TEST19: 다른 사람 팔로잉 목록 조회 (팔로우 상태 포함) - 모두 팔로우하지 않음")
+	@WithCustomUser(email = "current@test.com")
+	void getFollowingsWithStatusAllNotFollowing() throws Exception {
+		// given: 현재 로그인한 유저
+		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+
+		// given: targetUser와 그의 팔로잉들 생성
+		UserEntity targetUser = saveUser("TargetUser");
+		UserEntity following1 = saveUser("Following1");
+		UserEntity following2 = saveUser("Following2");
+
+		// targetUser가 팔로우하는 관계 생성
+		followEntityRepository.save(FollowEntity.builder().me(targetUser).following(following1).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(targetUser).following(following2).build());
+
+		// 현재 유저는 아무도 팔로우하지 않음
+
+		// when: 팔로우 상태가 포함된 팔로잉 목록 요청
+		ResultActions result = mockMvc.perform(get("/api/follows/followings/with-status")
+			.param("userId", String.valueOf(targetUser.getId()))
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: 모든 isFollowing이 false로 반환됨
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(2))
+			.andExpect(jsonPath("$.data.content[0].userId").value(following2.getId()))
+			.andExpect(jsonPath("$.data.content[0].isFollowing").value(false))
+			.andExpect(jsonPath("$.data.content[1].userId").value(following1.getId()))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").value(false));
+	}
+
+	@Test
+	@DisplayName("TEST20: 팔로잉 목록 조회 (팔로우 상태 포함) - 존재하지 않는 사용자")
+	@WithCustomUser(email = "current@test.com")
+	void getFollowingsWithStatusUserNotFound() throws Exception {
+		// when: 존재하지 않는 사용자의 팔로잉 목록 조회
+		ResultActions result = mockMvc.perform(get("/api/follows/followings/with-status")
+			.param("userId", "999999")
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: USER_NOT_FOUND 예외 발생
+		result.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("U-002"));
+	}
 }
 

--- a/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/follow/controller/FollowControllerIntegrationTest.java
@@ -288,5 +288,121 @@ public class FollowControllerIntegrationTest extends BaseIntegrationTest {
 			.andExpect(jsonPath("$.data.content[1].userId").value(followed.get(1).getId()))
 			.andExpect(jsonPath("$.data.content[2].userId").value(followed.get(0).getId()));
 	}
+
+	@Test
+	@DisplayName("TEST12: 인증된 유저의 팔로워 목록 조회 (팔로우 상태 포함) - 일부만 팔로우")
+	@WithCustomUser(email = "current@test.com")
+	void getFollowersWithStatusSuccess() throws Exception {
+		// given: 현재 로그인한 유저
+		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+		
+		// given: targetUser와 그의 팔로워들 생성
+		UserEntity targetUser = saveUser("TargetUser");
+		UserEntity follower1 = saveUser("Follower1");
+		UserEntity follower2 = saveUser("Follower2");
+		UserEntity follower3 = saveUser("Follower3");
+		
+		// targetUser의 팔로워들 생성
+		followEntityRepository.save(FollowEntity.builder().me(follower1).following(targetUser).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(follower2).following(targetUser).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(follower3).following(targetUser).build());
+		
+		// 현재 유저가 follower1과 follower3을 팔로우
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(follower1).build());
+		followEntityRepository.save(FollowEntity.builder().me(currentUser).following(follower3).build());
+
+		// when: 팔로우 상태가 포함된 팔로워 목록 요청
+		ResultActions result = mockMvc.perform(get("/api/follows/followers/with-status")
+			.param("userId", String.valueOf(targetUser.getId()))
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: 팔로워 목록과 팔로우 상태가 올바르게 반환됨
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(3))
+			.andExpect(jsonPath("$.data.content[0].userId").value(follower3.getId()))
+			.andExpect(jsonPath("$.data.content[0].isFollowing").value(true))
+			.andExpect(jsonPath("$.data.content[1].userId").value(follower2.getId()))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").value(false))
+			.andExpect(jsonPath("$.data.content[2].userId").value(follower1.getId()))
+			.andExpect(jsonPath("$.data.content[2].isFollowing").value(true));
+	}
+
+	@Test
+	@DisplayName("TEST13: 인증된 유저의 팔로워 목록 조회 (팔로우 상태 포함) - 아무도 팔로우하지 않음")
+	@WithCustomUser(email = "current@test.com")
+	void getFollowersWithStatusAllNotFollowing() throws Exception {
+		// given: 현재 로그인한 유저
+		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+		
+		// given: targetUser와 그의 팔로워들 생성
+		UserEntity targetUser = saveUser("TargetUser");
+		UserEntity follower1 = saveUser("Follower1");
+		UserEntity follower2 = saveUser("Follower2");
+		
+		// targetUser의 팔로워들 생성 (현재 유저는 아무도 팔로우하지 않음)
+		followEntityRepository.save(FollowEntity.builder().me(follower1).following(targetUser).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(follower2).following(targetUser).build());
+
+		// when: 팔로우 상태가 포함된 팔로워 목록 요청
+		ResultActions result = mockMvc.perform(get("/api/follows/followers/with-status")
+			.param("userId", String.valueOf(targetUser.getId()))
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: 모든 팔로워의 isFollowing이 false
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(2))
+			.andExpect(jsonPath("$.data.content[0].isFollowing").value(false))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").value(false));
+	}
+
+	@Test
+	@DisplayName("TEST14: 미인증 유저의 팔로워 목록 조회 - isFollowing 필드 없음")
+	void getFollowersUnauthenticatedUserSuccess() throws Exception {
+		// given: targetUser와 그의 팔로워들 생성
+		UserEntity targetUser = saveUser("TargetUser");
+		UserEntity follower1 = saveUser("Follower1");
+		UserEntity follower2 = saveUser("Follower2");
+		
+		// targetUser의 팔로워들 생성
+		followEntityRepository.save(FollowEntity.builder().me(follower1).following(targetUser).build());
+		Thread.sleep(10);
+		followEntityRepository.save(FollowEntity.builder().me(follower2).following(targetUser).build());
+
+		// when: 미인증 상태에서 팔로워 목록 요청
+		ResultActions result = mockMvc.perform(get("/api/follows/followers")
+			.param("userId", String.valueOf(targetUser.getId()))
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: isFollowing 필드가 없는 팔로워 목록 반환
+		result.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content.length()").value(2))
+			.andExpect(jsonPath("$.data.content[0].userId").value(follower2.getId()))
+			.andExpect(jsonPath("$.data.content[0].userName").exists())
+			.andExpect(jsonPath("$.data.content[0].userEmail").exists())
+			.andExpect(jsonPath("$.data.content[0].isFollowing").doesNotExist())
+			.andExpect(jsonPath("$.data.content[1].userId").value(follower1.getId()))
+			.andExpect(jsonPath("$.data.content[1].isFollowing").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("TEST15: 인증된 유저가 존재하지 않는 유저의 팔로워 목록 조회 시 예외 발생")
+	@WithCustomUser(email = "current@test.com")
+	void getFollowersWithStatusUserNotFound() throws Exception {
+		// when: 존재하지 않는 유저의 팔로워 목록 요청
+		ResultActions result = mockMvc.perform(get("/api/follows/followers/with-status")
+			.param("userId", String.valueOf(99999L))
+			.param("page", "0")
+			.param("size", "10"));
+
+		// then: USER_NOT_FOUND 예외 발생
+		result.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("U-002"));
+	}
 }
 


### PR DESCRIPTION
## Summary
closes #137
- 내 팔로워 목록 조회 API에 isFollowing 필드 추가 (내가 각 팔로워를 팔로우하는지 여부)
- 내 팔로잉 목록 조회 API에 isFollowing 필드 추가 (항상 true)
- 다른 사람의 팔로잉 목록 조회 시 팔로우 상태 포함한 새로운 인증 API 추가

### 변경된 API 목록
- `GET /api/follows/followers/me` - 내 팔로워 목록 (isFollowing 필드 추가)
- `GET /api/follows/followings/me` - 내 팔로잉 목록 (isFollowing 필드 추가)
- `GET /api/follows/followings/with-status` - 다른 사람 팔로잉 목록 (신규, 인증 필요)

### 구현 상세
- **DTO**: GetFollowingsWithStatusResponse 추가, 프로젝션 인터페이스 추가
- **Repository**: 팔로우 상태 포함 조회 쿼리 메서드 추가
- **Service**: 내 팔로워/팔로잉 조회 및 상태 포함 조회 메서드 구현
- **Controller**: 기존 API 수정 및 새로운 인증 API 추가

## Test plan
- [x] 내 팔로워 목록 조회 (팔로우 상태 포함) 테스트
- [x] 내 팔로잉 목록 조회 (isFollowing 항상 true) 테스트
- [x] 다른 사람 팔로잉 목록 조회 (팔로우 상태 포함) 테스트
- [x] 기존 미인증 API 동작 유지 테스트
- [x] 에러 케이스 테스트 (존재하지 않는 사용자)
- [x] 전체 FollowController 통합 테스트 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 팔로워/팔로잉 목록에 팔로우 상태 포함 엔드포인트 추가(내 목록 및 특정 사용자 대상).
  - 항목별 isFollowing, 유저 이미지 표시 여부/URL, 이름, 이메일 제공.
  - 최신순 정렬 및 페이지네이션 지원.
  - 비인증 요청 시 isFollowing 필드가 제외됩니다.
  - 존재하지 않는 사용자 요청 시 404 오류 응답.

- Tests
  - 인증/비인증 시나리오, 전부 미팔로우/부분 팔로우, 비존재 사용자(404), 최신순 정렬, 총합/페이지 응답 검증을 포함한 통합 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->