### PR TITLE
fix : image명에 스페이스 허용

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageService.java
@@ -31,13 +31,6 @@ public class AiImageService extends ImageService {
 		this.keyGenerator = keyGenerator;
 	}
 
-	// 이미지 저장 URL 생성
-	public CreateImageSaveUrlDto createImageSaveUrl(ImagePrefix imagePrefix, String fullFileName) {
-		imageValidationService.validateFullFileName(fullFileName);
-
-		return imageUtil.createImageSaveUrl(imagePrefix, fullFileName);
-	}
-
 	// AI 이미지 조회용 URL 생성
 	@Transactional(readOnly = true)
 	public String createImageGetUrl(Long id) {

--- a/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
@@ -18,6 +18,13 @@ public abstract class ImageService {
 	public CreateImageSaveUrlDto createImageSaveUrl(ImagePrefix imagePrefix, String fullFileName) {
 		imageValidationService.validateFullFileName(fullFileName);
 
+		fullFileName = replaceSpaceWithUnderscore(fullFileName);
+
 		return imageUtil.createImageSaveUrl(imagePrefix, fullFileName);
+	}
+
+	// 이미지 이름의 스페이스를 _로 변경
+	private String replaceSpaceWithUnderscore(String fullFileName) {
+		return fullFileName.replace(" ", "_");
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
@@ -30,13 +30,6 @@ public class PostImageService extends ImageService {
 
 	}
 
-	// 이미지 저장 URL 생성
-	public CreateImageSaveUrlDto createImageSaveUrl(ImagePrefix imagePrefix, String fullFileName) {
-		imageValidationService.validateFullFileName(fullFileName);
-
-		return imageUtil.createImageSaveUrl(imagePrefix, fullFileName);
-	}
-
 	// POST 이미지는 public이므로 get URL 생성 없이 바로 URL 응답
 	@Transactional(readOnly = true)
 	public String createImageGetUrl(final Long id) {


### PR DESCRIPTION
## 개요
- close #125 

## 작업사항
- 이미지명에 스페이스 허용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 없음
- 버그 수정
  - 이미지 저장 URL 생성 시 파일명에 포함된 공백을 밑줄(_)로 자동 치환하여 업로드/접근 오류를 예방하고 일관된 파일명 처리를 보장합니다.
- 리팩터링
  - 사용되지 않는 이미지 저장 URL 생성 경로를 정리하여 내부 API 표면을 축소했습니다. 기존의 이미지 조회, 저장, 삭제 흐름과 호환성에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->