### PR TITLE
Feature: 이미지 path에 이미지명 제거

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/image/service/ImageService.java
@@ -18,13 +18,6 @@ public abstract class ImageService {
 	public CreateImageSaveUrlDto createImageSaveUrl(ImagePrefix imagePrefix, String fullFileName) {
 		imageValidationService.validateFullFileName(fullFileName);
 
-		fullFileName = replaceSpaceWithUnderscore(fullFileName);
-
 		return imageUtil.createImageSaveUrl(imagePrefix, fullFileName);
-	}
-
-	// 이미지 이름의 스페이스를 _로 변경
-	private String replaceSpaceWithUnderscore(String fullFileName) {
-		return fullFileName.replace(" ", "_");
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
@@ -99,7 +99,7 @@ public class S3ImageUtil implements ImageUtil {
 	// 저장 PreSignedUrl 생성
 	@Override
 	public CreateImageSaveUrlDto createImageSaveUrl(ImagePrefix imagePrefix, String fullFileName) {
-		String path = createPath(imagePrefix, fullFileName);
+		String path = createPath(imagePrefix);
 
 		GeneratePresignedUrlRequest request = createGeneratePreSignedUrlRequest(path, PUT, getUrlExpiration());
 		URL url = amazonS3Client.generatePresignedUrl(request);
@@ -159,9 +159,9 @@ public class S3ImageUtil implements ImageUtil {
 	}
 
 	// 파일이 저장될 경로 생성
-	private String createPath(ImagePrefix imagePrefix, String fullFileName) {
+	private String createPath(ImagePrefix imagePrefix) {
 		// 이미지명 곂치지않게 uuid 추가
-		return String.format("%s/%s", imagePrefix.getPrefix(), UUID.randomUUID() + "-" + fullFileName);
+		return String.format("%s/%s", imagePrefix.getPrefix(), UUID.randomUUID());
 	}
 
 	// PreSignedUrl 만료 시간 설정

--- a/src/test/java/hanium/modic/backend/domain/image/util/S3ImageUtilTest.java
+++ b/src/test/java/hanium/modic/backend/domain/image/util/S3ImageUtilTest.java
@@ -240,7 +240,6 @@ class S3ImageUtilTest {
 		// then
 		assertThat(result.imageSaveUrl()).isEqualTo(expectedUrl);
 		assertThat(result.imagePath()).startsWith(imagePrefix.getPrefix() + "/");
-		assertThat(result.imagePath()).contains(fullFileName);
 	}
 
 	@ParameterizedTest

--- a/src/test/java/hanium/modic/backend/domain/image/util/S3ImageUtilTest.java
+++ b/src/test/java/hanium/modic/backend/domain/image/util/S3ImageUtilTest.java
@@ -202,7 +202,6 @@ class S3ImageUtilTest {
 		// then
 		assertThat(result.imageSaveUrl()).isEqualTo(expectedUrl);
 		assertThat(result.imagePath()).contains("post/");
-		assertThat(result.imagePath()).contains(fullFileName);
 		verify(amazonS3, times(1)).generatePresignedUrl(any(GeneratePresignedUrlRequest.class));
 	}
 


### PR DESCRIPTION
## 개요
- close #143 

## 작업사항
- imagePath에 한국어가 들어가면서 signedUrl 접근 에러가 발생한다. imagePath를 아예 uuid만 포함하도록 변경했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음
- 변경 사항
  - 이미지 업로드 시 생성되는 경로에서 원본 파일명이 더 이상 포함되지 않아, 경로가 prefix/UUID 형태로 단순화되었습니다.
  - 파일명 내 공백을 밑줄로 치환하던 동작이 제거되어, 업로드 과정에서 파일명이 임의로 변경되지 않습니다.
- 테스트
  - 경로에 원본 파일명이 포함되는지 검증하던 테스트를 경로 형식 및 URL 유효성 검증으로 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->