### PR TITLE
로그 매트릭 수집 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
     // OAuth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.5.0'
+    // metric
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-cloudwatch2")
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 개요
- close #140 

## 작업사항
### HTTP (서버 요청)

http.server.requests · Timer(초)
- 태그: method, uri, status, outcome, exception, application=modic-local, profile=local
- 집계: count, sum/avg, max, p95, p99 (설정에 의해 노출)
- 의미: 엔드포인트/상태코드별 요청 수·지연
- 참고: 퍼센타일(p95/p99)과 히스토그램은 지금 distribution 설정으로 활성화되어 CloudWatch에 퍼센타일 지표가 함께 전송됩니다.

### JDBC / 커넥션 풀(공통)
- jdbc.connections.active · Gauge(개) — 현재 사용 중 커넥션
- jdbc.connections.max · Gauge(개) — 풀 최대 크기
- jdbc.connections.min · Gauge(개) — 풀 최소 크기
- (드라이버/풀 구현에 따라) jdbc.connections.idle · Gauge(개)

### HikariCP 전용(스프링 기본 풀 사용 시 자동)
- hikaricp.connections · Gauge(개) — 현재 총 커넥션
- hikaricp.connections.active · Gauge
- hikaricp.connections.idle · Gauge
- hikaricp.connections.pending · Gauge — 대기 중(획득 대기)
- hikaricp.connections.max / hikaricp.connections.min · Gauge
- hikaricp.connections.timeout · Counter(건) — 타임아웃 발생 수
- hikaricp.connections.acquire · Timer(초) — 커넥션 획득 시간(p95/p99 포함)
- hikaricp.connections.usage · Timer(초) — 커넥션 사용 시간
- hikaricp.connections.creation · Timer(초) — 커넥션 생성 시간

태그: 보통 pool(DataSource 이름), application, profile

### 스레드풀 / 실행기(Executor)
(Spring의 TaskExecutor 자동 바인딩 + 직접 모니터링한 ExecutorService 포함 시)
- executor.active · Gauge(개) — 동시 실행 중 작업 수
- executor.pool.size · Gauge(개) — 현재 풀 크기
- executor.queued · Gauge(개) — 대기 큐 길이 (환경에 따라 executor.queue.remaining/queue.size 지표도 노출)
- executor.completed · FunctionCounter(건) — 완료된 작업 수 누계
태그: name(풀 이름), application, profile


### JVM / 시스템

메모리
- jvm.memory.used / max / committed · Gauge(바이트)
- jvm.buffer.count / memory.used / total.capacity · Gauge(버퍼 풀)
- jvm.classes.loaded / unloaded · Gauge(개)

스레드
- jvm.threads.live / daemon / peak · Gauge
- jvm.threads.states · Gauge(개) — 태그 state(RUNNABLE, BLOCKED 등)

GC
- jvm.gc.pause · Timer(초) — GC 정지 시간(p95/p99 가능)
- jvm.gc.memory.allocated / promoted · Counter(바이트)

프로세스/시스템
- process.uptime · Gauge(초), process.start.time · Gauge(epoch 초)
- process.cpu.usage · Gauge(0~1)
- system.cpu.count · Gauge(코어 수)
- system.cpu.usage · Gauge(0~1)
- system.load.average.1m · Gauge

태그: application, profile

### SQL 실행시간 / JPA(Hibernate) (옵션)
- hibernate.query.execution · Timer(초) — 쿼리 실행 시간(p95/p99 포함)
- hibernate.sessions.open / closed · Counter
- hibernate.transactions · Counter (태그: status)
- hibernate.flushes / hibernate.optimistic.failures 등

태그: entity, query, region 등(버전/설정에 따라 상이)

### 메시지 큐(RabbitMQ/Kafka) (옵션)

Observation/metrics 활성화 시 자동 수집됩니다.

RabbitMQ (Spring AMQP)
- spring.rabbitmq.listener.records · Counter — 소비 레코드 수
- spring.rabbitmq.template.requests · Counter — 발행 요청 수
- spring.rabbitmq.template.publish.latency · Timer(초)

