### PR TITLE
refactor: id를 postId로 통일 및 이미지 조회 로직 수정

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -123,7 +123,13 @@ public class PostService {
 		final boolean hasUserImage = userImage != null;
 		final String userEmail = userEntity.getEmail();
 
-		List<PostImageEntity> postImages = postImageEntityRepository.findAllByPostId(id);
+		List<ImageDto> postImages = postImageEntityRepository.findAllByPostId(id)
+			.stream()
+			.map(image -> new ImageDto(
+				imageUtil.createImageGetUrl(image.getImagePath()),
+				image.getId()
+			))
+			.toList();
 
 		// 하트 수 조회 (통계 테이블 사용)
 		long likeCount = postLikeService.getLikeCount(id);

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
@@ -17,7 +17,7 @@ public record GetPostResponse(
 	boolean hasUserImage,
 	String userImageUrl,
 	String userEmail,
-	Long id,
+	Long postId,
 	Long userId,
 	String title,
 	String description,

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostsResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostsResponse.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public record GetPostsResponse(
-	Long id,
+	Long postId,
 	Long userId,
 	String title,
 	String description,

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -29,8 +29,6 @@ import org.springframework.data.domain.Sort;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.common.response.PageResponse;
-import hanium.modic.backend.domain.image.domain.ImageExtension;
-import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.image.entityfactory.ImageFactory;
 import hanium.modic.backend.domain.image.util.ImageUtil;
 import hanium.modic.backend.domain.post.entity.PostEntity;
@@ -141,7 +139,7 @@ class PostServiceTest {
 
 		// then
 		assertThat(response).isNotNull();
-		assertThat(response.id()).isEqualTo(mockPost.getId());
+		assertThat(response.postId()).isEqualTo(mockPost.getId());
 		assertThat(response.title()).isEqualTo(mockPost.getTitle());
 		assertThat(response.description()).isEqualTo(mockPost.getDescription());
 		assertThat(response.commercialPrice()).isEqualTo(mockPost.getCommercialPrice());
@@ -217,7 +215,7 @@ class PostServiceTest {
 		PostEntity mockPost = createMockPostWithId(postId, mockUser);
 		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost, 2);
 		List<GetPostResponse.ImageDto> expectedImages = mockImages.stream()
-			.map(image -> new GetPostResponse.ImageDto(image.getImageUrl(), image.getId()))
+			.map(image -> new GetPostResponse.ImageDto(imageUtil.createImageGetUrl(image.getImagePath()), image.getId()))
 			.toList();
 
 		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
@@ -230,7 +228,7 @@ class PostServiceTest {
 
 		// then
 		assertThat(response).isNotNull();
-		assertThat(response.id()).isEqualTo(mockPost.getId());
+		assertThat(response.postId()).isEqualTo(mockPost.getId());
 		assertThat(response.title()).isEqualTo(mockPost.getTitle());
 		assertThat(response.description()).isEqualTo(mockPost.getDescription());
 		assertThat(response.commercialPrice()).isEqualTo(mockPost.getCommercialPrice());

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -154,7 +154,7 @@ class PostControllerTest extends BaseControllerTest {
 		mockMvc.perform(get("/api/posts/{id}", postId)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.id").value(response.id()))
+			.andExpect(jsonPath("$.data.postId").value(response.postId()))
 			.andExpect(jsonPath("$.data.title").value(response.title()))
 			.andExpect(jsonPath("$.data.description").value(response.description()))
 			.andExpect(jsonPath("$.data.likeCount").value(response.likeCount()))

--- a/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
@@ -76,7 +76,7 @@ class PublicPostControllerTest extends BaseControllerTest {
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value(200))
-			.andExpect(jsonPath("$.data.id").value(postId))
+			.andExpect(jsonPath("$.data.postId").value(postId))
 			.andExpect(jsonPath("$.data.title").value(mockPost.getTitle()))
 			.andExpect(jsonPath("$.data.description").value(mockPost.getDescription()))
 			.andExpect(jsonPath("$.data.commercialPrice").value(mockPost.getCommercialPrice()))


### PR DESCRIPTION
## 개요
프론트엔드 요청에 따라 응답 DTO의 `id` 필드를 `postId`로 통일하고, 이미지 조회 로직을 개선했습니다.

## 작업사항
- **Post 응답 DTO 필드 통일**: 
  - `GetPostResponse`와 `GetPostsResponse`의 `id` → `postId`로 변경
  - 프론트엔드에서 요청한 필드명 통일 적용

- **이미지 조회 로직 개선**:
  - 기존 PR에서 변경된 `createImageGetUrl` 사용 로직 반영
  - 이미지 URL 생성 방식 통일

- **테스트 코드 업데이트**:
  - 변경된 필드명에 맞게 관련 테스트 코드 수정
  - `PostServiceTest`, `PostControllerTest`, `PublicPostControllerTest` 업데이트

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 공개/일반 게시글 API 응답에서 식별자 필드명을 id → postId로 변경했습니다. 호환성 영향: 클라이언트는 필드명 참조를 postId로 업데이트해야 합니다.
  - 게시글 이미지 응답을 엔터티 노출 대신 표준화된 Image DTO로 제공하며, 각 이미지에 접근 가능한 URL을 포함합니다.
  - 그 외 응답 구조와 데이터(제목, 설명, 가격, 좋아요 수 등)는 동일하며 기능 동작에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->