### PR TITLE
파생 포스트 및 포스트에 자식 포스트 id와 url 제공 기능

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -72,8 +72,8 @@ public enum ErrorCode {
 	S3_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S-002", "S3 서버에서 에러가 발생하였습니다."),
 
 	// AI
-	AI_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "A-001", "해당 AI 요청을 찾을 수 없습니다."),
-	CREATED_AI_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "A-002", "생성된 AI 이미지를 찾을 수 없습니다."),
+	AI_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-001", "해당 AI 요청을 찾을 수 없습니다."),
+	CREATED_AI_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-002", "생성된 AI 이미지를 찾을 수 없습니다."),
 	AI_IMAGE_DATA_INCONSISTENCY(HttpStatus.INTERNAL_SERVER_ERROR, "A-003", "AI 이미지 데이터 일관성 오류가 발생했습니다."),
 	AI_IMAGE_PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "AI-004", "AI 이미지 생성권을 구매한 이력이 없습니다."),
 	AI_REQUEST_TICKET_PROCESSING_FAIL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "AI-005", "티켓 처리에 실패했습니다."),

--- a/src/main/java/hanium/modic/backend/domain/image/util/ImageUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/image/util/ImageUtil.java
@@ -22,4 +22,7 @@ public interface ImageUtil {
 
 	// FullImageName 파싱
 	ParsedImageName parseFullImageName(String fullFileName);
+
+	// 이미지 복사
+	String copyImage(String sourceImagePath, ImagePrefix destinationPrefix);
 }

--- a/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
+++ b/src/main/java/hanium/modic/backend/domain/image/util/S3ImageUtil.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.cloudfront.CloudFrontUrlSigner;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
@@ -178,5 +179,22 @@ public class S3ImageUtil implements ImageUtil {
 		if (imagePath == null || imagePath.isEmpty()) {
 			throw new AppException(INVALID_IMAGE_FILE_PATH_EXCEPTION);
 		}
+	}
+
+	// 이미지 복사 및 생성된 경로 반환
+	@Override
+	public String  copyImage(String sourcePath, ImagePrefix destinationPrefix) {
+		String destinationPath = createPath(destinationPrefix);
+
+		// 복사 요청 생성 및 실행
+		CopyObjectRequest request = new CopyObjectRequest(
+			s3Properties.getBucketName(),
+			sourcePath,
+			s3Properties.getBucketName(),
+			destinationPath
+		);
+		amazonS3Client.copyObject(request);
+
+		return destinationPath;
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
@@ -1,5 +1,6 @@
-package hanium.modic.backend.domain.ai.service;
+package hanium.modic.backend.domain.post.service;
 
+import hanium.modic.backend.domain.postLike.service.AsyncPostStatisticsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +13,6 @@ import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
-import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
 
 @Service
@@ -24,6 +24,7 @@ public class AiDerivedPostService {
 	private final PostEntityRepository postEntityRepository;
 	private final PostImageEntityRepository postImageEntityRepository;
 	private final PostService postService;
+	private final AsyncPostStatisticsService asyncPostStatisticsService;
 
 	/**
 	 * AI 파생 포스트 생성
@@ -79,6 +80,9 @@ public class AiDerivedPostService {
 		postImage.updatePost(savedPost);
 
 		postImageEntityRepository.save(postImage);
+
+		// 게시글 통계 초기화 (비동기)
+		asyncPostStatisticsService.initializeStatistics(savedPost.getId());
 
 		return CreatePostResponse.of(savedPost.getId());
 	}

--- a/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
@@ -1,7 +1,5 @@
 package hanium.modic.backend.domain.post.service;
 
-import hanium.modic.backend.domain.postLike.service.AsyncPostStatisticsService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,11 +7,15 @@ import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
+import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.image.util.ImageUtil;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.domain.postLike.service.AsyncPostStatisticsService;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ public class AiDerivedPostService {
 	private final PostImageEntityRepository postImageEntityRepository;
 	private final PostService postService;
 	private final AsyncPostStatisticsService asyncPostStatisticsService;
+	private final ImageUtil imageUtil;
 
 	/**
 	 * AI 파생 포스트 생성
@@ -69,13 +72,18 @@ public class AiDerivedPostService {
 
 		PostEntity savedPost = postEntityRepository.save(aiDerivedPost);
 
-		// AI 이미지를 포스트 이미지로 변환
+		// AI 이미지를 포스트 이미지로 별도 저장
+		String imagePath = imageUtil.copyImage(
+			createdAiImage.getImagePath(),
+			ImagePrefix.POST
+		);
+
 		PostImageEntity postImage = PostImageEntity.builder()
-			.imagePath(createdAiImage.getImagePath())
+			.imagePath(imagePath)
 			.fullImageName(createdAiImage.getFullImageName())
 			.imageName(createdAiImage.getImageName())
 			.extension(createdAiImage.getExtension())
-			.imagePurpose(createdAiImage.getImagePurpose())
+			.imagePurpose(ImagePrefix.POST)
 			.build();
 		postImage.updatePost(savedPost);
 

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -114,11 +115,28 @@ public class PostService {
 		// 현재 인증된 사용자의 좋아요 여부 확인
 		Boolean isLikedByCurrentUser = postLikeService.isLikedByUser(currentUserId, id);
 
-		// AI 파생 포스트 ID 목록 조회
+		// AI 파생 포스트의 id와 ImageUrl 조회
 		List<Long> derivedPostIds = postEntityRepository.findIdsByParentPostIdOrderByIdDesc(id);
 
+		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(derivedPostIds);
+
+		// 포스트ID별로 첫 번째 이미지 URL 찾기
+		Map<Long, String> firstImageByPostId = new LinkedHashMap<>();
+		for (PostImageEntity image : allPostImages) {
+			firstImageByPostId.computeIfAbsent(
+				image.getPostId(),
+				pid -> imageUtil.createImageGetUrl(image.getImagePath())
+			);
+		}
+		List<GetPostResponse.SimplePostDto> derivedPosts = derivedPostIds.stream()
+			.map(postId -> {
+				String firstImageUrl = firstImageByPostId.get(postId);
+				return new GetPostResponse.SimplePostDto(postId, firstImageUrl);
+			})
+			.toList();
+
 		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
-			isLikedByCurrentUser, derivedPostIds);
+			isLikedByCurrentUser, derivedPosts);
 	}
 
 	@Transactional(readOnly = true)
@@ -146,15 +164,33 @@ public class PostService {
 		// 비로그인 사용자이므로 좋아요 여부는 null로 설정
 		Boolean isLikedByCurrentUser = false;
 
-		// AI 파생 포스트 ID 목록 조회
+		// AI 파생 포스트의 id와 ImageUrl 조회
 		List<Long> derivedPostIds = postEntityRepository.findIdsByParentPostIdOrderByIdDesc(id);
 
+		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(derivedPostIds);
+
+		// 포스트ID별로 첫 번째 이미지 URL 찾기
+		Map<Long, String> firstImageByPostId = new LinkedHashMap<>();
+		for (PostImageEntity image : allPostImages) {
+			firstImageByPostId.computeIfAbsent(
+				image.getPostId(),
+				pid -> imageUtil.createImageGetUrl(image.getImagePath())
+			);
+		}
+		List<GetPostResponse.SimplePostDto> derivedPosts = derivedPostIds.stream()
+			.map(postId -> {
+				String firstImageUrl = firstImageByPostId.get(postId);
+				return new GetPostResponse.SimplePostDto(postId, firstImageUrl);
+			})
+			.toList();
+
 		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
-			isLikedByCurrentUser, derivedPostIds);
+			isLikedByCurrentUser, derivedPosts);
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<GetPostsResponse> getPosts(final String sort, final int page, final int size, final PostType postType) {
+	public PageResponse<GetPostsResponse> getPosts(final String sort, final int page, final int size,
+		final PostType postType) {
 
 		// Todo: sort 기능 추가
 

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -130,7 +130,7 @@ public class AiImageController {
 		summary = "생성된 AI 이미지 조회 URL 생성",
 		description = "AI가 생성한 최종 이미지를 확인할 수 있는 URL을 반환합니다. 사전에 생성 상태를 조회해야 합니다.",
 		responses = {
-			@ApiResponse(responseCode = "404", description = "생성된 AI 이미지를 찾을 수 없습니다.[A-002]"),
+			@ApiResponse(responseCode = "404", description = "생성된 AI 이미지를 찾을 수 없습니다.[AI-002]"),
 			@ApiResponse(responseCode = "400", description = "잘못된 이미지 파일 경로입니다.[I-004]"),
 			@ApiResponse(responseCode = "400", description = "이미지를 훔칠 수 없습니다.[I-006]")
 		}
@@ -149,7 +149,7 @@ public class AiImageController {
 		summary = "AI 이미지 생성 상태 조회",
 		description = "AI 이미지 생성 요청에 대한 현재 상태를 조회합니다.",
 		responses = {
-			@ApiResponse(responseCode = "404", description = "해당 AI 요청을 찾을 수 없습니다.[A-001]"),
+			@ApiResponse(responseCode = "404", description = "해당 AI 요청을 찾을 수 없습니다.[AI-001]"),
 			@ApiResponse(responseCode = "400", description = "이미지를 훔칠 수 없습니다.[I-006]")
 		}
 	)

--- a/src/main/java/hanium/modic/backend/web/post/controller/AiDerivedPostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/AiDerivedPostController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
 import hanium.modic.backend.common.response.AppResponse;
-import hanium.modic.backend.domain.ai.service.AiDerivedPostService;
+import hanium.modic.backend.domain.post.service.AiDerivedPostService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.post.dto.request.CreateAiDerivedPostRequest;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
@@ -30,7 +30,8 @@ public record GetPostResponse(
 	long likeCount,
 	Boolean isLikedByCurrentUser, // 로그인하지 않은 경우 null
 	// AI 파생 포스트 ID 목록 (원본 포스트인 경우에만 값이 있음)
-	List<Long> derivedPostIds
+	List<SimplePostDto> derivedPosts
+
 ) {
 	// 기존 메서드 (하트 정보 없음 - 하위호환성)
 	public static GetPostResponse of(
@@ -66,7 +67,7 @@ public record GetPostResponse(
 		List<ImageDto> imageDtos,
 		long likeCount,
 		Boolean isLikedByCurrentUser,
-		List<Long> derivedPostIds
+		List<SimplePostDto> derivedPosts
 	) {
 
 		return new GetPostResponse(
@@ -85,7 +86,7 @@ public record GetPostResponse(
 			imageDtos,
 			likeCount,
 			isLikedByCurrentUser,
-			derivedPostIds);
+			derivedPosts);
 	}
 
 	@Getter
@@ -93,5 +94,12 @@ public record GetPostResponse(
 	public static class ImageDto {
 		private String imageUrl;
 		private Long imageId;
+	}
+
+	@Getter
+	@AllArgsConstructor(access = AccessLevel.PUBLIC)
+	public static class SimplePostDto {
+		private Long postId;
+		private String imageUrl;
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiDerivedPostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiDerivedPostServiceTest.java
@@ -24,6 +24,7 @@ import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.domain.post.service.AiDerivedPostService;
 import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiDerivedPostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiDerivedPostServiceTest.java
@@ -20,12 +20,15 @@ import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
+import hanium.modic.backend.domain.image.domain.ImagePrefix;
+import hanium.modic.backend.domain.image.util.ImageUtil;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
 import hanium.modic.backend.domain.post.service.AiDerivedPostService;
 import hanium.modic.backend.domain.post.service.PostService;
+import hanium.modic.backend.domain.postLike.service.AsyncPostStatisticsService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
@@ -44,6 +47,12 @@ class AiDerivedPostServiceTest {
 
 	@Mock
 	private PostService postService;
+
+	@Mock
+	private ImageUtil imageUtil;
+
+	@Mock
+	private AsyncPostStatisticsService asyncPostStatisticsService;
 
 	@InjectMocks
 	private AiDerivedPostService aiDerivedPostService;
@@ -67,11 +76,12 @@ class AiDerivedPostServiceTest {
 
 		when(createdAiImageRepository.findById(createdAiImageId)).thenReturn(Optional.of(mockAiImage));
 		when(postEntityRepository.save(any(PostEntity.class))).thenReturn(mockSavedPost);
+		when(imageUtil.copyImage(anyString(), eq(ImagePrefix.POST))).thenReturn("copied-image-path");
+		doNothing().when(asyncPostStatisticsService).initializeStatistics(anyLong());
 
 		// when
 		CreatePostResponse response = aiDerivedPostService.createAiDerivedPost(
-			userId, createdAiImageId, title, description,
-			commercialPrice, nonCommercialPrice, ticketPrice);
+			userId, createdAiImageId, title, description, commercialPrice, nonCommercialPrice, ticketPrice);
 
 		// then
 		assertThat(response).isNotNull();
@@ -94,11 +104,11 @@ class AiDerivedPostServiceTest {
 		ArgumentCaptor<PostImageEntity> imageCaptor = ArgumentCaptor.forClass(PostImageEntity.class);
 		verify(postImageEntityRepository, times(1)).save(imageCaptor.capture());
 		PostImageEntity savedImage = imageCaptor.getValue();
-		assertThat(savedImage.getImagePath()).isEqualTo(mockAiImage.getImagePath());
+		assertThat(savedImage.getImagePath()).isEqualTo("copied-image-path");
 		assertThat(savedImage.getFullImageName()).isEqualTo(mockAiImage.getFullImageName());
 		assertThat(savedImage.getImageName()).isEqualTo(mockAiImage.getImageName());
 		assertThat(savedImage.getExtension()).isEqualTo(mockAiImage.getExtension());
-		assertThat(savedImage.getImagePurpose()).isEqualTo(mockAiImage.getImagePurpose());
+		assertThat(savedImage.getImagePurpose()).isEqualTo(ImagePrefix.POST);
 
 		verify(createdAiImageRepository, times(1)).findById(createdAiImageId);
 	}

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -151,7 +151,7 @@ class PostServiceTest {
 		assertThat(response.likeCount()).isEqualTo(10L);
 		assertThat(response.isLikedByCurrentUser()).isTrue();
 		assertThat(response.images()).hasSize(2);
-		assertThat(response.derivedPostIds()).isEmpty(); // 파생포스트 없음
+		assertThat(response.derivedPosts()).isEmpty(); // 파생포스트 없음
 
 		verify(postEntityRepository).findById(postId);
 		verify(userEntityRepository).findById(mockPost.getUserId());
@@ -188,7 +188,7 @@ class PostServiceTest {
 		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(5L);
 		assertThat(response.isLikedByCurrentUser()).isFalse();
-		assertThat(response.derivedPostIds()).isEmpty(); // 파생포스트 없음
+		assertThat(response.derivedPosts()).isEmpty(); // 파생포스트 없음
 
 		verify(postEntityRepository).findById(postId);
 		verify(userEntityRepository).findById(mockPost.getUserId());
@@ -635,8 +635,7 @@ class PostServiceTest {
 		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(15L);
 		assertThat(response.isLikedByCurrentUser()).isFalse();
-		assertThat(response.derivedPostIds()).hasSize(3);
-		assertThat(response.derivedPostIds()).containsExactly(10L, 11L, 12L);
+		assertThat(response.derivedPosts()).hasSize(3);
 
 		verify(postEntityRepository).findById(postId);
 		verify(userEntityRepository).findById(mockPost.getUserId());
@@ -673,7 +672,7 @@ class PostServiceTest {
 		assertThat(response.isAiDerivedPost()).isTrue();
 		assertThat(response.likeCount()).isEqualTo(3L);
 		assertThat(response.isLikedByCurrentUser()).isTrue();
-		assertThat(response.derivedPostIds()).isEmpty(); // AI 파생 포스트이므로 빈 배열
+		assertThat(response.derivedPosts()).isEmpty(); // AI 파생 포스트이므로 빈 배열
 
 		verify(postEntityRepository).findById(postId);
 		verify(userEntityRepository).findById(mockAiDerivedPost.getUserId());
@@ -707,8 +706,7 @@ class PostServiceTest {
 		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(25L);
 		assertThat(response.isLikedByCurrentUser()).isFalse(); // 비로그인 사용자
-		assertThat(response.derivedPostIds()).hasSize(2);
-		assertThat(response.derivedPostIds()).containsExactly(20L, 21L);
+		assertThat(response.derivedPosts()).hasSize(2);
 
 		verify(postEntityRepository).findById(postId);
 		verify(userEntityRepository).findById(mockPost.getUserId());

--- a/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.io.ByteArrayInputStream;
+import java.util.Optional;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,7 @@ import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.post.dto.request.CreateAiDerivedPostRequest;
@@ -55,63 +57,70 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 	@WithCustomUser(email = "test@email.com")
 	@DisplayName("AI 파생 포스트 생성 성공 - 통합 테스트")
 	void createAiDerivedPost_Success_IntegrationTest() throws Exception {
-		// given
-		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
+		try {
+			// given
+			UserEntity currentUser = ContextHolderUtil.getCurrentUser();
 
-		// CreatedAiImageEntity 생성 및 저장
-		CreatedAiImageEntity createdAiImage = CreatedAiImageEntity.builder()
-			.userId(currentUser.getId())
-			.postId(999L) // 임시 값
-			.requestId("test-request-123")
-			.imagePath("imagePath")
-			.fullImageName("ai-image-full.png")
-			.imageName("ai-image")
-			.extension(ImageExtension.PNG)
-			.imagePurpose(ImagePrefix.AI_RESPONSE)
-			.build();
-		createdAiImage = createdAiImageRepository.save(createdAiImage);
+			// CreatedAiImageEntity 생성 및 저장
+			CreatedAiImageEntity createdAiImage = CreatedAiImageEntity.builder()
+				.userId(currentUser.getId())
+				.postId(999L) // 임시 값
+				.requestId("test-request-123")
+				.imagePath("imagePath")
+				.fullImageName("ai-image-full.png")
+				.imageName("ai-image")
+				.extension(ImageExtension.PNG)
+				.imagePurpose(ImagePrefix.AI_RESPONSE)
+				.build();
+			createdAiImage = createdAiImageRepository.save(createdAiImage);
+			uploadImage("imagePath", "imageContent1");
 
-		CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
-			createdAiImage.getId(),
-			"AI Generated Post",
-			"This is an AI derived post created from integration test",
-			2000L,
-			1000L,
-			300L
-		);
+			CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
+				createdAiImage.getId(),
+				"AI Generated Post",
+				"This is an AI derived post created from integration test",
+				2000L,
+				1000L,
+				300L
+			);
 
-		String json = objectMapper.writeValueAsString(request);
+			String json = objectMapper.writeValueAsString(request);
 
-		// when
-		ResultActions result = mockMvc.perform(post("/api/ai/derived-posts")
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(json));
+			// when
+			ResultActions result = mockMvc.perform(post("/api/ai/derived-posts")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json));
 
-		// then
-		result.andExpect(status().isCreated())
-			.andExpect(jsonPath("$.data.postId").exists());
+			// then
+			result.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.postId").exists());
 
-		// 데이터베이스에서 검증
-		PostEntity savedPost = postEntityRepository.findAll().stream()
-			.filter(post -> "AI Generated Post".equals(post.getTitle()))
-			.findFirst()
-			.orElseThrow(() -> new AssertionError("AI 파생 포스트가 데이터베이스에 저장되지 않았습니다"));
+			// 데이터베이스에서 검증
+			PostEntity savedPost = postEntityRepository.findAll().stream()
+				.filter(post -> "AI Generated Post".equals(post.getTitle()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("AI 파생 포스트가 데이터베이스에 저장되지 않았습니다"));
 
-		assertThat(savedPost.getUserId()).isEqualTo(currentUser.getId());
-		assertThat(savedPost.getTitle()).isEqualTo("AI Generated Post");
-		assertThat(savedPost.getDescription()).isEqualTo("This is an AI derived post created from integration test");
-		assertThat(savedPost.getCommercialPrice()).isEqualTo(2000L);
-		assertThat(savedPost.getNonCommercialPrice()).isEqualTo(1000L);
-		assertThat(savedPost.getTicketPrice()).isEqualTo(300L);
-		assertThat(savedPost.getIsAiDerivedPost()).isTrue();
+			assertThat(savedPost.getUserId()).isEqualTo(currentUser.getId());
+			assertThat(savedPost.getTitle()).isEqualTo("AI Generated Post");
+			assertThat(savedPost.getDescription()).isEqualTo(
+				"This is an AI derived post created from integration test");
+			assertThat(savedPost.getCommercialPrice()).isEqualTo(2000L);
+			assertThat(savedPost.getNonCommercialPrice()).isEqualTo(1000L);
+			assertThat(savedPost.getTicketPrice()).isEqualTo(300L);
+			assertThat(savedPost.getIsAiDerivedPost()).isTrue();
 
-		// 포스트 이미지 검증
-		PostImageEntity savedPostImage = postImageEntityRepository.findAllByPostId(savedPost.getId()).get(0);
-		assertThat(savedPostImage.getImagePath()).isEqualTo("imagePath");
-		assertThat(savedPostImage.getFullImageName()).isEqualTo("ai-image-full.png");
-		assertThat(savedPostImage.getImageName()).isEqualTo("ai-image");
-		assertThat(savedPostImage.getExtension()).isEqualTo(ImageExtension.PNG);
-		assertThat(savedPostImage.getImagePurpose()).isEqualTo(ImagePrefix.AI_RESPONSE);
+			// 포스트 이미지 검증
+			PostImageEntity savedPostImage = postImageEntityRepository.findAllByPostId(savedPost.getId()).get(0);
+			assertThat(savedPostImage.getFullImageName()).isEqualTo("ai-image-full.png");
+			assertThat(savedPostImage.getImageName()).isEqualTo("ai-image");
+			assertThat(savedPostImage.getExtension()).isEqualTo(ImageExtension.PNG);
+			assertThat(savedPostImage.getImagePurpose()).isEqualTo(ImagePrefix.POST);
+
+			deleteImage(savedPostImage.getImagePath());
+		} finally {
+			deleteImage("imagePath");
+		}
 	}
 
 	@Test
@@ -353,5 +362,22 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 		// 포스트가 생성되지 않았는지 확인
 		long postCount = postEntityRepository.count();
 		assertThat(postCount).isEqualTo(0);
+	}
+
+	private void uploadImage(String filePath, String content) {
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(content.length());
+		metadata.setContentType("image/jpeg");
+
+		amazonS3.putObject(
+			s3Properties.getBucketName(),
+			filePath,
+			new ByteArrayInputStream(content.getBytes()),
+			metadata
+		);
+	}
+
+	private void deleteImage(String filePath) {
+		amazonS3.deleteObject(s3Properties.getBucketName(), filePath);
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerTest.java
@@ -24,9 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import hanium.modic.backend.base.BaseControllerTest;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
-import hanium.modic.backend.domain.ai.service.AiDerivedPostService;
+import hanium.modic.backend.domain.post.service.AiDerivedPostService;
 import hanium.modic.backend.web.post.dto.request.CreateAiDerivedPostRequest;
-import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
 
 @WebMvcTest(controllers = AiDerivedPostController.class)
 @AutoConfigureMockMvc(addFilters = false)


### PR DESCRIPTION
## 개요
- close #154 

## 작업사항
파생 포스트 및 포스트에 자식 포스트 id와 url 제공 기능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 게시글 상세/공개 조회에서 파생 게시글을 ID 목록 대신 썸네일(첫 이미지 URL)과 함께 제공합니다.
* 개선
  * AI 생성 이미지를 게시글용으로 안전하게 복사·저장하여 이미지 일관성과 표시 안정성을 높였습니다.
  * 게시글 통계 초기화를 비동기로 처리해 응답 안정성을 개선했습니다.
* 문서
  * AI 관련 404 오류 코드를 AI-001, AI-002로 명확히 표기했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->