### PR TITLE
feat: AI 이미지 생성권 남은 횟수 조회 API 구현 (#157)

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImagePermissionService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImagePermissionService.java
@@ -13,7 +13,7 @@ import hanium.modic.backend.domain.ai.repository.AiImagePermissionRepository;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.user.service.UserCoinService;
-import hanium.modic.backend.web.ai.dto.response.AiImagePermissionResponse;
+import hanium.modic.backend.web.ai.dto.response.GetRemainingGenerationsResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -75,12 +75,12 @@ public class AiImagePermissionService {
 
 	// 유저의 특정 포스트에 대한 남은 생성 횟수 조회
 	@Transactional(readOnly = true)
-	public AiImagePermissionResponse getRemainingGenerations(final Long userId, final Long postId) {
+	public GetRemainingGenerationsResponse getRemainingGenerations(final Long userId, final Long postId) {
 		AiImagePermissionEntity aiImagePermission = aiImagePermissionRepository.findByUserIdAndPostId(userId,
 				postId)
 			.orElseThrow(() -> new AppException(AI_IMAGE_PERMISSION_NOT_FOUND));
 
-		return new AiImagePermissionResponse(
+		return new GetRemainingGenerationsResponse(
 			aiImagePermission.getId(),
 			aiImagePermission.getRemainingGenerations()
 		);

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImagePermissionService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImagePermissionService.java
@@ -13,6 +13,7 @@ import hanium.modic.backend.domain.ai.repository.AiImagePermissionRepository;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.user.service.UserCoinService;
+import hanium.modic.backend.web.ai.dto.response.AiImagePermissionResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -70,5 +71,19 @@ public class AiImagePermissionService {
 		} catch (LockException e) {
 			throw new AppException(AI_IMAGE_PERMISSION_FAIL_EXCEPTION);
 		}
+	}
+
+	// 유저의 특정 포스트에 대한 남은 생성 횟수 조회
+	@Transactional(readOnly = true)
+	public AiImagePermissionResponse getRemainingGenerations(final Long userId, final Long postId) {
+		AiImagePermissionEntity aiImagePermission = aiImagePermissionRepository.findByUserIdAndPostId(userId,
+				postId)
+			.orElseThrow(() -> new AppException(AI_IMAGE_PERMISSION_NOT_FOUND));
+
+		return new AiImagePermissionResponse(
+			aiImagePermission.getId(),
+			aiImagePermission.getRemainingGenerations()
+		);
+
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImagePermissionController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImagePermissionController.java
@@ -2,15 +2,18 @@ package hanium.modic.backend.web.ai.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
 import hanium.modic.backend.domain.ai.service.AiImagePermissionService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.ai.dto.request.BuyAiImagePermissionRequest;
+import hanium.modic.backend.web.ai.dto.response.AiImagePermissionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,5 +69,23 @@ public class AiImagePermissionController {
 		aiImagePermissionService.buyAiImagePermissionByTicket(user.getId(), request.postId());
 
 		return ResponseEntity.ok().build();
+	}
+
+	@Operation(
+		summary = "AI 이미지 생성권 남은 횟수 조회",
+		description = "특정 포스트에 대한 사용자의 AI 이미지 생성권 남은 횟수를 조회합니다.(구매한 이력이 없으면 AI-004 에러)",
+		responses = {
+			@ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.[U-002]"),
+			@ApiResponse(responseCode = "404", description = "AI 이미지 생성권을 구매한 이력이 없습니다.[AI-004]")
+		}
+	)
+	@GetMapping("/remaining-generations")
+	public ResponseEntity<AiImagePermissionResponse> getRemainingGenerations(
+		@CurrentUser UserEntity user,
+		@RequestParam Long postId
+	) {
+		AiImagePermissionResponse response = aiImagePermissionService.getRemainingGenerations(user.getId(), postId);
+
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImagePermissionController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImagePermissionController.java
@@ -13,7 +13,7 @@ import hanium.modic.backend.common.annotation.user.CurrentUser;
 import hanium.modic.backend.domain.ai.service.AiImagePermissionService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.ai.dto.request.BuyAiImagePermissionRequest;
-import hanium.modic.backend.web.ai.dto.response.AiImagePermissionResponse;
+import hanium.modic.backend.web.ai.dto.response.GetRemainingGenerationsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -80,11 +80,11 @@ public class AiImagePermissionController {
 		}
 	)
 	@GetMapping("/remaining-generations")
-	public ResponseEntity<AiImagePermissionResponse> getRemainingGenerations(
+	public ResponseEntity<GetRemainingGenerationsResponse> getRemainingGenerations(
 		@CurrentUser UserEntity user,
 		@RequestParam Long postId
 	) {
-		AiImagePermissionResponse response = aiImagePermissionService.getRemainingGenerations(user.getId(), postId);
+		GetRemainingGenerationsResponse response = aiImagePermissionService.getRemainingGenerations(user.getId(), postId);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionListResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionListResponse.java
@@ -1,9 +1,0 @@
-package hanium.modic.backend.web.ai.dto.response;
-
-import java.util.List;
-
-public record AiImagePermissionListResponse(
-	List<AiImagePermissionResponse> permissions,
-	Integer totalCount
-) {
-}

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/AiImagePermissionResponse.java
@@ -3,12 +3,7 @@ package hanium.modic.backend.web.ai.dto.response;
 import java.time.LocalDateTime;
 
 public record AiImagePermissionResponse(
-	Long id,
-	Long userId,
-	Long postId,
-	Integer remainingGenerations,
-	Boolean isActive,
-	LocalDateTime createdAt,
-	LocalDateTime updatedAt
+	Long aiImagePermissionId,
+	Integer remainingGenerations
 ) {
 }

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/GetRemainingGenerationsResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/GetRemainingGenerationsResponse.java
@@ -1,8 +1,6 @@
 package hanium.modic.backend.web.ai.dto.response;
 
-import java.time.LocalDateTime;
-
-public record AiImagePermissionResponse(
+public record GetRemainingGenerationsResponse(
 	Long aiImagePermissionId,
 	Integer remainingGenerations
 ) {

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImagePermissionControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImagePermissionControllerIntegrationTest.java
@@ -268,4 +268,65 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 		// then
 		resultActions.andExpect(status().isBadRequest());
 	}
+
+	@Test
+	@WithCustomUser(email = "test@test.com")
+	@DisplayName("AI 이미지 생성권 남은 횟수 조회 - 성공")
+	void getRemainingGenerations_Success() throws Exception {
+		// given
+		UserEntity user = getCurrentUserWithCoin(0L);
+		PostEntity post = createTestPost(user);
+		
+		// AI 이미지 권한 생성
+		AiImagePermissionEntity permission = AiImagePermissionEntity.builder()
+			.userId(user.getId())
+			.postId(post.getId())
+			.remainingGenerations(15)
+			.build();
+		aiImagePermissionRepository.save(permission);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/ai/image-permissions/remaining-generations")
+			.param("postId", post.getId().toString()));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.aiImagePermissionId").value(permission.getId()))
+			.andExpect(jsonPath("$.remainingGenerations").value(15));
+	}
+
+	@Test
+	@WithCustomUser(email = "test@test.com")
+	@DisplayName("AI 이미지 생성권 남은 횟수 조회 - 구매한 이력이 없음")
+	void getRemainingGenerations_PermissionNotFound() throws Exception {
+		// given
+		UserEntity user = getCurrentUserWithCoin(0L);
+		PostEntity post = createTestPost(user);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/ai/image-permissions/remaining-generations")
+			.param("postId", post.getId().toString()));
+
+		// then
+		resultActions.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value(AI_IMAGE_PERMISSION_NOT_FOUND.getCode()))
+			.andExpect(jsonPath("$.message").value(AI_IMAGE_PERMISSION_NOT_FOUND.getMessage()));
+	}
+
+	@Test
+	@WithCustomUser(email = "test@test.com")
+	@DisplayName("AI 이미지 생성권 남은 횟수 조회 - 존재하지 않는 포스트")
+	void getRemainingGenerations_PostNotExist() throws Exception {
+		// given
+		Long nonExistentPostId = 9999L;
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/ai/image-permissions/remaining-generations")
+			.param("postId", nonExistentPostId.toString()));
+
+		// then
+		resultActions.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value(AI_IMAGE_PERMISSION_NOT_FOUND.getCode()))
+			.andExpect(jsonPath("$.message").value(AI_IMAGE_PERMISSION_NOT_FOUND.getMessage()));
+	}
 }


### PR DESCRIPTION
## 개요
특정 포스트에 대한 사용자의 AI 이미지 생성권 남은 횟수를 조회할 수 있는 API를 구현했습니다.

## 구현 내용

### API 추가
- **엔드포인트**: `GET /api/ai/image-permissions/remaining-generations`
- **파라미터**: `postId` (쿼리 파라미터)
- **인증**: `@CurrentUser` 사용하여 현재 로그인한 유저의 권한 조회
- **응답**: `GetRemainingGenerationsResponse` (aiImagePermissionId, remainingGenerations)

### Service Layer
- `AiImagePermissionService.getRemainingGenerations()` 메서드 추가
- `@Transactional(readOnly = true)` 적용으로 읽기 전용 트랜잭션 처리
- 권한이 없을 경우 `AI_IMAGE_PERMISSION_NOT_FOUND` 예외 발생


### Swagger 문서화
- API 문서 추가 (요약, 설명, 예외 응답 명시)
- 구매한 이력이 없을 경우 AI-004 에러 발생 안내

## 테스트 내용

### 통합 테스트 추가 (AiImagePermissionControllerIntegrationTest)
1. **정상 조회 테스트** (`getRemainingGenerations_Success`)
   - 권한이 있는 경우 정상적으로 남은 생성 횟수 반환

2. **권한 없음 테스트** (`getRemainingGenerations_PermissionNotFound`)
   - 구매한 이력이 없을 경우 404 에러와 적절한 에러 코드 반환

3. **존재하지 않는 포스트 테스트** (`getRemainingGenerations_PostNotExist`)
   - 존재하지 않는 포스트 ID로 조회 시 404 에러 반환

### 테스트 결과
- 모든 기존 테스트 및 새로운 테스트 통과
- 전체 빌드 성공

## 관련 이슈
Closes #157

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 남은 이미지 생성 횟수 조회 엔드포인트 추가: GET /api/ai/image-permissions/remaining-generations?postId=... (현재 사용자 기준)
  - 응답 스키마 단순화: aiImagePermissionId, remainingGenerations만 반환
- 문서
  - OpenAPI에 404 오류 사례(사용자/권한 없음)와 새로운 응답 스키마 반영
- 테스트
  - 성공 / 권한 없음 / 게시물 없음 시나리오에 대한 통합 테스트 추가
- 제거
  - 목록 응답 타입(AiImagePermissionListResponse) 삭제 (관련 API 형식 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->