### PR TITLE
feat: SSE를 통한 AI 이미지 실시간 응답 기능 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/dto/CreatedAiImageMessageDto.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/dto/CreatedAiImageMessageDto.java
@@ -4,7 +4,6 @@ import hanium.modic.backend.domain.image.domain.ImageExtension;
 
 public record CreatedAiImageMessageDto(
 	String requestId,
-	String imageUrl,
 	String imagePath,
 	String fullImageName,
 	String imageName,

--- a/src/main/java/hanium/modic/backend/domain/ai/dto/ImageResultMessageDto.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/dto/ImageResultMessageDto.java
@@ -1,0 +1,7 @@
+package hanium.modic.backend.domain.ai.dto;
+
+public record ImageResultMessageDto(
+	String requestId,
+	String imageUrl
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
@@ -11,9 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
 import hanium.modic.backend.domain.ai.domain.CreatedAiImageEntity;
 import hanium.modic.backend.domain.ai.dto.CreatedAiImageMessageDto;
+import hanium.modic.backend.domain.ai.dto.ImageResultMessageDto;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
 import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
+import hanium.modic.backend.domain.ai.service.CreatedAiImageService;
+import hanium.modic.backend.domain.ai.service.EmitterService;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,8 +25,11 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class AiImageCreatedListener {
+
 	private final CreatedAiImageRepository createdAiImageRepository;
 	private final AiRequestRepository aiRequestRepository;
+	private final EmitterService emitterService;
+	private final CreatedAiImageService createdAiImageService;
 
 	@Transactional
 	@RabbitListener(queues = AI_IMAGE_CREATED_QUEUE)
@@ -50,5 +56,13 @@ public class AiImageCreatedListener {
 		createdAiImageRepository.save(created);
 
 		aiRequest.updateStatus(AiImageStatus.DONE);
+
+		String imageUrl = createdAiImageService.createImageGetUrl(created.getId());
+
+		// 클라이언트는 이미지 생성 요청 후 SSE 연결을 맺어, SSE 연결 객체가 아래 Service에 존재한다. 이를 사용해 이미지를 응답한다.
+		emitterService.sendToClient(
+			message.requestId(),
+			new ImageResultMessageDto(message.requestId(), imageUrl)
+		);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/service/EmitterService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/EmitterService.java
@@ -1,0 +1,46 @@
+package hanium.modic.backend.domain.ai.service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class EmitterService {
+
+	/**
+	 * SseEmitter 관리 맵
+	 * 해당 맵은 단일 서버를 가정한 map이며, 멀티 서버 환경에서는 Redis등을 활용한 별도의 관리가 필요
+	 */
+	private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+	// requestId와 SseEmitter를 ,emitter관리 맵에 저장
+	public void addEmitter(String requestId, SseEmitter emitter) {
+		emitters.put(requestId, emitter);
+	}
+
+	// requestId에 해당하는 SseEmitter를 맵에서 제거
+	public void removeEmitter(String requestId) {
+		emitters.remove(requestId);
+	}
+
+	// emitters에서 연결객체를 찾아 해당 클라이언트에게 데이터를 SSE로 전송, 전송 후 연결 삭제
+	public void sendToClient(String requestId, Object data) {
+		SseEmitter emitter = emitters.get(requestId);
+		if (emitter != null) {
+			try {
+				emitter.send(SseEmitter.event()
+					.id(requestId)
+					.name("image")
+					.data(data));
+				emitter.complete();
+				emitters.remove(requestId);
+			} catch (IOException e) {
+				emitter.completeWithError(e);
+				emitters.remove(requestId);
+			}
+		}
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
 import hanium.modic.backend.common.response.AppResponse;
@@ -18,6 +19,7 @@ import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
+import hanium.modic.backend.domain.ai.service.EmitterService;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
@@ -45,6 +47,7 @@ public class AiImageController {
 
 	private final AiImageService aiImageService;
 	private final AiImageGenerationService aiImageGenerationService;
+	private final EmitterService emitterService;
 
 	// AI 요청 이미지 저장 URL 생성
 	@PostMapping("/save-url")
@@ -74,6 +77,7 @@ public class AiImageController {
 		summary = "AI 이미지 생성 요청",
 		description = """
 			사용자가 업로드한 이미지를 기반으로 AI 이미지 생성을 요청합니다. 참조 이미지(Post ID)와 함께 전송되며, 요청 ID를 반환합니다.
+			이미지 생성 요청 직후 SSE 구독을 통해 생성 상태를 실시간으로 확인할 수 있습니다.
 			생성권을 구매한 적이 없으면 AI-004
 			생성권을 구매했으나 다 사용했으면 AI-007
 			""",
@@ -91,8 +95,8 @@ public class AiImageController {
 	)
 	public ResponseEntity<AppResponse<RequestAiImageGenerationResponse>> requestAiImageGeneration(
 		@RequestBody @Valid AiImageGenerationRequest request,
-		@CurrentUser UserEntity userEntity) {
-
+		@CurrentUser UserEntity userEntity
+	) {
 		RequestAiImageGenerationResponse response = aiImageGenerationService.processImageGeneration(
 			request.imageUsagePurpose(),
 			request.fileName(),
@@ -103,6 +107,26 @@ public class AiImageController {
 
 		return ResponseEntity.status(CREATED)
 			.body(AppResponse.created(response));
+	}
+
+	// AI 이미지 생성 상태 실시간 구독 (SSE)
+	@GetMapping("/sse/{requestId}")
+	@Operation(
+		summary = "AI 이미지 생성 상태 실시간 구독 (SSE)",
+		description = """
+			AI 이미지 생성 요청 후, 해당 요청 ID로 SSE 구독을 시작해야 실시간으로 이미지를 받을 수 있습니다.
+			서버는 이미지 생성 완료 시 SSE를 통해 이미지를 전송하고 서버연결을 끊습니다.
+			"""
+	)
+	public SseEmitter subscribe(@PathVariable String requestId) {
+		SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+		emitterService.addEmitter(requestId, emitter);
+
+		emitter.onCompletion(() -> emitterService.removeEmitter(requestId));
+		emitter.onTimeout(() -> emitterService.removeEmitter(requestId));
+		emitter.onError((e) -> emitterService.removeEmitter(requestId));
+
+		return emitter;
 	}
 
 	// AI 요청 이미지 URL 조회
@@ -118,7 +142,8 @@ public class AiImageController {
 	)
 	public ResponseEntity<AppResponse<CreateImageGetUrlResponse>> createImageGetUrl(
 		@PathVariable Long imageId,
-		@CurrentUser UserEntity userEntity) {
+		@CurrentUser UserEntity userEntity
+	) {
 		String imageGetUrl = aiImageGenerationService.createImageGetUrl(imageId, userEntity.getId());
 
 		return ResponseEntity.ok(AppResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
@@ -137,7 +162,8 @@ public class AiImageController {
 	)
 	public ResponseEntity<AppResponse<CreateImageGetUrlResponse>> createAiImageGetUrl(
 		@PathVariable String requestId,
-		@CurrentUser UserEntity userEntity) {
+		@CurrentUser UserEntity userEntity
+	) {
 		String imageGetUrl = aiImageGenerationService.createAiImageGetUrl(requestId, userEntity.getId());
 
 		return ResponseEntity.ok(AppResponse.ok(new CreateImageGetUrlResponse(imageGetUrl)));
@@ -155,7 +181,8 @@ public class AiImageController {
 	)
 	public ResponseEntity<AppResponse<AiRequestStatusResponse>> getAiRequestStatus(
 		@PathVariable String requestId,
-		@CurrentUser UserEntity userEntity) {
+		@CurrentUser UserEntity userEntity
+	) {
 		AiImageStatus status = aiImageGenerationService.getAiImageStatus(userEntity.getId(), requestId);
 		return ResponseEntity.ok(AppResponse.ok(new AiRequestStatusResponse(status)));
 	}
@@ -169,8 +196,8 @@ public class AiImageController {
 	public ResponseEntity<AppResponse<PageResponse<MyGeneratedAiImageResponse>>> getMyGeneratedImages(
 		@RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
 		@RequestParam(defaultValue = "10") @Min(value = 10, message = "페이지 크기는 10 이상이어야 합니다.") @Max(value = 20, message = "페이지 크기는 20 이하여야 합니다.") int size,
-		@CurrentUser UserEntity userEntity) {
-
+		@CurrentUser UserEntity userEntity
+	) {
 		PageResponse<MyGeneratedAiImageResponse> response = aiImageGenerationService.getMyGeneratedImages(
 			userEntity.getId(), page, size);
 

--- a/src/main/java/hanium/modic/backend/web/ai/dto/response/RequestAiImageGenerationResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/dto/response/RequestAiImageGenerationResponse.java
@@ -6,7 +6,6 @@ public record RequestAiImageGenerationResponse(
 	Long imageId,
 	String requestId
 ) {
-
 	public static RequestAiImageGenerationResponse from(AiRequestEntity aiRequestEntity) {
 		return new RequestAiImageGenerationResponse(
 			aiRequestEntity.getId(),

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
@@ -31,6 +31,7 @@ import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
+import hanium.modic.backend.domain.ai.service.EmitterService;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
 import hanium.modic.backend.web.ai.dto.response.MyGeneratedAiImageResponse;
 import hanium.modic.backend.web.common.image.dto.request.CreateImageSaveUrlRequest;
@@ -47,6 +48,8 @@ class AiImageControllerTest extends BaseControllerTest {
 	private MockMvc mockMvc;
 	@Autowired
 	private ObjectMapper objectMapper;
+	@MockitoBean
+	private EmitterService emitterService;
 
 	@ParameterizedTest
 	@DisplayName("AI 요청 이미지 Url 생성 실패 - 필수값 누락 시 400 응답")


### PR DESCRIPTION
## 개요
AI 이미지 생성 요청 후 폴링 방식 대신 Server-Sent Events(SSE)를 통해 실시간으로 이미지 생성 결과를 클라이언트에게 전달하는 기능을 구현했습니다.

## 구현 내용

### 1. SSE 기반 실시간 응답 시스템
- `EmitterService`: SSE 연결 관리 및 클라이언트 응답 처리
- `AiImageController.subscribe()`: SSE 구독 엔드포인트 추가 (`GET /sse/{requestId}`)
- 클라이언트가 AI 이미지 생성 요청 후 즉시 SSE 구독을 통해 실시간 결과 수신 가능

### 2. 메시지 큐 리스너 개선
- `AiImageCreatedListener`: 이미지 생성 완료 시 SSE를 통한 자동 응답 추가
- `ImageResultMessageDto`: SSE 응답용 별도 DTO 생성
- `CreatedAiImageMessageDto`: 불필요한 `imageUrl` 필드 제거

### 3. API 문서 업데이트
- Swagger 문서에 SSE 구독 방식 안내 추가
- AI 이미지 생성 요청 API 설명에 SSE 사용법 명시

## 동작 플로우
1. 클라이언트가 AI 이미지 생성 요청 (`POST /ai-image/generation`)
2. 서버가 `requestId` 반환
3. 클라이언트가 해당 `requestId`로 SSE 구독 시작 (`GET /sse/{requestId}`)
4. RabbitMQ를 통해 이미지 생성 완료 메시지 수신
5. `AiImageCreatedListener`에서 SSE를 통해 클라이언트에게 이미지 URL 전송
6. SSE 연결 자동 종료

## 테스트 내용
- `AiImageControllerTest`: `EmitterService` 모킹 추가
- 기존 테스트 케이스들이 정상 동작하는지 확인

## 부족한 점 및 향후 개선사항
- **스레드 풀 고갈 문제**: SSE 연결이 증가할 경우 Tomcat 스레드 풀이 고갈될 수 있음
- **단일 서버 제한**: `ConcurrentHashMap`을 사용한 인메모리 관리로 멀티 서버 환경에서 제한적
- **향후 개선 방안**: MSA 분리 및 WebFlux 도입을 통한 비동기 처리로 스레드 효율성 개선 예정

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 실시간 이미지 생성 상태/결과 스트리밍(SSE) 지원 추가: /api/ai/images/sse/{requestId} 구독으로 생성 완료 시 이미지 URL을 즉시 수신.
- 변경 사항
  - 응답 메시지 구조 조정: 생성 이벤트에서 imageUrl가 제외되고, 결과 전용 메시지로 이미지 URL이 전달됨(클라이언트는 SSE를 통해 수신).
- 문서
  - 이미지 생성 요청 직후 SSE 기반 실시간 모니터링 흐름 안내 추가.
- 테스트
  - 컨트롤러 테스트에 SSE 관련 의존성 모킹 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->