### PR TITLE
feat: addEmitter에서 유저검증 로직 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/listener/AiImageCreatedListener.java
@@ -16,7 +16,7 @@ import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
 import hanium.modic.backend.domain.ai.repository.CreatedAiImageRepository;
 import hanium.modic.backend.domain.ai.service.CreatedAiImageService;
-import hanium.modic.backend.domain.ai.service.EmitterService;
+import hanium.modic.backend.domain.ai.service.AiRequestEmitterService;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +28,7 @@ public class AiImageCreatedListener {
 
 	private final CreatedAiImageRepository createdAiImageRepository;
 	private final AiRequestRepository aiRequestRepository;
-	private final EmitterService emitterService;
+	private final AiRequestEmitterService aiRequestEmitterService;
 	private final CreatedAiImageService createdAiImageService;
 
 	@Transactional
@@ -60,7 +60,7 @@ public class AiImageCreatedListener {
 		String imageUrl = createdAiImageService.createImageGetUrl(created.getId());
 
 		// 클라이언트는 이미지 생성 요청 후 SSE 연결을 맺어, SSE 연결 객체가 아래 Service에 존재한다. 이를 사용해 이미지를 응답한다.
-		emitterService.sendToClient(
+		aiRequestEmitterService.sendToClient(
 			message.requestId(),
 			new ImageResultMessageDto(message.requestId(), imageUrl)
 		);

--- a/src/main/java/hanium/modic/backend/domain/ai/repository/AiRequestRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/repository/AiRequestRepository.java
@@ -18,6 +18,8 @@ public interface AiRequestRepository extends JpaRepository<AiRequestEntity, Long
 
 	boolean existsByRequestIdAndUserId(String requestId, Long userId);
 
+	boolean existsByRequestId(String requestId);
+
 	// 사용자별 AI 요청 조회 (상태별, 페이지네이션, 최신순 정렬)
 	Page<AiRequestEntity> findAllByUserIdAndStatusOrderByRequestIdDesc(Long userId, AiImageStatus status,
 		Pageable pageable);

--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiRequestEmitterService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiRequestEmitterService.java
@@ -1,14 +1,26 @@
 package hanium.modic.backend.domain.ai.service;
 
+import static hanium.modic.backend.common.error.ErrorCode.*;
+
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.domain.AiRequestEntity;
+import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
+import lombok.RequiredArgsConstructor;
+
 @Service
-public class EmitterService {
+@RequiredArgsConstructor
+public class AiRequestEmitterService {
+
+	private final AiRequestRepository aiRequestRepository;
 
 	/**
 	 * SseEmitter 관리 맵
@@ -17,7 +29,14 @@ public class EmitterService {
 	private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
 	// requestId와 SseEmitter를 ,emitter관리 맵에 저장
-	public void addEmitter(String requestId, SseEmitter emitter) {
+	public void addEmitter(Long userId, String requestId, SseEmitter emitter) {
+		AiRequestEntity aiRequest = aiRequestRepository.findByRequestId(requestId)
+			.orElseThrow(() -> new AppException(ErrorCode.AI_REQUEST_NOT_FOUND));
+
+		if (!Objects.equals(aiRequest.getUserId(), userId)) {
+			throw new AppException(USER_ROLE_EXCEPTION);
+		}
+
 		emitters.put(requestId, emitter);
 	}
 

--- a/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/controller/AiImageController.java
@@ -19,7 +19,7 @@ import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
-import hanium.modic.backend.domain.ai.service.EmitterService;
+import hanium.modic.backend.domain.ai.service.AiRequestEmitterService;
 import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
@@ -47,7 +47,7 @@ public class AiImageController {
 
 	private final AiImageService aiImageService;
 	private final AiImageGenerationService aiImageGenerationService;
-	private final EmitterService emitterService;
+	private final AiRequestEmitterService aiRequestEmitterService;
 
 	// AI 요청 이미지 저장 URL 생성
 	@PostMapping("/save-url")
@@ -118,13 +118,16 @@ public class AiImageController {
 			서버는 이미지 생성 완료 시 SSE를 통해 이미지를 전송하고 서버연결을 끊습니다.
 			"""
 	)
-	public SseEmitter subscribe(@PathVariable String requestId) {
+	public SseEmitter subscribe(
+		@PathVariable String requestId,
+		@CurrentUser UserEntity userEntity
+	) {
 		SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
-		emitterService.addEmitter(requestId, emitter);
+		aiRequestEmitterService.addEmitter(userEntity.getId(), requestId, emitter);
 
-		emitter.onCompletion(() -> emitterService.removeEmitter(requestId));
-		emitter.onTimeout(() -> emitterService.removeEmitter(requestId));
-		emitter.onError((e) -> emitterService.removeEmitter(requestId));
+		emitter.onCompletion(() -> aiRequestEmitterService.removeEmitter(requestId));
+		emitter.onTimeout(() -> aiRequestEmitterService.removeEmitter(requestId));
+		emitter.onError((e) -> aiRequestEmitterService.removeEmitter(requestId));
 
 		return emitter;
 	}

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImageControllerTest.java
@@ -31,7 +31,7 @@ import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.service.AiImageGenerationService;
 import hanium.modic.backend.domain.ai.service.AiImageService;
-import hanium.modic.backend.domain.ai.service.EmitterService;
+import hanium.modic.backend.domain.ai.service.AiRequestEmitterService;
 import hanium.modic.backend.web.ai.dto.request.AiImageGenerationRequest;
 import hanium.modic.backend.web.ai.dto.response.MyGeneratedAiImageResponse;
 import hanium.modic.backend.web.common.image.dto.request.CreateImageSaveUrlRequest;
@@ -49,7 +49,7 @@ class AiImageControllerTest extends BaseControllerTest {
 	@Autowired
 	private ObjectMapper objectMapper;
 	@MockitoBean
-	private EmitterService emitterService;
+	private AiRequestEmitterService aiRequestEmitterService;
 
 	@ParameterizedTest
 	@DisplayName("AI 요청 이미지 Url 생성 실패 - 필수값 누락 시 400 응답")


### PR DESCRIPTION
## 개요
- close #160 

## 작업사항
sseEmtter 서비스의 addEmitter에 유저검증 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - AI 이미지 SSE 구독 시 로그인 사용자 정보가 필요합니다. 요청 ID와 사용자 일치 여부를 검증하여 불일치 시 접근이 거부됩니다.
  - 존재하지 않는 요청에 대해 즉시 오류가 반환되며, 구독 수명주기(완료/타임아웃/오류)에서도 일관된 정리 처리가 이루어집니다.
- 리팩터링
  - 이벤트 전송 관리 컴포넌트를 교체하여 의존성을 정리하고 안정성을 향상했습니다.
- 테스트
  - 컨트롤러 테스트를 새로운 전송 관리 컴포넌트에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->