### PR TITLE
feat: 포스트 관련 s3이미지 삭제는 soft로 변경

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/service/AiImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/AiImageService.java
@@ -12,7 +12,6 @@ import hanium.modic.backend.domain.ai.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.repository.AiRequestRepository;
 import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
-import hanium.modic.backend.domain.image.dto.CreateImageSaveUrlDto;
 import hanium.modic.backend.domain.image.dto.ParsedImageName;
 import hanium.modic.backend.domain.image.service.ImageService;
 import hanium.modic.backend.domain.image.service.ImageValidationService;
@@ -47,7 +46,7 @@ public class AiImageService extends ImageService {
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
 
 		aiRequestRepository.delete(image);
-		imageUtil.deleteImage(image.getImagePath());
+		// s3 이미지는 삭제 x
 	}
 
 	// AI 요청 이미지 저장
@@ -74,15 +73,6 @@ public class AiImageService extends ImageService {
 				.userId(userId)
 				.postId(postId)
 				.build());
-	}
-
-	// 요청 상태 업데이트
-	@Transactional
-	public void updateRequestStatus(String requestId, AiImageStatus status) {
-		AiRequestEntity request = aiRequestRepository.findByRequestId(requestId)
-			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
-
-		request.updateStatus(status);
 	}
 
 	// 이미지 경로가 중복되면 에러 (요청 이미지)

--- a/src/main/java/hanium/modic/backend/domain/ai/service/CreatedAiImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/service/CreatedAiImageService.java
@@ -31,6 +31,6 @@ public class CreatedAiImageService {
 			.orElseThrow(() -> new AppException(ErrorCode.CREATED_AI_IMAGE_NOT_FOUND));
 
 		createdAiImageRepository.delete(createdAiImageEntity);
-		imageUtil.deleteImage(createdAiImageEntity.getImagePath());
+		// s3 이미지는 삭제 x
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
@@ -72,14 +72,9 @@ public class AiDerivedPostService {
 
 		PostEntity savedPost = postEntityRepository.save(aiDerivedPost);
 
-		// AI 이미지를 포스트 이미지로 별도 저장
-		String imagePath = imageUtil.copyImage(
-			createdAiImage.getImagePath(),
-			ImagePrefix.POST
-		);
-
+		// 파생 포스트 이미지 저장
 		PostImageEntity postImage = PostImageEntity.builder()
-			.imagePath(imagePath)
+			.imagePath(createdAiImage.getImagePath()) // 기존 AI 이미지 경로 사용, AI 이미지 Entity 삭제되어도 S3는 삭제 x
 			.fullImageName(createdAiImage.getFullImageName())
 			.imageName(createdAiImage.getImageName())
 			.extension(createdAiImage.getExtension())

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostImageService.java
@@ -45,7 +45,7 @@ public class PostImageService extends ImageService {
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
 
 		postImageEntityRepository.delete(image);
-		imageUtil.deleteImage(image.getImagePath()); // s3는 비동기로 삭제, 트랜잭션 무관
+		// s3 이미지는 삭제 x
 	}
 
 	// 여러 이미지 삭제
@@ -63,7 +63,7 @@ public class PostImageService extends ImageService {
 			.toList();
 
 		postImageEntityRepository.deleteAllByIds(ids);
-		imageUtil.deleteImages(imagePaths); // s3는 비동기로 삭제, 트랜잭션 무관
+		// s3 이미지는 삭제 x
 	}
 
 	// 원격 저장소에 이미지 저장 확인 후 DB에 저장

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiDerivedPostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiDerivedPostServiceTest.java
@@ -76,7 +76,6 @@ class AiDerivedPostServiceTest {
 
 		when(createdAiImageRepository.findById(createdAiImageId)).thenReturn(Optional.of(mockAiImage));
 		when(postEntityRepository.save(any(PostEntity.class))).thenReturn(mockSavedPost);
-		when(imageUtil.copyImage(anyString(), eq(ImagePrefix.POST))).thenReturn("copied-image-path");
 		doNothing().when(asyncPostStatisticsService).initializeStatistics(anyLong());
 
 		// when
@@ -104,7 +103,7 @@ class AiDerivedPostServiceTest {
 		ArgumentCaptor<PostImageEntity> imageCaptor = ArgumentCaptor.forClass(PostImageEntity.class);
 		verify(postImageEntityRepository, times(1)).save(imageCaptor.capture());
 		PostImageEntity savedImage = imageCaptor.getValue();
-		assertThat(savedImage.getImagePath()).isEqualTo("copied-image-path");
+		assertThat(savedImage.getImagePath()).isEqualTo(mockAiImage.getImagePath()); // s3 이미지는 같은 것을 사용
 		assertThat(savedImage.getFullImageName()).isEqualTo(mockAiImage.getFullImageName());
 		assertThat(savedImage.getImageName()).isEqualTo(mockAiImage.getImageName());
 		assertThat(savedImage.getExtension()).isEqualTo(mockAiImage.getExtension());

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostImageServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostImageServiceTest.java
@@ -102,7 +102,6 @@ class PostImageServiceTest {
 
 		when(postImageEntityRepository.findById(imageId)).thenReturn(Optional.of(postImageEntity));
 		doNothing().when(postImageEntityRepository).delete(postImageEntity);
-		doNothing().when(imageUtil).deleteImage(imagePath);
 
 		// when
 		postImageService.deleteImage(imageId);
@@ -110,7 +109,7 @@ class PostImageServiceTest {
 		// then
 		verify(postImageEntityRepository, times(1)).findById(imageId);
 		verify(postImageEntityRepository, times(1)).delete(postImageEntity);
-		verify(imageUtil, times(1)).deleteImage(imagePath);
+		verify(imageUtil, never()).deleteImage(imagePath); // S3 이미지는 삭제하지 않음
 	}
 
 	@Test
@@ -412,13 +411,12 @@ class PostImageServiceTest {
 		}
 
 		doNothing().when(postImageEntityRepository).deleteAllByIds(imageIds);
-		doNothing().when(imageUtil).deleteImages(imagePaths);
 
 		// when
 		postImageService.deleteImages(images);
 
 		// then
 		verify(postImageEntityRepository, times(1)).deleteAllByIds(imageIds);
-		verify(imageUtil, times(1)).deleteImages(imagePaths);
+		verify(imageUtil, never()).deleteImages(imagePaths); // S3 이미지는 삭제하지 않음
 	}
 }


### PR DESCRIPTION
## 개요
- close #163 

## 작업사항
포스트 자체의 엔티티 구조를 변경하는 것을 고려하였으나, 비용이 너무 커
당장은 포스트 관련 모든 s3 이미지 삭제를 soft 삭제로 변경하였다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 이미지 삭제 시 외부 저장소의 파일은 유지되고, 앱 내 기록만 삭제되도록 동작 변경(삭제 속도 및 안정성 개선).
  - AI 생성 이미지를 활용한 파생 게시물 생성 시 이미지 복사 없이 원본 경로를 재사용하여 중복 저장을 줄이고 게시물 생성 속도를 개선.
  - 게시물 이미지에 용도 정보가 반영되어 관리 일관성 향상.

- **Tests**
  - 이미지 삭제 및 파생 게시물 생성 로직 변경에 맞춰 테스트 케이스 업데이트(외부 파일 삭제 호출 검증 제거, 경로 재사용 검증 추가).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->