### PR TITLE
✨ feat: GetSimplePostsResponse에 다중 이미지 지원 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -308,18 +307,20 @@ public class PostService {
 		// 배치로 모든 포스트 이미지 조회 (N+1 문제 해결)
 		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(postIds);
 
-		// 포스트ID별로 첫 번째 이미지 URL을 찾는 Map 생성
-		Map<Long, String> firstImageByPostId = new LinkedHashMap<>();
-		for (PostImageEntity image : allPostImages) {
-			firstImageByPostId.computeIfAbsent(
-				image.getPostId(),
-				pid -> imageUtil.createImageGetUrl(image.getImagePath())
-			);
-		}
+		// 포스트ID별로 그룹화
+		Map<Long, List<PostImageEntity>> imagesByPostId = allPostImages.stream()
+			.collect(Collectors.groupingBy(PostImageEntity::getPostId));
 
 		return posts.map(post -> {
-			String firstImageUrl = firstImageByPostId.get(post.getId());
-			return new GetSimplePostsResponse(post.getId(), firstImageUrl);
+			List<GetSimplePostsResponse.ImageDto> postImages = imagesByPostId.getOrDefault(post.getId(), List.of())
+				.stream()
+				.map(image -> new GetSimplePostsResponse.ImageDto(
+					imageUtil.createImageGetUrl(image.getImagePath()),
+					image.getId()
+				))
+				.toList();
+
+			return new GetSimplePostsResponse(post.getId(), postImages);
 		});
 	}
 

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetSimplePostsResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetSimplePostsResponse.java
@@ -1,7 +1,19 @@
 package hanium.modic.backend.web.post.dto.response;
 
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public record GetSimplePostsResponse(
 	Long postId,
-	String imageUrl
+	List<ImageDto> images
 ) {
+	@Getter
+	@AllArgsConstructor(access = AccessLevel.PUBLIC)
+	public static class ImageDto {
+		private String imageUrl;
+		private Long imageId;
+	}
 }

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -417,8 +417,15 @@ class PostServiceTest {
 		Page<PostEntity> mockPostPage = new PageImpl<>(mockPosts,
 			PageRequest.of(page, size), mockPosts.size());
 
-		List<PostImageEntity> mockImagesPost1 = ImageFactory.createMockPostImages(mockPosts.get(0), 2);
-		List<PostImageEntity> mockImagesPost2 = ImageFactory.createMockPostImages(mockPosts.get(1), 3);
+		List<PostImageEntity> mockImagesPost1 = List.of(
+			ImageFactory.createMockPostImageWithId(mockPosts.get(0), 1L),
+			ImageFactory.createMockPostImageWithId(mockPosts.get(0), 2L)
+		);
+		List<PostImageEntity> mockImagesPost2 = List.of(
+			ImageFactory.createMockPostImageWithId(mockPosts.get(1), 3L),
+			ImageFactory.createMockPostImageWithId(mockPosts.get(1), 4L),
+			ImageFactory.createMockPostImageWithId(mockPosts.get(1), 5L)
+		);
 		List<PostImageEntity> allMockImages = new ArrayList<>();
 		allMockImages.addAll(mockImagesPost1);
 		allMockImages.addAll(mockImagesPost2);
@@ -438,11 +445,15 @@ class PostServiceTest {
 
 		GetSimplePostsResponse firstPost = result.getContent().get(0);
 		assertThat(firstPost.postId()).isEqualTo(1L);
-		assertThat(firstPost.imageUrl()).isNotNull();
+		assertThat(firstPost.images()).isNotEmpty();
+		assertThat(firstPost.images().get(0).getImageUrl()).isNotNull();
+		assertThat(firstPost.images().get(0).getImageId()).isNotNull();
 
 		GetSimplePostsResponse secondPost = result.getContent().get(1);
 		assertThat(secondPost.postId()).isEqualTo(2L);
-		assertThat(secondPost.imageUrl()).isNotNull();
+		assertThat(secondPost.images()).isNotEmpty();
+		assertThat(secondPost.images().get(0).getImageUrl()).isNotNull();
+		assertThat(secondPost.images().get(0).getImageId()).isNotNull();
 
 		verify(postEntityRepository).findAllByUserId(userId, PageRequest.of(page, size));
 		verify(postImageEntityRepository).findAllByPostIdIn(Arrays.asList(1L, 2L));
@@ -500,7 +511,7 @@ class PostServiceTest {
 
 		GetSimplePostsResponse response = result.getContent().get(0);
 		assertThat(response.postId()).isEqualTo(1L);
-		assertThat(response.imageUrl()).isNull();
+		assertThat(response.images()).isEmpty();
 
 		verify(postEntityRepository).findAllByUserId(userId, PageRequest.of(page, size));
 		verify(postImageEntityRepository).findAllByPostIdIn(Arrays.asList(1L));


### PR DESCRIPTION
## Summary
- GetSimplePostsResponse를 단일 이미지 URL에서 다중 이미지 리스트로 변경
- 각 이미지에 imageId와 imageUrl을 포함하는 ImageDto 구조 도입  
- PostService에서 N+1 문제 방지하면서 포스트별 모든 이미지를 그룹화하여 반환

## Test plan
- [x] 기존 단위 테스트가 새로운 응답 구조에 맞게 업데이트됨
- [x] PostService의 getSimplePostsByUserId 메서드 테스트 통과
- [x] 이미지가 없는 포스트에 대한 빈 리스트 반환 테스트 통과
- [ ] 실제 API 호출로 다중 이미지 응답 구조 검증
- [ ] 프론트엔드와의 연동 테스트 필요

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 게시물 간략 목록에서 단일 대표 이미지 대신 여러 이미지를 함께 제공합니다.
  * 이미지별 식별자가 포함되어 이미지 선택·관리 등 연동이 용이해집니다.
  * 이미지가 없는 게시물은 비어 있는 목록으로 표시됩니다.

* 테스트
  * 다중 이미지 시나리오를 반영해 테스트 케이스를 업데이트하고 검증 범위를 확장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->