### PR TITLE
AI 채팅 기능 리팩토링

### DIFF
--- a/src/main/java/hanium/modic/backend/common/config/Resilience4jConfig.java
+++ b/src/main/java/hanium/modic/backend/common/config/Resilience4jConfig.java
@@ -22,6 +22,7 @@ public class Resilience4jConfig {
 			.recordException(e ->
 				e instanceof java.io.IOException             // SocketTime, ConnectTimeout, IOException 발생 시 실패로 간주
 					|| e instanceof AppException
+					|| e instanceof org.springframework.web.reactive.function.client.WebClientException
 			)
 			.recordResult(response -> {
 				if (response == null)

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
@@ -68,7 +68,7 @@ public class AiServerService {
 		// AI 요청 처리
 		try {
 			// AiAgent를 통해 해당 메시지 채팅응답용인지, 이미지 생성용인지 구분
-			RequestCategory requestCategory = classifyRequestCategory(chatMessage.getTextContent());
+			RequestCategory requestCategory = classifyRequestCategory(chatMessage.getTextContent(), chatMessage.hasImage());
 			log.info("Classified request category: {}", requestCategory);
 
 			if (requestCategory == RequestCategory.CHAT_GENERATION) {
@@ -87,17 +87,31 @@ public class AiServerService {
 	}
 
 	// AiAgent를 통해 해당 메시지 채팅응답용인지, 이미지 생성용인지 구분 후 처리
-	private RequestCategory classifyRequestCategory(String message) {
-
+	private RequestCategory classifyRequestCategory(String message, boolean hasImage) {
 		String systemPrompt = """
-			You are a classifier.
-			Given a user input, decide whether it is:
-			- "IMAGE_GENERATION" if the user is asking to generate an image
-			- "CHAT_GENERATION" if it is a normal conversation
-			Only return one of the two exact words.
-			""";
+        You are a classifier.
+        The user can provide both text and/or an image.
+        
+        Decide the intent:
+        - "IMAGE_GENERATION": 
+            * If the user only provides an image without text.
+            * If the text is asking to generate, modify, or create a new image.
+            * If the user provides both image and text, but the text still indicates a new image should be generated.
+        - "CHAT_GENERATION": 
+            * If the user only wants a conversational response.
+            * If the user provides both image and text, but the text indicates normal chat about the image, not a request for new generation.
 
-		String category = aiChatService.prompt(systemPrompt, message);
+        Only return one of the two exact words.
+        """;
+
+		// 메시지가 null 또는 빈 문자열일 수 있으니 기본값 처리
+		String safeMessage = (message == null) ? "" : message;
+
+		// hasImage 여부도 프롬프트에 포함
+		String input = String.format("User input: \"%s\"%nImage provided: %s",
+			safeMessage, hasImage ? "YES" : "NO");
+
+		String category = aiChatService.prompt(systemPrompt, input).trim();
 		return RequestCategory.valueOf(category);
 	}
 

--- a/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
@@ -152,6 +152,19 @@ public class AiChatController {
 		description = """
 			AI 이미지 생성 요청 후, 해당 요청 ID로 SSE 구독을 시작해야 실시간으로 이미지를 받을 수 있습니다.
 			서버는 이미지 생성 완료 시 SSE를 통해 이미지를 전송하고 서버연결을 끊습니다.
+			
+			SSE응답 형식은 Message 목록 조회 내용 형식과 유사합니다.
+			{
+			  "messageId": 1,
+			  "messageOrder": 1,
+			  "senderType": "AI", // AI 응답
+			  "textContent": "안녕하세요! 생성된 메시지입니다.",
+			  "requestId": "req-1234567890",
+			  "imageUrl": "https://example.com/images/1.png", // 없으면 null
+			  "createdAt": "2025-09-24T13:45:00",
+			  "status": "RESPONSE" // 응답이므로 RESPONSE
+			}
+			
 			""",
 		responses = {
 			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),


### PR DESCRIPTION
## 개요
AI 채팅 시스템의 안정성과 확장성을 위한 리팩토링 작업을 진행했습니다. 

## 구현 내용

### 1. SSE 응답 형식을 Swagger에 추가
- **구현**: SSE에서 응답하는 내용에 맞게 Swagger 설명을 추가했습니다.
- **상세**: SSE 응답 형식이 Swagger에 명시되어 있지 않아, 프론트에서 어려움을 느낄거같아 추가했습니다.

### 2. 서킷브레이커에 WebClientException도 처리하도록 변경
- **구현**: 서킷 브레이커 동작 조건에 WebClientException을 추가했습니다.
- **목적**: WebClient에서 정의한 예외처리 외의 에러가 발생할 수 있으니 이에 대해 보강했습니다.

### 3. AI 이미지 생성 요청 판단 프롬프트 강화
- **구현**: AI 채팅 시, 이미지 생성 요청인지 채팅응답요청인지 판단하는 로직에서 프롬프트를 강화했습니다.
- **목적**: 이미지만 있고, 채팅이 없는 경우 이미지 생성으로 판단해야 하는데, 채팅응답으로 판단했습니다. 이를 개선했습니다.
- **상세**: 이미지 유무, 채팅 유무를 모두 고려하여 이에 맞게 응답하도록 처리했습니다.
