### PR TITLE
feat: 포스트 리뷰 상세 조회 API 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Build stage
+
+FROM bellsoft/liberica-openjdk-alpine:17 AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN ./gradlew clean build -x test
+
+
+# Run stage
+
+FROM bellsoft/liberica-openjdk-alpine:17
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  backend:
+    image: my-spring-app
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+    ports:
+      - "8080:8080"

--- a/docs/ai-chat-implementation-issues.md
+++ b/docs/ai-chat-implementation-issues.md
@@ -1,0 +1,165 @@
+# AI Chat 구현 문제점 분석 보고서
+
+## 개요
+현재 feature/167-implement-ai-chat 브랜치에서 AI 채팅 기능 구현 중 발견된 주요 문제점들을 정리한 문서입니다.
+
+## 주요 문제점
+
+### 1. 컴파일 에러 (60개)
+
+#### 1.1 삭제된 클래스 참조 문제
+다음 클래스들이 삭제되었지만 테스트 코드에서 여전히 참조되고 있음:
+
+**삭제된 클래스들:**
+- `AiImageGenerationService`
+- `CreatedAiImageEntity` → `AiResponseImageEntity`로 이름 변경된 것으로 추정
+- `CreatedAiImageRepository`
+- `AiImageGenerationRequest`
+
+**영향받는 테스트 파일들:**
+- `AiImageGenerationServiceTest.java`
+- `AiFactory.java` (EntityFactory)
+- `AiChatImageControllerTest.java`
+- `AiDerivedPostServiceTest.java`
+- `AiDerivedPostControllerIntegrationTest.java`
+
+#### 1.2 패키지 구조 변경으로 인한 import 오류
+```java
+// 존재하지 않는 패키지
+import hanium.modic.backend.web.ai.aiServer.dto.request.AiImageGenerationRequest;
+```
+
+#### 1.3 Enum 값 불일치
+```java
+// 존재하지 않는 enum 값
+AiImageStatus.REQUEST_DONE
+```
+
+#### 1.4 DTO 생성자 파라미터 불일치
+```java
+// MyGeneratedAiImageResponse의 생성자 파라미터 개수 불일치
+new MyGeneratedAiImageResponse(1L, "https://test.com/image1.jpg", 1L)
+// 실제로는 4개 파라미터 필요: (Long, String, Long, Long)
+```
+
+### 2. 아키텍처 설계 문제
+
+#### 2.1 엔티티 관계 설계 문제
+
+**AiChatMessageEntity의 구조적 문제:**
+```java
+// 불필요한 필드가 많음
+@Column(name = "ai_chat_image_id")
+private Long aiChatImageId; // 이미지 첨부 시에만 값 존재
+
+@Column(name = "request_id", nullable = false) 
+private String requestId; // ai 요청 아이디
+
+@Enumerated(EnumType.STRING)
+@Column(nullable = false)
+private AiImageStatus status = AiImageStatus.REQUEST_PENDING;
+```
+
+**문제점:**
+- 채팅 메시지에 AI 이미지 상태가 포함되어 있어 관심사 분리 원칙 위배
+- 텍스트 메시지와 이미지 생성 요청이 같은 엔티티에 혼재
+- `requestId`가 모든 메시지에 필수값으로 설정되어 있음
+
+#### 2.2 비즈니스 로직 분산 문제
+
+**AiChatRoomEntity의 책임 과다:**
+```java
+// 남은 이미지 생성 횟수 감소, 락과 함께 사용해야 함
+public void decreaseRemainingGenerations() throws AppException {
+    if (hasRemainingGenerations()) {
+        this.remainingGenerations--;
+    } else {
+        throw new AppException(REMAINING_GENERATIONS_NOT_ENOUGH_EXCEPTION);
+    }
+}
+```
+
+**문제점:**
+- 엔티티에서 비즈니스 예외 처리
+- 기존 `AiImagePermissionEntity`와 중복되는 권한 관리 로직
+- 두 엔티티에서 같은 기능을 다르게 구현할 위험
+
+#### 2.3 서비스 레이어 의존성 문제
+
+**AiChatMessageService의 과도한 의존성:**
+```java
+@Service
+public class AiChatMessageService {
+    private final AiChatMessageRepository aiChatMessageRepository;
+    private final AiChatRoomService aiChatRoomService;
+    private final AiServerService aiServerService;           // 문제: 외부 서비스 직접 의존
+    private final AiChatImageRepository aiChatImageRepository;
+    private final AiChatImageService aiChatImageService;
+    private final KeyGenerator keyGenerator;
+    private final AiChatRoomRepository aiChatRoomRepository;
+}
+```
+
+**문제점:**
+- 서비스간 강한 결합
+- 단일 책임 원칙 위배
+- 테스트 복잡성 증가
+
+### 3. 데이터베이스 설계 문제
+
+#### 3.1 중복된 권한 관리
+- 기존: `ai_image_permissions` 테이블에서 `remaining_generations` 관리
+- 신규: `ai_chat_rooms` 테이블에서 `remaining_generations` 관리
+
+#### 3.2 비정규화된 인덱스
+```java
+@Index(name = "idx_user_post_order", columnList = "user_id, post_id, message_order")
+@Index(name = "idx_user_post_created", columnList = "user_id, post_id, create_at")
+```
+- 유사한 복합 인덱스 중복
+- 성능 최적화 근거 부족
+
+### 4. API 설계 문제
+
+#### 4.1 일관성 없는 응답 구조
+```java
+// 컨트롤러에서 서비스 결과를 그대로 반환하지 않음
+SendUserMessageResponse response = aiChatMessageService.sendUserMessage(user.getId(), postId, request);
+```
+
+#### 4.2 SSE 연결 관리 부실
+```java
+// Todo 주석으로 처리된 중요한 기능
+// Todo: 현재 Timeout을 무한대로 설정했는데, 적절한 값으로 변경 필요 및 처리 기능 필요
+SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+```
+
+### 5. 테스트 코드 문제
+
+#### 5.1 Factory 패턴 불일치
+- 기존 Factory에서 생성하는 엔티티가 삭제됨
+- 새로운 엔티티들에 대한 Factory 메서드 부족
+
+#### 5.2 테스트 데이터 불일치
+- DTO 생성자 파라미터 변경사항이 테스트에 반영되지 않음
+- Mock 데이터 구조가 실제 엔티티와 불일치
+
+## 권장 해결 방안
+
+### 1. 단기 해결책 (빌드 오류 해결)
+1. 삭제된 클래스 참조 제거 및 대체 클래스로 변경
+2. Enum 값 및 DTO 생성자 파라미터 수정
+3. import 경로 수정
+
+### 2. 중기 해결책 (아키텍처 개선)
+1. 채팅 메시지와 이미지 생성 요청 분리
+2. 권한 관리 로직 통합 (기존 AiImagePermission 활용)
+3. 서비스 레이어 의존성 정리
+
+### 3. 장기 해결책 (설계 개선)
+1. 도메인 모델 재설계
+2. 이벤트 기반 아키텍처 도입 고려
+3. 통합 테스트 전략 수립
+
+## 결론
+현재 구현에서는 기능 추가에 집중한 나머지 기존 아키텍처와의 일관성이 부족하고, 테스트 코드 동기화가 이루어지지 않았습니다. 단계적 리팩토링을 통해 안정성과 확장성을 확보할 필요가 있습니다.

--- a/docs/ai-chat-system-design.md
+++ b/docs/ai-chat-system-design.md
@@ -1,0 +1,516 @@
+# AI 채팅 시스템 설계서
+
+## 1. 개요
+
+사용자와 AI(Claude, OpenAI GPT) 간의 실시간 채팅 및 이미지 생성 기능을 구현하는 시스템입니다. 
+Post 내에서 유저별로 독립적인 채팅 세션을 제공하며, SSE를 통한 실시간 응답, 텍스트/이미지 복합 채팅 내역 저장, 그리고 AI 서비스 이중화를 통한 고가용성을 제공합니다.
+
+**주요 특징:**
+- Post-User 조합당 하나의 채팅 세션 (유저가 Post에 들어가면 기존 채팅 내역이 표시)
+- AI 이미지 생성권을 보유한 사용자만 채팅 기능 이용 가능
+- 텍스트와 이미지를 함께 포함하는 복합 채팅 메시지 지원
+- 채팅 내역 영구 보관 (삭제 불가, 페이지네이션 지원)
+- AI Provider 이중화: Claude(기본) + OpenAI GPT (장애 시 자동 전환)
+- 컨텍스트 초기화 기능 (기존 채팅은 표시하되 AI 컨텍스트에서 제외)
+- 기존 채팅 내역을 반영한 연속적 대화 지원
+
+## 2. 핵심 기능
+
+### 2.1 채팅 기본 기능
+- 사용자와 AI 간의 실시간 채팅 (텍스트 + 이미지)
+- 텍스트 채팅 및 AI 이미지 생성 요청
+- 사용자 이미지 업로드 및 AI에게 전달 (기존 AiImageGenerationService 활용)
+- 채팅 내역 영구 저장 (삭제 불가)
+- 채팅 순서, 내용, 날짜, 이미지 관리
+- AI 이미지 생성권 보유자만 접근 가능
+
+### 2.2 실시간 통신
+- Server-Sent Events (SSE)를 통한 실시간 응답 스트리밍
+- AI API 응답의 실시간 전달
+- 텍스트는 SSE로 스트리밍 전달, 이미지는 AI서버에서 MQ를 통해 받고 이를 SSE로 전달
+
+### 2.3 복합 메시지 지원
+- 텍스트와 이미지가 함께 포함된 메시지
+- 이미지 엔티티 기반 이미지 관리 (imageId 참조)
+- 사용자 업로드 이미지와 AI 생성 이미지 구분
+- 이미지 메타데이터 저장 (설명, 생성 타입, 원본 관계 등)
+
+### 2.4 컨텍스트 관리
+- 기존 채팅 내역 기반 연속 대화 (GPT처럼 대화 맥락 유지)
+- 컨텍스트 초기화 기능 (채팅 내역은 UI에 표시되지만 AI 컨텍스트에서 제외)
+- 이미지 생성 시 전체 채팅 요약 활용
+- 컨텍스트 윈도우 최적화로 토큰 사용량 관리
+- 이미지가 포함된 대화 맥락도 AI에게 전달
+
+### 2.5 고가용성
+- Claude(기본) + OpenAI GPT API 이중화
+- 응답 에러 발생 시 자동 Fallback
+- 사용자는 AI Provider 선택 불가 (시스템이 자동 관리)
+- 특정 API 장애 감지 시 즉시 다른 API로 전환
+
+### 2.6 데이터 관리
+- 채팅 목록 조회 (페이지네이션)
+- Post별, 유저별 독립적인 채팅 세션
+- 여러 Post에 대한 동시 채팅 지원
+- 이미지 생성 시에만 AI 이미지 생성권 1회 차감
+- 텍스트 채팅은 무제한 (생성권 보유 조건 하에)
+
+## 3. 데이터베이스 설계
+
+### 3.1 Entity 구조
+
+#### ChatSessionEntity
+```java
+@Entity
+@Table(name = "chat_sessions")
+public class ChatSessionEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+    
+    // 세션명은 시스템에서 자동 관리 (사용자 설정 불가)
+    
+    @Column(name = "context_reset_at")
+    private LocalDateTime contextResetAt;
+    
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+    
+    // Unique constraint: (user_id, post_id)
+}
+```
+
+#### ChatMessageEntity
+```java
+@Entity
+@Table(name = "chat_messages")
+public class ChatMessageEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "chat_session_id", nullable = false)
+    private Long chatSessionId;
+    
+    @Column(name = "message_order", nullable = false)
+    private Long messageOrder;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_type", nullable = false)
+    private SenderType senderType; // USER, AI
+    
+    @Column(name = "text_content", columnDefinition = "TEXT")
+    private String textContent; // 텍스트 내용
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ai_provider")
+    private AiProvider aiProvider; // CLAUDE, OPENAI
+    
+    // Index: (chat_session_id, message_order)
+}
+```
+
+#### ChatMessageImageEntity
+```java
+@Entity
+@Table(name = "chat_message_images")
+public class ChatMessageImageEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "chat_message_id", nullable = false)
+    private Long chatMessageId;
+    
+    @Column(name = "image_id", nullable = false)
+    private Long imageId; // Image Entity 참조
+    
+    @Column(name = "description")
+    private String description; // 이미지 설명
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "generation_type", nullable = false)
+    private GenerationType generationType; // UPLOADED, AI_GENERATED
+    
+    @Column(name = "from_origin_image", nullable = false)
+    private Boolean fromOriginImage = false; // 원본 이미지로부터 파생되었는지
+    
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder; // 메시지 내 이미지 순서
+    
+    // Index: (chat_message_id, display_order)
+}
+```
+
+#### ChatContextEntity
+```java
+@Entity
+@Table(name = "chat_contexts")
+public class ChatContextEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "chat_session_id", nullable = false)
+    private Long chatSessionId;
+    
+    @Column(name = "context_summary", columnDefinition = "TEXT")
+    private String contextSummary; // 전체 채팅 요약 (이미지 생성 시 활용)
+    
+    @Column(name = "token_count")
+    private Integer tokenCount;
+    
+    @Column(name = "last_updated_message_order")
+    private Long lastUpdatedMessageOrder;
+    
+    // Hybrid 컨텍스트 관리를 위한 필드
+    @Column(name = "recent_message_count")
+    private Integer recentMessageCount; // 원문 유지할 최근 메시지 수
+    
+    @Column(name = "summary_start_order")
+    private Long summaryStartOrder; // 요약이 시작되는 메시지 순서
+}
+```
+
+### 3.2 Enum 정의
+```java
+public enum SenderType {
+    USER, AI
+}
+
+public enum AiProvider {
+    CLAUDE, OPENAI
+}
+
+public enum GenerationType {
+    UPLOADED,    // 사용자 업로드 이미지
+    AI_GENERATED // AI 생성 이미지
+}
+```
+
+## 4. API 설계
+
+### 4.1 채팅 세션 관리
+```
+GET /api/posts/{postId}/chat/session
+- 채팅 세션 정보 조회/생성 (AI 이미지 생성권 검증 포함)
+
+POST /api/posts/{postId}/chat/context/reset
+- 컨텍스트 초기화 (채팅 내역은 유지되지만 AI 컨텍스트에서 제외)
+```
+
+### 4.2 채팅 메시지
+```
+POST /api/posts/{postId}/chat/messages
+- 복합 메시지 전송 (텍스트 + 이미지)
+- 요청 본문: { "textContent": "...", "imageIds": [1, 2, 3] }
+- SSE를 통한 실시간 응답
+- 이미지 생성 요청 시 AI 이미지 생성권 1회 차감
+
+GET /api/posts/{postId}/chat/messages
+- 채팅 내역 조회 (페이지네이션)
+- 텍스트와 이미지 정보를 함께 반환
+- 영구 저장된 모든 채팅 내역 조회 가능
+- 응답: { "messages": [{ "textContent": "...", "images": [...] }], "hasNext": true }
+```
+
+### 4.3 SSE 엔드포인트
+```
+GET /api/posts/{postId}/chat/stream
+- SSE 연결 설정
+- 텍스트 응답과 이미지 생성 진행 상황 모두 스트리밍
+```
+
+### 4.4 이미지 업로드
+```
+POST /api/posts/{postId}/chat/images/upload
+- 채팅용 이미지 업로드
+- 응답: { "imageId": 123, "imageUrl": "..." }
+- 채팅 메시지 전송 시 imageId로 참조
+```
+
+## 5. 시스템 아키텍처
+
+### 5.1 전체 구조
+```
+Client -> Controller -> Service -> AI Provider (Claude/OpenAI) -> Response Streaming
+                    -> ChatRepository -> Database
+                    -> ImageRepository -> Image Storage
+```
+
+### 5.2 핵심 컴포넌트
+
+#### ChatService
+- 채팅 세션 관리
+- 복합 메시지 저장 및 조회 (텍스트 + 이미지)
+- 컨텍스트 관리 및 초기화
+- 페이지네이션 지원
+
+#### AiChatService
+- AI Provider 선택 및 Fallback
+- 응답 스트리밍 처리
+- 컨텍스트 기반 요청 생성
+- Vision API 연동 (이미지 포함 요청)
+
+#### SseService
+- SSE 연결 관리
+- 실시간 텍스트/이미지 응답 전송
+- 연결 끊어짐 처리
+
+#### ImageService
+- 채팅용 이미지 업로드 관리
+- 이미지 메타데이터 저장
+- AI 생성 이미지 처리
+
+### 5.3 메시지 큐 연동
+```java
+/**
+ * 이미지 생성 요청을 큐에 전송
+ */
+public class ChatImageGenerationService {
+    
+    /**
+     * 채팅 기반 이미지 생성 요청
+     */
+    public void requestImageGeneration(Long chatSessionId, String prompt, List<Long> imageIds, Long styleImageId) {
+        ChatContext context = chatService.getChatContext(chatSessionId);
+        List<ChatMessage> recentMessages = chatService.getRecentMessages(chatSessionId, 10);
+        
+        ImageGenerationRequest request = ImageGenerationRequest.builder()
+            .prompt(prompt)
+            .imagesPath(getImagePaths(imageIds))
+            .styleImageId(styleImageId.toString())
+            .styleImagePath(getStyleImagePath(styleImageId))
+            .chat(buildChatHistory(recentMessages))
+            .chatSummary(context.getContextSummary())
+            .build();
+            
+        aiGenerationService.sendToQueue(request);
+    }
+    
+    private List<ChatHistoryItem> buildChatHistory(List<ChatMessage> messages) {
+        return messages.stream()
+            .map(msg -> ChatHistoryItem.builder()
+                .role(msg.getSenderType() == USER ? "user" : "assistant")
+                .contents(buildContents(msg))
+                .build())
+            .collect(toList());
+    }
+    
+    private List<ChatContent> buildContents(ChatMessage message) {
+        List<ChatContent> contents = new ArrayList<>();
+        
+        // 텍스트 추가
+        if (StringUtils.hasText(message.getTextContent())) {
+            contents.add(ChatContent.builder()
+                .type("text")
+                .text(message.getTextContent())
+                .build());
+        }
+        
+        // 이미지들 추가
+        message.getImages().forEach(img -> {
+            contents.add(ChatContent.builder()
+                .type("image")
+                .imagePath(img.getImagePath())
+                .description(img.getDescription())
+                .generationType(img.getGenerationType().name().toLowerCase())
+                .fromOriginImage(img.getFromOriginImage())
+                .build());
+        });
+        
+        return contents;
+    }
+}
+```
+
+### 5.4 AI Provider 이중화 전략
+```java
+@Component
+public class AiProviderFailoverService {
+    private final ClaudeService claudeService;
+    private final OpenAiService openAiService;
+    private final CircuitBreaker claudeCircuitBreaker;
+    private final CircuitBreaker openAiCircuitBreaker;
+    
+    /**
+     * 기본: Claude, 장애 시: OpenAI
+     */
+    public Flux<String> sendMessage(String message, ChatContext context) {
+        return claudeCircuitBreaker.executeSupplier(() -> {
+            if (claudeCircuitBreaker.getState() == CircuitBreaker.State.OPEN) {
+                log.info("Claude circuit breaker is open, switching to OpenAI");
+                return openAiService.sendMessage(message, context);
+            }
+            
+            try {
+                return claudeService.sendMessage(message, context);
+            } catch (Exception e) {
+                log.warn("Claude failed, switching to OpenAI", e);
+                return openAiService.sendMessage(message, context);
+            }
+        });
+    }
+    
+    /**
+     * SSE 연결 끊어짐 시 AI 응답을 DB에 저장
+     */
+    public void handleDisconnectedResponse(String sessionId, String partialResponse) {
+        chatService.savePartialResponse(sessionId, partialResponse);
+        // SSE 연결은 종료, 재연결 시 누락분 전송
+    }
+}
+```
+
+## 6. 기술 스택
+
+### 6.1 백엔드
+- **Framework**: Spring Boot, Spring WebFlux
+- **SSE**: Server-Sent Events
+- **Circuit Breaker**: Resilience4j
+- **AI APIs**: OpenAI GPT API, Anthropic Claude API
+
+### 6.2 데이터베이스
+- **Primary**: MySQL (채팅 내역 저장)
+- **Cache**: Redis (세션 관리, 컨텍스트 캐싱)
+
+## 7. 구현 우선순위
+
+1. **Phase 1**: 기본 채팅 기능
+   - 데이터베이스 설계 및 Entity 생성
+   - 채팅 세션 관리
+   - 기본 텍스트 채팅
+
+2. **Phase 2**: SSE 및 실시간 기능
+   - SSE 구현
+   - AI API 연동
+   - 실시간 응답 스트리밍
+
+3. **Phase 3**: 고급 기능
+   - 컨텍스트 관리
+   - 이미지 메시지 지원
+   - 페이지네이션
+
+4. **Phase 4**: 고가용성
+   - AI Provider 이중화
+   - Circuit Breaker 구현
+   - 장애 복구 로직
+
+## 8. 성능 및 확장성 고려사항
+
+### 8.1 성능 최적화
+- 채팅 내역 페이지네이션으로 메모리 효율성
+- **Hybrid 컨텍스트 관리**로 토큰 사용량과 품질 균형 유지
+- Redis 캐싱으로 응답 속도 향상
+- **Circuit Breaker**로 Provider 장애 시 빠른 Failover
+- **SSE 연결 복구** 로직으로 안정적인 실시간 통신
+
+### 8.2 확장성
+- 채팅 세션별 독립적인 처리
+- AI Provider 확장 가능한 구조
+- 메시지 순서 보장을 위한 인덱스 설계
+
+## 9. 보안 및 권한 관리
+
+### 9.1 인증 및 권한
+- JWT 기반 사용자 인증
+- AI 이미지 생성권 보유 여부 검증
+- Post 접근 권한 검증
+
+### 9.2 보안
+- AI API 키 보안 관리
+- 메시지 내용 검증 및 필터링
+- 채팅 세션 격리 (Post-User별 독립적 관리)
+
+### 9.3 사용 제한
+- 이미지 생성 시에만 AI 이미지 생성권 차감
+- 일반 텍스트 채팅은 무료 (생성권 보유자만 이용 가능)
+- 일일 채팅 횟수 제한 없음
+
+## 10. 미해결 질문사항
+
+### 10.1 컨텍스트 관리 전략 (확정)
+**전략:** Hybrid 방식 (최근 N개 + 요약)
+- **원본 유지:** 최근 N개 메시지는 원문 그대로 유지
+- **요약 처리:** 오래된 대화는 요약해서 컨텍스트에 포함
+- **장점:** 연속적 이미지 생성 시 스타일 유지, 세부 디테일 조정에 유리
+- **최적화:** "이전 그림이랑 같은 분위기로" 같은 요청에 강함
+
+### 10.2 장애 감지 및 복구 (확정)
+**전략:** 연속 실패 횟수 기반 Circuit Breaker
+- **기닸 기준:** 연속 N회 실패 시 OpenAI -> Claude로 자동 전환
+- **복구 로직:** 일정 시간 후 OpenAI 재시도 (Half-Open 상태)
+- **모니터링:** 각 Provider별 성공/실패 비율 추적
+- **Fallback 체인:** OpenAI → Claude → 에러 응답
+
+### 10.3 SSE 연결 관리 (확정)
+**연결 끊어짐 시 처리:**
+- **진행 중인 AI 응답:** DB에 저장 후 SSE 연결은 종료
+- **클라이언트 재연결:** 클라이언트가 재연결 시 누락된 메시지 전송
+- **서버 상태 관리:** 메모리에 진행 중인 요청 상태 저장
+- **복구 대응:** 재연결 시 마지막 수신 메시지 이후 내용 전송
+
+## 11. 미해결 질문사항 및 확인 필요 사항
+
+### 11.1 이미지 생성 시 권한 차감 시점
+**질문:** 이미지 생성 요청을 큐에 보낼 때 권한을 차감할지, 실제 이미지가 생성 완료되었을 때 차감할지?
+- **옵션 A:** 요청 시점 차감 (실패해도 차감됨, 사용자 예측 가능)
+- **옵션 B:** 성공 시점 차감 (실패 시 차감 안됨, 복잡한 롤백 로직 필요)
+
+### 11.2 채팅 컨텍스트 윈도우 크기
+**질문:** 몇 개의 최근 메시지를 원문으로 유지할지?
+- **옵션 A:** 최근 10개 메시지
+- **옵션 B:** 토큰 수 기준 (예: 최근 2000 토큰)
+- **옵션 C:** 사용자/Post별 설정 가능
+
+### 11.3 이미지가 포함된 메시지의 토큰 계산
+**질문:** Vision API 사용 시 이미지 토큰을 어떻게 계산하고 관리할지?
+- 이미지 크기별 토큰 수 계산 방법
+- 컨텍스트 요약 시 이미지 포함 여부
+
+### 11.4 채팅 세션별 동시 요청 제한
+**질문:** 한 세션에서 동시에 여러 요청을 보낼 수 있게 할지?
+- **옵션 A:** 세션당 1개 요청만 허용 (순차 처리)
+- **옵션 B:** 동시 요청 허용 (응답 순서 보장 방법 필요)
+
+### 11.5 AI Provider 장애 감지 기준
+**질문:** 어떤 상황을 '장애'로 판단하고 Failover를 수행할지?
+- HTTP 500 에러
+- 응답 시간 초과 (몇 초?)
+- 연속 실패 횟수 (몇 회?)
+- 특정 에러 코드들
+
+### 11.6 페이지네이션 정렬 기준
+**질문:** 채팅 목록 조회 시 정렬 기준은?
+- **옵션 A:** 생성 시간 기준 최신순 (일반적)
+- **옵션 B:** 메시지 순서 기준 (채팅 흐름 유지)
+
+### 11.7 컨텍스트 초기화 후 이미지 생성
+**질문:** 컨텍스트를 초기화한 후 이미지 생성 요청 시 채팅 요약을 어떻게 처리할지?
+- **옵션 A:** 초기화 시점 이후의 메시지만 요약에 포함
+- **옵션 B:** 전체 채팅 내역을 요약에 포함 (UI 표시와 동일)
+- **옵션 C:** 요약 자체를 초기화
+
+### 11.8 이미지 업로드 용량 및 형식 제한
+**질문:** 채팅에서 업로드할 수 있는 이미지의 제한 사항은?
+- 최대 파일 크기
+- 허용 형식 (JPG, PNG, WebP 등)
+- 한 메시지당 최대 이미지 개수
+
+### 11.9 SSE 연결 끊어짐 시 재연결 정책
+**질문:** SSE 연결이 끊어진 클라이언트가 재연결할 때 어떤 정보를 제공할지?
+- 마지막 수신한 메시지 ID
+- 누락된 메시지 자동 전송 여부
+- 진행 중인 AI 응답 처리 방법
+
+### 11.10 채팅 데이터 보관 정책
+**질문:** 영구 저장이라고 했지만, 실제 운영상 데이터 정리 정책이 필요할지?
+- 비활성 사용자의 채팅 데이터 처리
+- 이미지 파일의 저장 기간
+- 데이터베이스 용량 관리 방안

--- a/docs/post-tree-api-design.md
+++ b/docs/post-tree-api-design.md
@@ -1,0 +1,123 @@
+# Post Tree API 설계
+
+## 개요
+특정 포스트를 포함하여 하위 트리를 모두 조회하는 API입니다. 포스트 간의 부모-자식 관계를 통해 트리 구조를 파악할 수 있는 데이터를 제공하며, 프론트엔드에서 트리를 구성할 수 있도록 설계되었습니다.
+
+## API 명세
+
+### Endpoint
+```
+GET /api/v1/posts/{postId}/tree
+```
+
+### Path Parameters
+- `postId` (Long): 트리의 루트가 될 포스트 ID
+
+### Response
+```json
+{
+  "data": [
+    {
+      "postId": 1,
+      "title": "Original Post Title",
+      "parentPostId": null,
+      "representativeImageUrl": "https://example.com/image1.jpg",
+      "postStatus": "COMPLETED"
+    },
+    {
+      "postId": 2,
+      "title": "Derived Post Title 1",
+      "parentPostId": 1,
+      "representativeImageUrl": "https://example.com/image2.jpg",
+      "postStatus": "PROCESSING"
+    },
+    {
+      "postId": 3,
+      "title": "Derived Post Title 2",
+      "parentPostId": 1,
+      "representativeImageUrl": "https://example.com/image3.jpg",
+      "postStatus": "COMPLETED"
+    }
+  ]
+}
+```
+
+### Response 필드 설명
+- `postId`: 포스트의 고유 ID
+- `title`: 포스트 제목
+- `parentPostId`: 부모 포스트 ID (루트 포스트의 경우 null)
+- `representativeImageUrl`: 포스트의 대표 이미지 URL (첫 번째 이미지)
+- `postStatus`: 포스트 상태 (PENDING, PROCESSING, COMPLETED, FAILED)
+
+## 비즈니스 로직
+
+### 트리 조회 방식
+1. 요청된 `postId`를 루트로 하는 모든 하위 포스트를 재귀적으로 조회
+2. 각 포스트의 첫 번째 이미지를 대표 이미지로 설정
+3. 포스트 상태(PostStatus)와 함께 응답
+4. 프론트엔드에서 `parentPostId`를 통해 트리 구조 생성
+
+### 대표 이미지 선택 규칙
+- 포스트에 연결된 이미지 중 첫 번째 이미지를 대표 이미지로 사용
+- 이미지가 없는 경우 `representativeImageUrl`은 null로 응답
+- 이미지 URL은 CloudFront 서명된 URL로 제공
+
+### PostStatus 값
+- `PENDING`: 대기 중
+- `PROCESSING`: 처리 중
+- `COMPLETED`: 완료
+- `FAILED`: 실패
+
+## 구현 계획
+
+### 1. DTO 클래스
+```java
+public record GetPostTreeResponse(
+    Long postId,
+    String title,
+    Long parentPostId,
+    String representativeImageUrl,
+    PostStatus postStatus
+)
+```
+
+### 2. Repository 메서드
+```java
+// 특정 포스트의 모든 하위 포스트를 재귀적으로 조회
+List<PostEntity> findAllDescendantsByPostId(Long postId);
+```
+
+### 3. Service 메서드
+```java
+public List<GetPostTreeResponse> getPostTree(Long postId);
+```
+
+### 4. Controller 메서드
+```java
+@GetMapping("/{postId}/tree")
+public ResponseEntity<ApiResponse<List<GetPostTreeResponse>>> getPostTree(
+    @PathVariable Long postId
+);
+```
+
+## 성능 고려사항
+
+### 데이터베이스 최적화
+- 재귀 쿼리 또는 CTE(Common Table Expression) 사용
+- 이미지 조회를 위한 배치 쿼리 적용
+- 인덱스: `parent_post_id`에 인덱스 필요
+
+### 캐싱 전략
+- 자주 조회되는 트리 구조는 Redis 캐싱 고려
+- 포스트 상태 변경 시 관련 캐시 무효화
+
+## 에러 처리
+
+### 가능한 에러 상황
+- 존재하지 않는 포스트 ID 요청: `POST_NOT_FOUND_EXCEPTION`
+- 권한이 없는 포스트 접근: `ACCESS_DENIED_EXCEPTION`
+- 시스템 에러: `INTERNAL_SERVER_ERROR`
+
+## 보안 고려사항
+- 비공개 포스트에 대한 접근 권한 검증
+- 이미지 URL의 서명된 URL 생성으로 보안 강화

--- a/docs/simplified-ai-chat-system-design.md
+++ b/docs/simplified-ai-chat-system-design.md
@@ -1,0 +1,321 @@
+# 단순화된 AI 채팅 시스템 설계서
+
+## 1. 개요
+
+기존 AI 이미지 생성권 시스템을 활용하여 단순화된 AI 채팅 시스템을 구현합니다.
+복잡한 세션 관리를 제거하고 기존 Permission 엔티티에 채팅 기능을 통합합니다.
+
+## 2. 핵심 설계 변경사항
+
+### 2.1 기존 엔티티 활용
+- **AiImagePermissionEntity → ChatRoomEntity로 확장**: 기존 구매 이력이 채팅방 역할
+- **ChatSession 제거**: 불필요한 중간 레이어 제거
+- **ChatContext 제거**: 요약 기능을 ChatRoom에 통합
+- **ChatMessageImage 제거**: ChatMessage에 통합
+
+### 2.2 단순화된 컨텍스트 관리
+- **최근 20개 메시지** + **전체 요약본**만 AI 서버에 전송
+- 복잡한 토큰 계산, 메시지 순서 추적 로직 제거
+- 요약 업데이트는 새로운 메시지 + 기존 요약으로 단순화
+
+## 3. 데이터베이스 설계
+
+### 3.1 Entity 구조
+
+#### ChatRoomEntity (기존 AiImagePermissionEntity 확장)
+```java
+@Entity
+@Table(name = "ai_image_permissions") // 기존 테이블 활용
+public class ChatRoomEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+    
+    @Column(name = "remaining_generations", nullable = false)
+    private Integer remainingGenerations;
+    
+    // 새로 추가되는 채팅 관련 필드들
+    @Column(name = "chat_summary", columnDefinition = "TEXT")
+    private String chatSummary; // 전체 채팅 요약
+    
+    @Column(name = "context_reset_at")
+    private LocalDateTime contextResetAt; // 컨텍스트 초기화 시점
+    
+    // Unique constraint: (user_id, post_id)
+}
+```
+
+#### ChatMessageEntity (단순화)
+```java
+@Entity
+@Table(name = "chat_messages")
+public class ChatMessageEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+    
+    @Column(name = "message_order", nullable = false)
+    private Long messageOrder;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_type", nullable = false)
+    private SenderType senderType; // USER, AI
+    
+    @Column(name = "text_content", columnDefinition = "TEXT")
+    private String textContent;
+    
+    @Column(name = "ai_request_id")
+    private String aiRequestId; // 이미지 첨부 시에만 값 존재, 없으면 null
+    
+    // Index: (user_id, post_id, message_order)
+}
+```
+
+### 3.2 Enum 정의
+```java
+public enum SenderType {
+    USER, AI
+}
+```
+
+## 4. API 설계
+
+### 4.1 채팅방 관리
+```
+GET /api/posts/{postId}/chat/room
+- 채팅방 정보 조회 (AI 이미지 생성권 = 채팅방 입장권)
+- 구매 이력 없으면 403 에러
+
+POST /api/posts/{postId}/chat/context/reset 
+- 생성권 없으면 막음
+- 컨텍스트 초기화 (요약 초기화 + contextResetAt 업데이트)
+```
+
+### 4.2 채팅 메시지
+```
+POST /api/posts/{postId}/chat/messages
+- 생성권 없으면 채팅도 막음
+- 메시지 전송 (텍스트 + 이미지 aiRequestId)
+- 요청: { "textContent": "...", "aiRequestId": "uuid-string" (optional) }
+
+GET /api/posts/{postId}/chat/messages  
+- 메시지 목록 조회 (페이지네이션)
+```
+
+### 4.3 SSE
+```
+GET /api/posts/{postId}/chat/stream
+- 실시간 AI 응답 수신
+```
+
+## 5. 서비스 레이어 설계
+
+### 5.1 ChatRoomService
+```java
+@Service
+public class ChatRoomService {
+    
+    /**
+     * 채팅방 정보 조회 (기존 Permission 조회)
+     */
+    public ChatRoomResponse getChatRoom(Long userId, Long postId);
+    
+    /**
+     * 채팅 요약 업데이트
+     */
+    public void updateChatSummary(Long userId, Long postId, String newSummary);
+    
+    /**
+     * 컨텍스트 초기화
+     */
+    public void resetContext(Long userId, Long postId);
+}
+```
+
+### 5.2 ChatMessageService  
+```java
+@Service
+public class ChatMessageService {
+    
+    /**
+     * 사용자 메시지 저장
+     */
+    public ChatMessageResponse saveUserMessage(Long userId, Long postId, ChatMessageRequest request);
+    
+    /**
+     * AI 메시지 저장
+     */
+    public ChatMessageResponse saveAiMessage(Long userId, Long postId, String textContent);
+    
+    /**
+     * 메시지 목록 조회 (페이지네이션)
+     */
+    public ChatMessagesResponse getMessages(Long userId, Long postId, int page, int size);
+    
+    /**
+     * AI 컨텍스트용 최근 20개 메시지 조회
+     */
+    public List<ChatMessageEntity> getRecentMessagesForAi(Long userId, Long postId);
+}
+```
+
+### 5.3 AiChatService
+```java
+@Service  
+public class AiChatService {
+    
+    /**
+     * AI에게 전송할 컨텍스트 구성
+     * - 채팅방 요약 + 최근 20개 메시지
+     */
+    public AiChatContext buildChatContext(Long userId, Long postId);
+    
+    /**
+     * AI API 호출 및 응답 처리
+     */
+    public CompletableFuture<String> callAiApi(AiChatContext context, String newMessage);
+    
+    /**
+     * 새로운 채팅 요약 생성
+     */
+    public String generateNewSummary(String existingSummary, String newMessage, String aiResponse);
+}
+```
+
+## 6. DTO 설계
+
+### 6.1 Request/Response DTOs
+```java
+// 채팅방 응답
+public record ChatRoomResponse(
+    Long roomId,
+    Long userId, 
+    Long postId,
+    Integer remainingGenerations,
+    String chatSummary,
+    LocalDateTime contextResetAt
+) {}
+
+// 메시지 전송 요청
+public record ChatMessageRequest(
+    String textContent,
+    String aiRequestId, // 이미지 첨부 시에만
+    Boolean isImageGeneration
+) {}
+
+// 메시지 응답
+public record ChatMessageResponse(
+    Long messageId,
+    Long messageOrder,
+    SenderType senderType, 
+    String textContent,
+    String aiRequestId, // 이미지 정보
+    String imageUrl,    // 이미지 URL (조회 시 동적 생성)
+    LocalDateTime createdAt
+) {}
+```
+
+## 7. 주요 비즈니스 로직
+
+### 7.1 채팅방 입장 검증
+```java
+public ChatRoomResponse getChatRoom(Long userId, Long postId) {
+    // 기존 AiImagePermission 조회로 채팅방 존재 확인
+    AiImagePermissionEntity permission = aiImagePermissionRepository
+        .findByUserIdAndPostId(userId, postId)
+        .orElseThrow(() -> new AppException(AI_IMAGE_PERMISSION_NOT_FOUND));
+    
+    return ChatRoomResponse.from(permission);
+}
+```
+
+### 7.2 AI 컨텍스트 구성
+```java
+public AiChatContext buildChatContext(Long userId, Long postId) {
+    // 1. 채팅방 요약 조회
+    String summary = chatRoomService.getChatSummary(userId, postId);
+    
+    // 2. 최근 20개 메시지 조회 (컨텍스트 초기화 이후만)
+    List<ChatMessageEntity> recentMessages = getRecentMessages(userId, postId, 20);
+    
+    return new AiChatContext(summary, recentMessages);
+}
+```
+
+### 7.3 요약 업데이트 로직
+```java
+public void updateSummaryAfterChat(Long userId, Long postId, String userMessage, String aiResponse) {
+    String existingSummary = getChatSummary(userId, postId);
+    String newSummary = generateNewSummary(existingSummary, userMessage, aiResponse);
+    updateChatSummary(userId, postId, newSummary);
+}
+```
+
+## 8. 마이그레이션 계획
+
+### 8.1 기존 테이블 수정
+```sql
+-- ai_image_permissions 테이블에 컬럼 추가
+ALTER TABLE ai_image_permissions 
+ADD COLUMN chat_summary TEXT,
+ADD COLUMN context_reset_at DATETIME;
+```
+
+### 8.2 새 테이블 생성
+```sql
+-- chat_messages 테이블 생성
+CREATE TABLE chat_messages (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    post_id BIGINT NOT NULL, 
+    message_order BIGINT NOT NULL,
+    sender_type VARCHAR(10) NOT NULL,
+    text_content TEXT,
+    ai_request_id VARCHAR(255),
+    create_at DATETIME NOT NULL,
+    update_at DATETIME NOT NULL,
+    
+    INDEX idx_user_post_order (user_id, post_id, message_order),
+    INDEX idx_user_post_created (user_id, post_id, create_at)
+);
+```
+
+## 9. 장점
+
+### 9.1 단순성
+- **테이블 수 감소**: 4개 → 2개 (50% 감소)  
+- **Join 쿼리 최소화**: 복잡한 세션-메시지 조인 제거
+- **비즈니스 로직 단순화**: 불필요한 상태 관리 제거
+
+### 9.2 성능
+- **기존 인덱스 활용**: AiImagePermission의 (user_id, post_id) 인덱스
+- **쿼리 최적화**: 직접적인 user_id, post_id 조건
+- **캐시 효율성**: Redis에 요약만 캐싱하면 충분
+
+### 9.3 일관성  
+- **권한 시스템 통합**: 이미지 생성권 = 채팅권
+- **기존 로직 재사용**: AiImagePermissionService 그대로 활용
+- **데이터 무결성**: FK 관계 단순화
+
+## 10. 구현 순서
+
+1. **Entity 수정**: AiImagePermissionEntity에 채팅 필드 추가
+2. **ChatMessageEntity 구현**: 단순화된 메시지 엔티티  
+3. **Service 레이어**: ChatRoomService, ChatMessageService
+4. **Controller 구현**: 기존 Permission 컨트롤러 확장
+5. **AI 연동**: 컨텍스트 구성 및 API 호출 로직
+6. **테스트**: 기존 AI 이미지 생성 기능과 호환성 확인
+
+이 설계가 훨씬 깔끔하고 실용적입니다!

--- a/src/main/java/hanium/modic/backend/domain/post/repository/PostEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/post/repository/PostEntityRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import hanium.modic.backend.domain.post.entity.PostEntity;
 
@@ -16,4 +18,31 @@ public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 	Page<PostEntity> findAllByIsAiDerivedPost(Boolean isAiDerivedPost, Pageable pageable);
 
 	List<Long> findIdsByParentPostIdOrderByIdDesc(Long parentPostId);
+
+	/**
+	 * 특정 포스트를 포함한 모든 하위 트리 노드를 재귀적으로 조회
+	 * MySQL의 CTE(Common Table Expression)를 사용하여 재귀 쿼리 수행
+	 *
+	 * @param postId 트리의 루트 포스트 ID
+	 * @return 해당 포스트와 모든 하위 포스트 엔티티 리스트
+	 */
+	@Query(value = """
+		WITH RECURSIVE post_tree AS (
+			SELECT id, user_id, title, description, commercial_price, non_commercial_price,
+			       ticket_price, is_ai_derived_post, parent_post_id, derived_post_status,
+			       create_at, update_at
+			FROM post
+			WHERE id = :postId
+
+			UNION ALL
+
+			SELECT p.id, p.user_id, p.title, p.description, p.commercial_price, p.non_commercial_price,
+			       p.ticket_price, p.is_ai_derived_post, p.parent_post_id, p.derived_post_status,
+			       p.create_at, p.update_at
+			FROM post p
+			INNER JOIN post_tree pt ON p.parent_post_id = pt.id
+		)
+		SELECT * FROM post_tree ORDER BY id
+		""", nativeQuery = true)
+	List<PostEntity> findAllDescendantsByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -30,6 +30,7 @@ import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse.ImageDto;
 import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
 import hanium.modic.backend.web.post.dto.response.GetSimplePostsResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -332,5 +333,54 @@ public class PostService {
 			case AI_DERIVED -> postEntityRepository.findAllByIsAiDerivedPost(true, pageable);
 			case ALL -> postEntityRepository.findAll(pageable);
 		};
+	}
+
+	/**
+	 * 특정 포스트를 포함한 하위 트리를 조회
+	 * 각 노드의 대표 이미지(첫 번째 이미지)와 포스트 상태를 포함하여 반환
+	 *
+	 * @param postId 트리의 루트 포스트 ID
+	 * @return 트리 구조로 구성된 포스트 정보 리스트
+	 * @throws AppException 포스트가 존재하지 않을 경우
+	 */
+	@Transactional(readOnly = true)
+	public List<GetPostTreeResponse> getPostTree(Long postId) {
+		// 포스트 존재 여부 확인
+		if (!postEntityRepository.existsById(postId)) {
+			throw new AppException(POST_NOT_FOUND_EXCEPTION);
+		}
+
+		// 재귀적으로 모든 하위 트리 포스트 조회
+		List<PostEntity> treeNodes = postEntityRepository.findAllDescendantsByPostId(postId);
+
+		// 포스트가 없을 경우 예외 처리
+		if (treeNodes.isEmpty()) {
+			throw new AppException(POST_NOT_FOUND_EXCEPTION);
+		}
+
+		// 모든 포스트 ID 추출
+		List<Long> postIds = treeNodes.stream()
+			.map(PostEntity::getId)
+			.toList();
+
+		// 배치로 모든 포스트 이미지 조회 (N+1 문제 해결)
+		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(postIds);
+
+		// 포스트ID별로 첫 번째 이미지 URL 매핑
+		Map<Long, String> representativeImageByPostId = new LinkedHashMap<>();
+		for (PostImageEntity image : allPostImages) {
+			representativeImageByPostId.computeIfAbsent(
+				image.getPostId(),
+				pid -> imageUtil.createImageGetUrl(image.getImagePath())
+			);
+		}
+
+		// PostEntity를 GetPostTreeResponse로 변환
+		return treeNodes.stream()
+			.map(post -> {
+				String representativeImageUrl = representativeImageByPostId.get(post.getId());
+				return GetPostTreeResponse.of(post, representativeImageUrl);
+			})
+			.toList();
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewService.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewService.java
@@ -106,6 +106,34 @@ public class PostReviewService {
 			.forEach(postImageEntity -> postImageEntity.updatePostReview(postReview));
 	}
 
+	// 포스트 리뷰 상세 조회
+	@Transactional(readOnly = true)
+	public PostReviewDetailResponse getPostReviewDetail(final Long reviewId) {
+		final PostReviewEntity postReview = postReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new AppException(POST_REVIEW_NOT_FOUND_EXCEPTION));
+
+		final UserEntity user = userEntityRepository.findById(postReview.getUserId())
+			.orElseThrow(() -> new AppException(USER_NOT_FOUND_EXCEPTION));
+
+		final List<PostReviewImageEntity> images = postReviewImageRepository.findAllByPostReviewId(reviewId);
+		final List<String> imageUrls = images.stream()
+			.map(image -> postReviewImageService.createImageGetUrl(image.getId()))
+			.toList();
+
+		String userImageUrl = user.getUserImageUrl();
+		boolean hasUserImage = userImageUrl != null;
+
+		return new PostReviewDetailResponse(
+			user.getName(),
+			hasUserImage,
+			userImageUrl,
+			postReview.getCreateAt(),
+			postReview.getId(),
+			postReview.getDescription(),
+			imageUrls
+		);
+	}
+
 	// 포스트 리뷰 목록 조회
 	@Transactional(readOnly = true)
 	public Page<PostReviewDetailResponse> getPostReviews(final Long postId, final int page, final int size) {

--- a/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
@@ -2,6 +2,8 @@ package hanium.modic.backend.web.post.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -26,6 +28,7 @@ import hanium.modic.backend.web.post.dto.request.UpdatePostRequest;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
 import hanium.modic.backend.web.postReview.dto.response.CanReviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -131,6 +134,24 @@ public class PostController {
 			response = CanReviewResponse.denied();
 		}
 
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+
+	@GetMapping("/{postId}/tree")
+	@Operation(
+		summary = "게시글 트리 조회 API",
+		description = """
+			특정 포스트를 포함한 하위 트리의 모든 노드를 조회합니다.
+			각 노드는 postId, title, parentPostId, 대표이미지URL, postStatus를 포함합니다.
+			프론트엔드에서 parentPostId를 통해 트리 구조를 구성할 수 있습니다.
+			""",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "트리 조회 성공"),
+			@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")
+		}
+	)
+	public ResponseEntity<AppResponse<List<GetPostTreeResponse>>> getPostTree(@PathVariable Long postId) {
+		List<GetPostTreeResponse> response = postService.getPostTree(postId);
 		return ResponseEntity.ok(AppResponse.ok(response));
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostTreeResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostTreeResponse.java
@@ -1,0 +1,33 @@
+package hanium.modic.backend.web.post.dto.response;
+
+import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.enums.PostStatus;
+
+/**
+ * 포스트 트리 조회 응답 DTO
+ * 특정 포스트를 포함한 하위 트리의 모든 노드 정보를 담는 응답 객체
+ */
+public record GetPostTreeResponse(
+	Long postId,
+	String title,
+	Long parentPostId,
+	String representativeImageUrl,
+	PostStatus postStatus
+) {
+	/**
+	 * PostEntity와 대표 이미지 URL을 통해 GetPostTreeResponse 생성
+	 *
+	 * @param postEntity 포스트 엔티티
+	 * @param representativeImageUrl 대표 이미지 URL
+	 * @return GetPostTreeResponse 인스턴스
+	 */
+	public static GetPostTreeResponse of(PostEntity postEntity, String representativeImageUrl) {
+		return new GetPostTreeResponse(
+			postEntity.getId(),
+			postEntity.getTitle(),
+			postEntity.getParentPostId(),
+			representativeImageUrl,
+			postEntity.getDerivedPostStatus()
+		);
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/postReview/controller/PostReviewController.java
+++ b/src/main/java/hanium/modic/backend/web/postReview/controller/PostReviewController.java
@@ -97,6 +97,23 @@ public class PostReviewController {
 		return ResponseEntity.ok().build();
 	}
 
+	@GetMapping("/{reviewId}")
+	@Operation(
+		summary = "포스트 리뷰 상세 조회",
+		description = "특정 리뷰의 상세 정보를 조회합니다. 작성자 정보, 내용, 이미지가 포함됩니다.",
+		responses = {
+			@ApiResponse(responseCode = "404", description = "해당 리뷰를 찾을 수 없습니다.[R-001]"),
+			@ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.[U-002]")
+		}
+	)
+	public ResponseEntity<AppResponse<PostReviewDetailResponse>> getPostReviewDetail(
+		@PathVariable long reviewId
+	) {
+		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);
+
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+
 	@GetMapping
 	@Operation(
 		summary = "포스트 리뷰 목록 조회",

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -44,6 +44,7 @@ import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
 import hanium.modic.backend.web.post.dto.response.GetSimplePostsResponse;
 
 @ExtendWith(MockitoExtension.class)
@@ -726,5 +727,131 @@ class PostServiceTest {
 		verify(postEntityRepository).findIdsByParentPostIdOrderByIdDesc(postId);
 		// 비로그인 사용자이므로 isLikedByUser는 호출되지 않음
 		verify(postLikeService, never()).isLikedByUser(any(), any());
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 성공 - 하위 포스트가 있는 경우")
+	void getPostTree_WithChildPosts_ShouldReturnTreeResponse() {
+		// given
+		UserEntity mockUser = UserFactory.createMockUser(1L);
+		Long rootPostId = 1L;
+		PostEntity rootPost = createMockPostWithId(rootPostId, mockUser);
+		PostEntity childPost1 = createMockAiDerivedPostWithId(2L, mockUser, rootPostId);
+		PostEntity childPost2 = createMockAiDerivedPostWithId(3L, mockUser, rootPostId);
+
+		List<PostEntity> treeNodes = List.of(rootPost, childPost1, childPost2);
+		List<PostImageEntity> rootImages = ImageFactory.createMockPostImages(rootPost, 1);
+		List<PostImageEntity> child1Images = ImageFactory.createMockPostImages(childPost1, 1);
+		List<PostImageEntity> child2Images = ImageFactory.createMockPostImages(childPost2, 1);
+		List<PostImageEntity> allImages = new ArrayList<>();
+		allImages.addAll(rootImages);
+		allImages.addAll(child1Images);
+		allImages.addAll(child2Images);
+
+		when(postEntityRepository.existsById(rootPostId)).thenReturn(true);
+		when(postEntityRepository.findAllDescendantsByPostId(rootPostId)).thenReturn(treeNodes);
+		when(postImageEntityRepository.findAllByPostIdIn(List.of(1L, 2L, 3L))).thenReturn(allImages);
+		when(imageUtil.createImageGetUrl(any())).thenReturn("http://example.com/image.jpg");
+
+		// when
+		List<GetPostTreeResponse> result = postService.getPostTree(rootPostId);
+
+		// then
+		assertThat(result).hasSize(3);
+
+		GetPostTreeResponse rootResponse = result.get(0);
+		assertThat(rootResponse.postId()).isEqualTo(rootPostId);
+		assertThat(rootResponse.title()).isEqualTo(rootPost.getTitle());
+		assertThat(rootResponse.parentPostId()).isNull();
+		assertThat(rootResponse.representativeImageUrl()).isEqualTo("http://example.com/image.jpg");
+		assertThat(rootResponse.postStatus()).isEqualTo(rootPost.getDerivedPostStatus());
+
+		GetPostTreeResponse child1Response = result.get(1);
+		assertThat(child1Response.postId()).isEqualTo(2L);
+		assertThat(child1Response.parentPostId()).isEqualTo(rootPostId);
+
+		GetPostTreeResponse child2Response = result.get(2);
+		assertThat(child2Response.postId()).isEqualTo(3L);
+		assertThat(child2Response.parentPostId()).isEqualTo(rootPostId);
+
+		verify(postEntityRepository).existsById(rootPostId);
+		verify(postEntityRepository).findAllDescendantsByPostId(rootPostId);
+		verify(postImageEntityRepository).findAllByPostIdIn(any());
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 실패 - 존재하지 않는 포스트")
+	void getPostTree_PostNotFound_ShouldThrowException() {
+		// given
+		Long nonExistentPostId = 999L;
+		when(postEntityRepository.existsById(nonExistentPostId)).thenReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> postService.getPostTree(nonExistentPostId))
+			.isInstanceOf(AppException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND_EXCEPTION);
+
+		verify(postEntityRepository).existsById(nonExistentPostId);
+		verify(postEntityRepository, never()).findAllDescendantsByPostId(any());
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 성공 - 하위 포스트가 없는 경우")
+	void getPostTree_WithoutChildPosts_ShouldReturnSingleNode() {
+		// given
+		UserEntity mockUser = UserFactory.createMockUser(1L);
+		Long rootPostId = 1L;
+		PostEntity rootPost = createMockPostWithId(rootPostId, mockUser);
+		List<PostEntity> treeNodes = List.of(rootPost);
+		List<PostImageEntity> rootImages = ImageFactory.createMockPostImages(rootPost, 1);
+
+		when(postEntityRepository.existsById(rootPostId)).thenReturn(true);
+		when(postEntityRepository.findAllDescendantsByPostId(rootPostId)).thenReturn(treeNodes);
+		when(postImageEntityRepository.findAllByPostIdIn(List.of(rootPostId))).thenReturn(rootImages);
+		when(imageUtil.createImageGetUrl(any())).thenReturn("http://example.com/image.jpg");
+
+		// when
+		List<GetPostTreeResponse> result = postService.getPostTree(rootPostId);
+
+		// then
+		assertThat(result).hasSize(1);
+
+		GetPostTreeResponse response = result.get(0);
+		assertThat(response.postId()).isEqualTo(rootPostId);
+		assertThat(response.title()).isEqualTo(rootPost.getTitle());
+		assertThat(response.parentPostId()).isNull();
+		assertThat(response.representativeImageUrl()).isEqualTo("http://example.com/image.jpg");
+
+		verify(postEntityRepository).existsById(rootPostId);
+		verify(postEntityRepository).findAllDescendantsByPostId(rootPostId);
+		verify(postImageEntityRepository).findAllByPostIdIn(any());
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 성공 - 이미지가 없는 포스트")
+	void getPostTree_WithoutImages_ShouldReturnNullImageUrl() {
+		// given
+		UserEntity mockUser = UserFactory.createMockUser(1L);
+		Long rootPostId = 1L;
+		PostEntity rootPost = createMockPostWithId(rootPostId, mockUser);
+		List<PostEntity> treeNodes = List.of(rootPost);
+
+		when(postEntityRepository.existsById(rootPostId)).thenReturn(true);
+		when(postEntityRepository.findAllDescendantsByPostId(rootPostId)).thenReturn(treeNodes);
+		when(postImageEntityRepository.findAllByPostIdIn(List.of(rootPostId))).thenReturn(Collections.emptyList());
+
+		// when
+		List<GetPostTreeResponse> result = postService.getPostTree(rootPostId);
+
+		// then
+		assertThat(result).hasSize(1);
+
+		GetPostTreeResponse response = result.get(0);
+		assertThat(response.postId()).isEqualTo(rootPostId);
+		assertThat(response.representativeImageUrl()).isNull();
+
+		verify(postEntityRepository).existsById(rootPostId);
+		verify(postEntityRepository).findAllDescendantsByPostId(rootPostId);
+		verify(postImageEntityRepository).findAllByPostIdIn(any());
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/postReview/service/PostReviewServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/postReview/service/PostReviewServiceTest.java
@@ -1,0 +1,197 @@
+package hanium.modic.backend.domain.postReview.service;
+
+import static hanium.modic.backend.common.error.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.postReview.entity.PostReviewEntity;
+import hanium.modic.backend.domain.postReview.entity.PostReviewImageEntity;
+import hanium.modic.backend.domain.postReview.repository.PostReviewImageRepository;
+import hanium.modic.backend.domain.postReview.repository.PostReviewRepository;
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.web.postReview.dto.response.PostReviewDetailResponse;
+
+@ExtendWith(MockitoExtension.class)
+class PostReviewServiceTest {
+
+	@Mock
+	private PostReviewRepository postReviewRepository;
+	@Mock
+	private PostReviewImageService postReviewImageService;
+	@Mock
+	private PostReviewImageRepository postReviewImageRepository;
+	@Mock
+	private UserEntityRepository userEntityRepository;
+
+	@InjectMocks
+	private PostReviewService postReviewService;
+
+	@Test
+	@DisplayName("후기 상세 조회 - 성공")
+	void getPostReviewDetail_Success() {
+		// Given
+		Long reviewId = 1L;
+		Long userId = 1L;
+		LocalDateTime createTime = LocalDateTime.of(2024, 1, 1, 12, 0);
+
+		PostReviewEntity mockReview = mock(PostReviewEntity.class);
+		when(mockReview.getId()).thenReturn(reviewId);
+		when(mockReview.getUserId()).thenReturn(userId);
+		when(mockReview.getDescription()).thenReturn("테스트 리뷰입니다.");
+		when(mockReview.getCreateAt()).thenReturn(createTime);
+
+		UserEntity mockUser = mock(UserEntity.class);
+		when(mockUser.getName()).thenReturn("testUser");
+		when(mockUser.getUserImageUrl()).thenReturn("https://example.com/user.jpg");
+
+		PostReviewImageEntity mockImage1 = mock(PostReviewImageEntity.class);
+		when(mockImage1.getId()).thenReturn(1L);
+
+		PostReviewImageEntity mockImage2 = mock(PostReviewImageEntity.class);
+		when(mockImage2.getId()).thenReturn(2L);
+
+		List<PostReviewImageEntity> mockImages = List.of(mockImage1, mockImage2);
+
+		when(postReviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
+		when(userEntityRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(postReviewImageRepository.findAllByPostReviewId(reviewId)).thenReturn(mockImages);
+		when(postReviewImageService.createImageGetUrl(1L)).thenReturn("https://example.com/image1.jpg");
+		when(postReviewImageService.createImageGetUrl(2L)).thenReturn("https://example.com/image2.jpg");
+
+		// When
+		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);
+
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.userName()).isEqualTo("testUser");
+		assertThat(response.hasUserImage()).isTrue();
+		assertThat(response.userImageUrl()).isEqualTo("https://example.com/user.jpg");
+		assertThat(response.createdAt()).isEqualTo(createTime);
+		assertThat(response.postReviewId()).isEqualTo(reviewId);
+		assertThat(response.description()).isEqualTo("테스트 리뷰입니다.");
+		assertThat(response.imageUrls()).hasSize(2);
+		assertThat(response.imageUrls()).containsExactly(
+			"https://example.com/image1.jpg",
+			"https://example.com/image2.jpg"
+		);
+	}
+
+	@Test
+	@DisplayName("후기 상세 조회 - 리뷰 없음")
+	void getPostReviewDetail_ReviewNotFound() {
+		// Given
+		Long nonExistentReviewId = 999L;
+		when(postReviewRepository.findById(nonExistentReviewId)).thenReturn(Optional.empty());
+
+		// When & Then
+		AppException exception = assertThrows(AppException.class,
+			() -> postReviewService.getPostReviewDetail(nonExistentReviewId));
+
+		assertThat(exception.getErrorCode()).isEqualTo(POST_REVIEW_NOT_FOUND_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("후기 상세 조회 - 사용자 없음")
+	void getPostReviewDetail_UserNotFound() {
+		// Given
+		Long reviewId = 1L;
+		Long userId = 1L;
+
+		PostReviewEntity mockReview = mock(PostReviewEntity.class);
+		when(mockReview.getUserId()).thenReturn(userId);
+
+		when(postReviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
+		when(userEntityRepository.findById(userId)).thenReturn(Optional.empty());
+
+		// When & Then
+		AppException exception = assertThrows(AppException.class,
+			() -> postReviewService.getPostReviewDetail(reviewId));
+
+		assertThat(exception.getErrorCode()).isEqualTo(USER_NOT_FOUND_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("후기 상세 조회 - 이미지 없음")
+	void getPostReviewDetail_NoImages() {
+		// Given
+		Long reviewId = 1L;
+		Long userId = 1L;
+		LocalDateTime createTime = LocalDateTime.of(2024, 1, 1, 12, 0);
+
+		PostReviewEntity mockReview = mock(PostReviewEntity.class);
+		when(mockReview.getId()).thenReturn(reviewId);
+		when(mockReview.getUserId()).thenReturn(userId);
+		when(mockReview.getDescription()).thenReturn("이미지 없는 리뷰입니다.");
+		when(mockReview.getCreateAt()).thenReturn(createTime);
+
+		UserEntity mockUser = mock(UserEntity.class);
+		when(mockUser.getName()).thenReturn("testUser");
+		when(mockUser.getUserImageUrl()).thenReturn("https://example.com/user.jpg");
+
+		when(postReviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
+		when(userEntityRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(postReviewImageRepository.findAllByPostReviewId(reviewId)).thenReturn(Collections.emptyList());
+
+		// When
+		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);
+
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.userName()).isEqualTo("testUser");
+		assertThat(response.hasUserImage()).isTrue();
+		assertThat(response.userImageUrl()).isEqualTo("https://example.com/user.jpg");
+		assertThat(response.postReviewId()).isEqualTo(reviewId);
+		assertThat(response.description()).isEqualTo("이미지 없는 리뷰입니다.");
+		assertThat(response.imageUrls()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("후기 상세 조회 - 프로필 사진 없는 사용자")
+	void getPostReviewDetail_UserWithoutProfileImage() {
+		// Given
+		Long reviewId = 1L;
+		Long userId = 1L;
+		LocalDateTime createTime = LocalDateTime.of(2024, 1, 1, 12, 0);
+
+		PostReviewEntity mockReview = mock(PostReviewEntity.class);
+		when(mockReview.getId()).thenReturn(reviewId);
+		when(mockReview.getUserId()).thenReturn(userId);
+		when(mockReview.getDescription()).thenReturn("프로필 없는 사용자의 리뷰입니다.");
+		when(mockReview.getCreateAt()).thenReturn(createTime);
+
+		UserEntity mockUser = mock(UserEntity.class);
+		when(mockUser.getName()).thenReturn("testUser");
+		when(mockUser.getUserImageUrl()).thenReturn(null);
+
+		when(postReviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
+		when(userEntityRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(postReviewImageRepository.findAllByPostReviewId(reviewId)).thenReturn(Collections.emptyList());
+
+		// When
+		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);
+
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.userName()).isEqualTo("testUser");
+		assertThat(response.hasUserImage()).isFalse();
+		assertThat(response.userImageUrl()).isNull();
+		assertThat(response.postReviewId()).isEqualTo(reviewId);
+		assertThat(response.description()).isEqualTo("프로필 없는 사용자의 리뷰입니다.");
+		assertThat(response.imageUrls()).isEmpty();
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.post.enums.PostType;
 import hanium.modic.backend.domain.postReview.service.PostReviewAuthorizationService;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +38,7 @@ import hanium.modic.backend.web.post.dto.request.CreatePostRequest;
 import hanium.modic.backend.web.post.dto.request.UpdatePostRequest;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
 
 @WebMvcTest(controllers = PostController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -384,5 +386,84 @@ class PostControllerTest extends BaseControllerTest {
 				"이미지 개수 초과"
 			)
 		);
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 성공")
+	void getPostTree_Success() throws Exception {
+		// given
+		Long postId = 1L;
+		List<GetPostTreeResponse> mockResponse = List.of(
+			new GetPostTreeResponse(1L, "Root Post", null, "http://example.com/image1.jpg", PostStatus.APPROVED),
+			new GetPostTreeResponse(2L, "Child Post 1", 1L, "http://example.com/image2.jpg", PostStatus.PENDING),
+			new GetPostTreeResponse(3L, "Child Post 2", 1L, "http://example.com/image3.jpg", PostStatus.APPROVED)
+		);
+
+		when(postService.getPostTree(postId)).thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/posts/{postId}/tree", postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data.length()").value(3))
+			.andExpect(jsonPath("$.data[0].postId").value(1))
+			.andExpect(jsonPath("$.data[0].title").value("Root Post"))
+			.andExpect(jsonPath("$.data[0].parentPostId").doesNotExist())
+			.andExpect(jsonPath("$.data[0].representativeImageUrl").value("http://example.com/image1.jpg"))
+			.andExpect(jsonPath("$.data[0].postStatus").value("APPROVED"))
+			.andExpect(jsonPath("$.data[1].postId").value(2))
+			.andExpect(jsonPath("$.data[1].parentPostId").value(1))
+			.andExpect(jsonPath("$.data[1].postStatus").value("PENDING"))
+			.andExpect(jsonPath("$.data[2].postId").value(3))
+			.andExpect(jsonPath("$.data[2].parentPostId").value(1))
+			.andExpect(jsonPath("$.data[2].postStatus").value("APPROVED"));
+
+		verify(postService).getPostTree(postId);
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 실패 - 존재하지 않는 포스트")
+	void getPostTree_PostNotFound() throws Exception {
+		// given
+		Long postId = 999L;
+		when(postService.getPostTree(postId)).thenThrow(new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION));
+
+		// when & then
+		mockMvc.perform(get("/api/posts/{postId}/tree", postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.isSuccess").value(false))
+			.andExpect(jsonPath("$.code").value("P-001"));
+
+		verify(postService).getPostTree(postId);
+	}
+
+	@Test
+	@DisplayName("포스트 트리 조회 성공 - 하위 포스트가 없는 경우")
+	void getPostTree_SingleNode() throws Exception {
+		// given
+		Long postId = 1L;
+		List<GetPostTreeResponse> mockResponse = List.of(
+			new GetPostTreeResponse(1L, "Single Post", null, "http://example.com/image.jpg", PostStatus.APPROVED)
+		);
+
+		when(postService.getPostTree(postId)).thenReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/posts/{postId}/tree", postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].postId").value(1))
+			.andExpect(jsonPath("$.data[0].title").value("Single Post"))
+			.andExpect(jsonPath("$.data[0].parentPostId").doesNotExist())
+			.andExpect(jsonPath("$.data[0].representativeImageUrl").value("http://example.com/image.jpg"))
+			.andExpect(jsonPath("$.data[0].postStatus").value("APPROVED"));
+
+		verify(postService).getPostTree(postId);
 	}
 }


### PR DESCRIPTION
## Summary

포스트 리뷰 상세 조회 API를 구현했습니다. 설계 문서(`docs/post-review-detail-api-design.md`)에 따라 단일 리뷰에 대한 상세 정보를 제공하는 새로운 엔드포인트를 추가했습니다.

### 주요 변경사항

- **PostReviewController**: `GET /{reviewId}` 엔드포인트 추가
- **PostReviewService**: `getPostReviewDetail()` 메서드 구현  
- **단위 테스트**: 5가지 테스트 시나리오 구현
- **OpenAPI 문서화**: Swagger 어노테이션 추가

### 기능 상세

- 작성자 정보 (이름, 프로필 사진)
- 리뷰 내용 및 생성일
- 첨부된 이미지 URL 목록
- 적절한 에러 처리 (404: 리뷰/사용자 없음)

## Test Plan

✅ **단위 테스트**
- [x] 후기 상세 조회 성공 (모든 필드 검증)
- [x] 리뷰 없음 예외 처리 (POST_REVIEW_NOT_FOUND_EXCEPTION)
- [x] 사용자 없음 예외 처리 (USER_NOT_FOUND_EXCEPTION)  
- [x] 이미지 없는 리뷰 처리 (빈 배열 반환)
- [x] 프로필 사진 없는 사용자 처리 (hasUserImage: false)

✅ **API 검증 항목**
- [x] 존재하는 reviewId로 조회 시 200 OK + 상세 데이터 반환
- [x] 존재하지 않는 reviewId로 조회 시 404 NOT_FOUND
- [x] 프로필 사진 유무에 따른 hasUserImage 필드 정확성
- [x] 이미지가 없는 경우 빈 배열 반환
- [x] 모든 필드 (userName, createdAt, description, imageUrls) 존재 확인

🔄 **수동 테스트 필요**
- [ ] Swagger UI에서 API 문서 확인
- [ ] 실제 데이터로 엔드포인트 호출 테스트
- [ ] 프론트엔드 연동 테스트

## 기술적 고려사항

- **성능**: 기존 목록 조회와 동일한 패턴으로 N+1 문제 방지
- **일관성**: 기존 PostReviewDetailResponse 재사용으로 API 일관성 유지  
- **에러 처리**: 기존 에러 처리 패턴 준수 (AppException, ErrorCode)
- **확장성**: 향후 좋아요/댓글수 기능 추가 시 최소한의 변경으로 대응 가능

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 후기 상세 조회 API 추가: 작성자 정보, 프로필 이미지 존재 여부/URL, 후기 설명, 생성 시각, 첨부 이미지 URL 목록 제공(404 처리 명시).
  * 게시글 트리 조회 API 추가: 루트 게시글의 하위 트리(대표 이미지, 상태 포함) 반환.
* **문서**
  * 여러 AI 채팅 설계·이슈 및 게시글 트리 API 설계 문서 추가.
* **테스트**
  * 단위테스트 추가: 후기 및 게시글 트리 성공/실패/이미지 관련 시나리오 검증.
* **환경**
  * 멀티스테이지 Docker 이미지 및 docker-compose 구성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->