### PR TITLE
feat(vote): 투표 완료 시 정답 참여자에게 리워드 티켓 지급

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/vote/repository/SimilarityVoteResultRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/repository/SimilarityVoteResultRepository.java
@@ -1,10 +1,13 @@
 package hanium.modic.backend.domain.vote.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import hanium.modic.backend.domain.vote.entity.SimilarityVoteResultEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
 
 public interface SimilarityVoteResultRepository extends JpaRepository<SimilarityVoteResultEntity, Long> {
 
@@ -24,4 +27,9 @@ public interface SimilarityVoteResultRepository extends JpaRepository<Similarity
 	long countTodayVotesByUserId(@Param("userId") Long userId,
 		@Param("startOfDay") java.time.LocalDateTime startOfDay,
 		@Param("startOfNextDay") java.time.LocalDateTime startOfNextDay);
+
+	/**
+	 * 특정 투표에서 특정 결정을 한 참여자들만 조회
+	 */
+	List<SimilarityVoteResultEntity> findByVoteIdAndDecision(Long voteId, VoteDecision decision);
 }

--- a/src/main/java/hanium/modic/backend/domain/vote/service/VoteCompletionRewardService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VoteCompletionRewardService.java
@@ -1,0 +1,79 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static hanium.modic.backend.common.error.ErrorCode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.redis.distributedLock.LockManager;
+import hanium.modic.backend.common.error.exception.LockException;
+import hanium.modic.backend.domain.ticket.service.TicketService;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteResultEntity;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteResultRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class VoteCompletionRewardService {
+
+    private final SimilarityVoteRepository similarityVoteRepository;
+    private final SimilarityVoteSummaryRepository voteSummaryRepository;
+    private final SimilarityVoteResultRepository voteResultRepository;
+    private final TicketService ticketService;
+    private final LockManager lockManager;
+
+    /**
+     * 투표가 완료되었을 때 최종 결정과 동일한 판단을 한 사용자들에게 리워드 티켓 지급
+     */
+    public void processCompletionReward(Long voteId) {
+        // 1) 투표 존재 확인
+        similarityVoteRepository.findById(voteId)
+            .orElseThrow(() -> new AppException(VOTE_NOT_FOUND_EXCEPTION));
+
+        // 2) 최종 결과 확인
+        SimilarityVoteSummaryEntity summary = voteSummaryRepository.findByVoteId(voteId)
+            .orElseThrow(() -> new AppException(VOTE_SUMMARY_NOT_FOUND_EXCEPTION));
+
+        VoteDecision finalDecision = summary.getFinalDecision();
+        if (finalDecision == null || finalDecision == VoteDecision.PENDING) {
+            log.warn("투표 최종 결정이 확정되지 않음: voteId={}", voteId);
+            return; // 완료 콜만 수행, 리워드는 보류
+        }
+
+        // 3) 최종 결정과 동일한 결정을 한 참여자 조회
+        List<SimilarityVoteResultEntity> correctResults = voteResultRepository.findByVoteIdAndDecision(voteId, finalDecision);
+        List<Long> userIds = correctResults.stream().map(SimilarityVoteResultEntity::getUserId).distinct().toList();
+
+        if (userIds.isEmpty()) {
+            log.info("완료 리워드 대상 사용자가 없음: voteId={}, finalDecision={}", voteId, finalDecision);
+            return;
+        }
+
+        // 4) 다중 사용자 분산락 하에 티켓 지급 (원자성 보장)
+        try {
+            lockManager.multipleUserLock(userIds, () -> {
+                for (Long userId : userIds) {
+                    ticketService.giveRewardTicket(userId);
+                }
+            });
+        } catch (LockException e) {
+            log.error("완료 리워드 분산락 획득 실패: voteId={}, userCount={}", voteId, userIds.size(), e);
+            throw new AppException(VOTE_UPDATE_FAIL_EXCEPTION);
+        }
+
+        log.info("투표 완료 리워드 지급 완료: voteId={}, finalDecision={}, rewardedUsers={}",
+            voteId, finalDecision, userIds.size());
+    }
+}
+
+

--- a/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
@@ -44,6 +44,7 @@ public class VotingService {
 	private final LockManager lockManager;
 	private final VoteProperties voteProperties;
 	private final VoteRewardService voteRewardService;
+	private final VoteCompletionRewardService voteCompletionRewardService;
 
 	/**
 	 * 투표 참여 메서드
@@ -155,6 +156,13 @@ public class VotingService {
 
 				// 연결된 파생 게시물의 상태 업데이트
 				updateDerivedPostStatus(voteId);
+
+				// 투표 완료 리워드 처리 (에러는 로깅만)
+				try {
+					voteCompletionRewardService.processCompletionReward(voteId);
+				} catch (Exception e) {
+					log.error("투표 완료 리워드 처리 실패: voteId={}", voteId, e);
+				}
 			}
 		}
 

--- a/src/test/java/hanium/modic/backend/domain/vote/service/VoteCompletionRewardServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/vote/service/VoteCompletionRewardServiceTest.java
@@ -1,0 +1,121 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.error.exception.LockException;
+import hanium.modic.backend.common.redis.distributedLock.LockManager;
+import hanium.modic.backend.domain.ticket.service.TicketService;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteResultEntity;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteResultRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+
+@ExtendWith(MockitoExtension.class)
+class VoteCompletionRewardServiceTest {
+
+    @Mock SimilarityVoteRepository voteRepository;
+    @Mock SimilarityVoteSummaryRepository summaryRepository;
+    @Mock SimilarityVoteResultRepository resultRepository;
+    @Mock TicketService ticketService;
+    @Mock LockManager lockManager;
+
+    @InjectMocks VoteCompletionRewardService sut;
+
+    @Test
+    @DisplayName("투표 완료 시 정답 참여자들에게 티켓을 지급한다")
+    void processCompletionReward_Success() throws Exception {
+        Long voteId = 1L;
+
+        when(voteRepository.findById(voteId)).thenReturn(Optional.of(mock(SimilarityVoteEntity.class)));
+        // summary with final decision APPROVE
+        SimilarityVoteSummaryEntity summary = SimilarityVoteSummaryEntity.builder()
+            .voteId(voteId)
+            .approveWeight(10L)
+            .denyWeight(0L)
+            .totalWeight(10L)
+            .finalDecision(VoteDecision.APPROVE)
+            .build();
+        when(summaryRepository.findByVoteId(voteId)).thenReturn(Optional.of(summary));
+
+        // two correct users
+        SimilarityVoteResultEntity r1 = SimilarityVoteResultEntity.builder().voteId(voteId).userId(10L).decision(VoteDecision.APPROVE).build();
+        SimilarityVoteResultEntity r2 = SimilarityVoteResultEntity.builder().voteId(voteId).userId(20L).decision(VoteDecision.APPROVE).build();
+        when(resultRepository.findByVoteIdAndDecision(voteId, VoteDecision.APPROVE)).thenReturn(List.of(r1, r2));
+
+        // lock executes runnable immediately
+        doAnswer(invocation -> { Runnable r = invocation.getArgument(1); r.run(); return null; })
+            .when(lockManager).multipleUserLock(eq(List.of(10L, 20L)), any());
+
+        sut.processCompletionReward(voteId);
+
+        verify(ticketService, times(1)).giveRewardTicket(10L);
+        verify(ticketService, times(1)).giveRewardTicket(20L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투표에 대한 리워드 처리 시 예외를 발생시킨다")
+    void processCompletionReward_VoteNotFound() {
+        Long voteId = 1L;
+        when(voteRepository.findById(voteId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.processCompletionReward(voteId)).isInstanceOf(AppException.class);
+    }
+
+    @Test
+    @DisplayName("모든 참여자가 오답인 경우 아무도 티켓을 받지 않는다")
+    void processCompletionReward_AllWrongAnswers() throws Exception {
+        Long voteId = 1L;
+        when(voteRepository.findById(voteId)).thenReturn(Optional.of(mock(SimilarityVoteEntity.class)));
+        SimilarityVoteSummaryEntity summary = SimilarityVoteSummaryEntity.builder()
+            .voteId(voteId)
+            .approveWeight(0L)
+            .denyWeight(10L)
+            .totalWeight(10L)
+            .finalDecision(VoteDecision.DENY)
+            .build();
+        when(summaryRepository.findByVoteId(voteId)).thenReturn(Optional.of(summary));
+        when(resultRepository.findByVoteIdAndDecision(voteId, VoteDecision.DENY)).thenReturn(List.of());
+
+        sut.processCompletionReward(voteId);
+        verify(ticketService, never()).giveRewardTicket(anyLong());
+    }
+
+    @Test
+    @DisplayName("티켓 지급 중 예외 발생 시 전체 작업이 롤백된다(락 획득 실패)")
+    void processCompletionReward_TicketDistributionFails() throws Exception {
+        Long voteId = 1L;
+        when(voteRepository.findById(voteId)).thenReturn(Optional.of(mock(SimilarityVoteEntity.class)));
+        SimilarityVoteSummaryEntity summary = SimilarityVoteSummaryEntity.builder()
+            .voteId(voteId)
+            .approveWeight(10L)
+            .denyWeight(0L)
+            .totalWeight(10L)
+            .finalDecision(VoteDecision.APPROVE)
+            .build();
+        when(summaryRepository.findByVoteId(voteId)).thenReturn(Optional.of(summary));
+        SimilarityVoteResultEntity r1 = SimilarityVoteResultEntity.builder().voteId(voteId).userId(10L).decision(VoteDecision.APPROVE).build();
+        when(resultRepository.findByVoteIdAndDecision(voteId, VoteDecision.APPROVE)).thenReturn(List.of(r1));
+
+        doThrow(new LockException(new RuntimeException("fail"))).when(lockManager).multipleUserLock(eq(List.of(10L)), any());
+
+        assertThatThrownBy(() -> sut.processCompletionReward(voteId)).isInstanceOf(AppException.class);
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- 투표 완료 시 정답을 선택한 참여자들에게 리워드 티켓을 지급하는 기능 구현
- VoteCompletionRewardService를 통한 분산락 기반 안전한 리워드 처리

## Changes
- **VoteCompletionRewardService**: 투표 완료 시 정답 참여자 식별 및 티켓 지급 서비스 신규 추가
- **SimilarityVoteResultRepository**: `findByVoteIdAndDecision` 메서드 추가로 정답 참여자 조회 기능 구현
- **VotingService**: 투표 완료 처리 시 리워드 지급 로직 연동 (예외 발생 시 로깅 처리)
- **VoteCompletionRewardServiceTest**: 신규 서비스에 대한 단위 테스트 추가

## Test plan
- [ ] 투표 완료 시 정답 참여자에게 티켓이 정상 지급되는지 확인
- [ ] 분산락을 통한 동시성 처리가 올바르게 작동하는지 테스트
- [ ] 리워드 지급 실패 시 기존 투표 기능에 영향이 없는지 확인
- [ ] 단위 테스트 실행: `./gradlew test --tests "*VoteCompletionRewardServiceTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 투표가 완료되면 최종 결정과 일치한 참여자에게 보상 티켓이 자동 지급됩니다.
  - 지급 과정은 중복 지급을 방지하고 안정적으로 처리되어, 일시적 장애가 있어도 투표 완료 흐름에는 영향이 없습니다.
  - 사용자는 추가 조치 없이 보상을 수령하며, 관련 알림/경험은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->