### PR TITLE
feat: AI 서버용 투표 집계 조회 API 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/vote/entity/SimilarityVoteSummaryEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/entity/SimilarityVoteSummaryEntity.java
@@ -16,6 +16,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 유사도 투표 집계 엔티티
+ * - 투표별 가중치 합산 결과와 AI/최종 결정 상태를 보관합니다.
+ * - AI 서버(또는 외부 소비자)가 조회했는지 여부를 `fetchedByAi` 로 추적합니다.
+ */
 @Table(name = "similarity_vote_summary",
 	indexes = {
 		@Index(name = "idx_similarity_vote_summary_vote_id", columnList = "vote_id")
@@ -48,6 +53,12 @@ public class SimilarityVoteSummaryEntity extends BaseEntity {
 	@Column(name = "final_decision")
 	@Enumerated(EnumType.STRING)
 	private VoteDecision finalDecision;
+
+	/**
+	 * AI 서버에서 완료 결과를 조회했는지 여부
+	 */
+	@Column(name = "fetched_by_ai", nullable = false)
+	private Boolean fetchedByAi = false;
 
 	@Builder
 	public SimilarityVoteSummaryEntity(
@@ -86,12 +97,22 @@ public class SimilarityVoteSummaryEntity extends BaseEntity {
 		this.aiDecision = aiDecision;
 	}
 
+	/**
+	 * 최소 총 가중치 임계치에 도달한 경우 최종 결정을 결정합니다.
+	 * 임계치 미만일 경우 PENDING 상태를 유지합니다.
+	 */
 	public void updateFinalDecision(long minTotalWeight) {
-		// 최소 총 가중치에 도달한 경우에만 최종 결정을 업데이트
 		if (this.totalWeight >= minTotalWeight) {
 			this.finalDecision = this.approveWeight > this.denyWeight ? VoteDecision.APPROVE : VoteDecision.DENY;
 		} else {
-			this.finalDecision = VoteDecision.PENDING; // 아직 임계치에 도달하지 않은 경우 대기 상태 유지
+			this.finalDecision = VoteDecision.PENDING;
 		}
+	}
+
+	/**
+	 * 외부(AI 서버)가 조회 완료로 표시합니다.
+	 */
+	public void markAsFetched() {
+		this.fetchedByAi = true;
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/vote/repository/SimilarityVoteSummaryRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/repository/SimilarityVoteSummaryRepository.java
@@ -1,13 +1,20 @@
 package hanium.modic.backend.domain.vote.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
 
+/**
+ * 유사도 투표 집계 리포지토리
+ * - 투표별 집계 조회 및 완료/조회 상태 관련 쿼리를 제공합니다.
+ */
 public interface SimilarityVoteSummaryRepository extends JpaRepository<SimilarityVoteSummaryEntity, Long> {
 
 	/**
@@ -22,4 +29,21 @@ public interface SimilarityVoteSummaryRepository extends JpaRepository<Similarit
 	@Query("SELECT COUNT(svs) > 0 FROM SimilarityVoteSummaryEntity svs " +
 		"WHERE svs.voteId = :voteId AND svs.totalWeight >= :minTotalWeight")
 	boolean isVoteCompleted(@Param("voteId") Long voteId, @Param("minTotalWeight") int minTotalWeight);
+
+	/**
+	 * 파생 쿼리: 최종 결정이 PENDING이 아니며 아직 AI에서 조회하지 않은 건수
+	 */
+	long countByFinalDecisionNotAndFetchedByAiFalse(VoteDecision finalDecision);
+
+	/**
+	 * 파생 쿼리: 최종 결정이 PENDING이 아니며 아직 AI에서 조회하지 않은 목록
+	 */
+	List<SimilarityVoteSummaryEntity> findByFinalDecisionNotAndFetchedByAiFalse(VoteDecision finalDecision);
+
+	/**
+	 * 대량 업데이트: 조회 완료로 마킹
+	 */
+	@Modifying
+	@Query("UPDATE SimilarityVoteSummaryEntity s SET s.fetchedByAi = true WHERE s.id IN :ids")
+	void markAsFetchedByIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/hanium/modic/backend/domain/vote/service/VoteSummaryQueryService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VoteSummaryQueryService.java
@@ -1,0 +1,56 @@
+package hanium.modic.backend.domain.vote.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryAiResponse;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryCountResponse;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryListResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 투표 집계 조회 서비스
+ * - AI 서버(또는 외부)에서 사용할 완료 결과 조회/카운트 기능을 제공합니다.
+ * - 조회 시 즉시 fetchedByAi=true로 마킹하여 중복 조회를 방지합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoteSummaryQueryService {
+
+	private final SimilarityVoteSummaryRepository voteSummaryRepository;
+
+    /**
+     * 최종 결정이 PENDING이 아닌(=완료된) 집계 결과 개수를 반환합니다.
+     */
+    public VoteSummaryCountResponse getCompletedCount() {
+		long count = voteSummaryRepository.countByFinalDecisionNotAndFetchedByAiFalse(VoteDecision.PENDING);
+		return new VoteSummaryCountResponse(count);
+	}
+
+	@Transactional
+    public VoteSummaryListResponse getCompletedSummaries() {
+		List<SimilarityVoteSummaryEntity> summaries =
+			voteSummaryRepository.findByFinalDecisionNotAndFetchedByAiFalse(VoteDecision.PENDING);
+
+		if (summaries.isEmpty()) {
+			return new VoteSummaryListResponse(List.of());
+		}
+
+        // 조회된 것으로 마킹하여 중복 응답 방지
+        List<Long> ids = summaries.stream().map(SimilarityVoteSummaryEntity::getId).toList();
+		voteSummaryRepository.markAsFetchedByIds(ids);
+
+		List<VoteSummaryAiResponse> items = summaries.stream()
+			.map(VoteSummaryAiResponse::of)
+			.toList();
+		return new VoteSummaryListResponse(items);
+	}
+}
+
+

--- a/src/main/java/hanium/modic/backend/web/vote/controller/VoteSummaryController.java
+++ b/src/main/java/hanium/modic/backend/web/vote/controller/VoteSummaryController.java
@@ -1,0 +1,39 @@
+package hanium.modic.backend.web.vote.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hanium.modic.backend.common.response.AppResponse;
+import hanium.modic.backend.domain.vote.service.VoteSummaryQueryService;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryCountResponse;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 투표 요약(집계) 조회 컨트롤러
+ * - 완료된 집계 결과 개수 및 상세 목록을 제공합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/votes/summaries")
+public class VoteSummaryController {
+
+	private final VoteSummaryQueryService voteSummaryQueryService;
+
+    @GetMapping("/count")
+    @Operation(summary = "완료된 집계 결과 개수 조회", description = "아직 조회되지 않은 완료된 vote summary의 개수를 조회합니다.")
+	public ResponseEntity<AppResponse<VoteSummaryCountResponse>> getCompletedCount() {
+		VoteSummaryCountResponse response = voteSummaryQueryService.getCompletedCount();
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+
+    @GetMapping
+    @Operation(summary = "완료된 집계 결과 조회", description = "완료된 vote summary 데이터를 조회하고 조회 완료로 마킹합니다.")
+	public ResponseEntity<AppResponse<VoteSummaryListResponse>> getCompletedSummaries() {
+		VoteSummaryListResponse responses = voteSummaryQueryService.getCompletedSummaries();
+		return ResponseEntity.ok(AppResponse.ok(responses));
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteSummaryAiResponse.java
+++ b/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteSummaryAiResponse.java
@@ -1,0 +1,32 @@
+package hanium.modic.backend.web.vote.dto.response;
+
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+
+/**
+ * 투표 요약 응답 DTO (단일 항목)
+ * - 승인/반대 비율과 AI/최종 결정을 제공합니다.
+ */
+public record VoteSummaryAiResponse(
+	Long voteId,
+	Double approveRatio,
+	Double denyRatio,
+	VoteDecision aiDecision,
+	VoteDecision finalDecision
+) {
+	public static VoteSummaryAiResponse of(SimilarityVoteSummaryEntity summary) {
+		double totalWeight = summary.getTotalWeight().doubleValue();
+		double approveRatio = totalWeight > 0 ? summary.getApproveWeight().doubleValue() / totalWeight : 0.0;
+		double denyRatio = totalWeight > 0 ? summary.getDenyWeight().doubleValue() / totalWeight : 0.0;
+
+        return new VoteSummaryAiResponse(
+			summary.getVoteId(),
+			approveRatio,
+			denyRatio,
+			summary.getAiDecision(),
+			summary.getFinalDecision()
+		);
+	}
+}
+
+

--- a/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteSummaryCountResponse.java
+++ b/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteSummaryCountResponse.java
@@ -1,0 +1,11 @@
+package hanium.modic.backend.web.vote.dto.response;
+
+/**
+ * 완료된 집계 결과 개수 응답 DTO
+ */
+public record VoteSummaryCountResponse(
+	Long count
+) {
+}
+
+

--- a/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteSummaryListResponse.java
+++ b/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteSummaryListResponse.java
@@ -1,0 +1,17 @@
+package hanium.modic.backend.web.vote.dto.response;
+
+import java.util.List;
+
+/**
+ * 투표 요약 목록 응답 DTO
+ * - 단일 항목 DTO인 VoteSummaryAiResponse의 리스트를 래핑합니다.
+ */
+public record VoteSummaryListResponse(
+    List<VoteSummaryAiResponse> items
+) {
+    public static VoteSummaryListResponse from(List<VoteSummaryAiResponse> list) {
+        return new VoteSummaryListResponse(list);
+    }
+}
+
+

--- a/src/test/java/hanium/modic/backend/domain/vote/service/VoteSummaryQueryServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/vote/service/VoteSummaryQueryServiceTest.java
@@ -1,0 +1,92 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryListResponse;
+
+@ExtendWith(MockitoExtension.class)
+class VoteSummaryQueryServiceTest {
+
+	@Mock
+	private SimilarityVoteSummaryRepository voteSummaryRepository;
+
+	@InjectMocks
+	private VoteSummaryQueryService sut;
+
+	@Test
+    @DisplayName("완료된 집계 결과 개수 조회: PENDING 제외 카운트 반환")
+	void getCompletedCount_returnsCount() {
+		// given
+		given(voteSummaryRepository.countByFinalDecisionNotAndFetchedByAiFalse(VoteDecision.PENDING))
+			.willReturn(3L);
+
+		// when
+		Long count = sut.getCompletedCount().count();
+
+		// then
+		assertThat(count).isEqualTo(3L);
+	}
+
+	@Test
+    @DisplayName("완료된 집계 결과 목록 조회: 조회 완료 마킹 후 래핑하여 반환")
+	void getCompletedSummaries_marksFetched_andReturnsWrapped() {
+		// given
+		SimilarityVoteSummaryEntity s1 = SimilarityVoteSummaryEntity.builder()
+			.voteId(1L)
+			.approveWeight(60L)
+			.denyWeight(40L)
+			.totalWeight(100L)
+			.aiDecision(VoteDecision.APPROVE)
+			.finalDecision(VoteDecision.APPROVE)
+			.build();
+		SimilarityVoteSummaryEntity s2 = SimilarityVoteSummaryEntity.builder()
+			.voteId(2L)
+			.approveWeight(30L)
+			.denyWeight(70L)
+			.totalWeight(100L)
+			.aiDecision(VoteDecision.DENY)
+			.finalDecision(VoteDecision.DENY)
+			.build();
+
+		given(voteSummaryRepository.findByFinalDecisionNotAndFetchedByAiFalse(VoteDecision.PENDING))
+			.willReturn(List.of(s1, s2));
+
+		// when
+		VoteSummaryListResponse response = sut.getCompletedSummaries();
+
+		// then
+		then(voteSummaryRepository).should().markAsFetchedByIds(anyList());
+		assertThat(response.items()).hasSize(2);
+		assertThat(response.items().get(0).approveRatio() + response.items().get(0).denyRatio()).isEqualTo(1.0);
+		assertThat(response.items().get(1).approveRatio() + response.items().get(1).denyRatio()).isEqualTo(1.0);
+	}
+
+	@Test
+    @DisplayName("완료된 집계 결과 목록 조회: 없을 경우 빈 목록 반환 및 마킹 미수행")
+	void getCompletedSummaries_empty() {
+		// given
+		given(voteSummaryRepository.findByFinalDecisionNotAndFetchedByAiFalse(VoteDecision.PENDING))
+			.willReturn(List.of());
+
+		// when
+		VoteSummaryListResponse response = sut.getCompletedSummaries();
+
+		// then
+		then(voteSummaryRepository).should(never()).markAsFetchedByIds(anyList());
+		assertThat(response.items()).isEmpty();
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/vote/controller/VoteSummaryControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/vote/controller/VoteSummaryControllerTest.java
@@ -1,0 +1,53 @@
+package hanium.modic.backend.web.vote.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import hanium.modic.backend.base.BaseControllerTest;
+import hanium.modic.backend.domain.vote.service.VoteSummaryQueryService;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryCountResponse;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryListResponse;
+
+@WebMvcTest(controllers = VoteSummaryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class VoteSummaryControllerTest extends BaseControllerTest {
+
+	@MockitoBean
+	private VoteSummaryQueryService voteSummaryQueryService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+    @DisplayName("[API] 완료된 집계 개수 조회 성공")
+	void getCompletedCount() throws Exception {
+		when(voteSummaryQueryService.getCompletedCount()).thenReturn(new VoteSummaryCountResponse(5L));
+
+		mockMvc.perform(get("/api/votes/summaries/count"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.count").value(5));
+	}
+
+	@Test
+    @DisplayName("[API] 완료된 집계 목록 조회 성공 (items 래핑)")
+	void getCompletedSummaries() throws Exception {
+		when(voteSummaryQueryService.getCompletedSummaries()).thenReturn(
+			VoteSummaryListResponse.from(java.util.List.of()));
+
+		mockMvc.perform(get("/api/votes/summaries"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.items").isArray());
+	}
+}
+
+


### PR DESCRIPTION
## 요약
AI 서버에서 완료된 투표 집계 결과를 조회할 수 있는 REST API를 구현했습니다.

### 주요 기능
- 완료된 투표 집계 개수 조회 API
- 완료된 투표 집계 상세 데이터 조회 API
- 중복 조회 방지를 위한 조회 완료 상태 추적
- 승인/반대 비율 계산 및 AI/최종 결정 제공

### API 엔드포인트
- `GET /api/votes/summaries/count` - 완료된 집계 결과 개수 조회
- `GET /api/votes/summaries` - 완료된 집계 결과 상세 조회 (조회 시 자동 마킹)

### 주요 변경사항
- `SimilarityVoteSummaryEntity`에 `fetchedByAi` 필드 추가
- 조회 상태 기반 Repository 쿼리 메서드 추가
- `VoteSummaryQueryService` 도메인 서비스 구현
- `VoteSummaryController` REST API 컨트롤러 구현
- 응답 DTO 구조 설계 (비율 계산 포함)

### application.yml 설정 추가 필요
다음 설정을 `application.yml`의 `security.permit-urls`에 추가해야 합니다:

```yaml
security:
  permit-urls:
    - "GET:/api/votes/summaries/count"
    - "GET:/api/votes/summaries"
```

## 테스트 계획
- [x] 도메인 서비스 단위 테스트 (VoteSummaryQueryServiceTest)
- [x] REST API 컨트롤러 통합 테스트 (VoteSummaryControllerTest)
- [x] 중복 조회 방지 검증
- [x] 비율 계산 정확성 검증
- [x] 빈 결과 처리 검증

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 완료된 투표 요약 건수 조회 API 추가: GET /api/votes/summaries/count
  - 완료된 투표 요약 목록 조회 API 추가: GET /api/votes/summaries
  - 응답에 투표 ID, 승인/반대 비율, AI 결정, 최종 결정 포함
  - 조회 시 중복 재전달 방지 처리 적용

- 테스트
  - 서비스·컨트롤러 단위 테스트 추가: 건수/목록 응답 구조·상태 코드 검증 및 중복 방지 동작 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->