### PR TITLE
[Feature] 포스트 썸네일 필수화 및 파생 포스트 상태 개편

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
 	POST_ROLE_EXCEPTION(HttpStatus.FORBIDDEN, "P-002", "포스트에 대한 권한이 없습니다."),
 	POST_ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "P-003", "포스트에 대한 접근 권한이 없습니다."),
 	NOT_AI_DERIVED_POST_EXCEPTION(HttpStatus.BAD_REQUEST, "P-004", "AI 파생 포스트가 아닙니다."),
+	THUMBNAIL_IMAGE_NOT_IN_IMAGE_LIST_EXCEPTION(HttpStatus.BAD_REQUEST, "P-005", "썸네일 이미지는 이미지 목록에 포함되어야 합니다."),
 
 	// Post Like
 	CANNOT_LIKE_OWN_POST_EXCEPTION(HttpStatus.BAD_REQUEST, "PL-001", "자신의 게시글에는 하트를 할 수 없습니다."),

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/dto/ChatMessageRequest.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/dto/ChatMessageRequest.java
@@ -1,6 +1,7 @@
 package hanium.modic.backend.domain.ai.aiChat.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * 채팅 메시지 전송 요청 DTO
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "채팅 메시지 전송 요청")
 public record ChatMessageRequest(
 	@Schema(description = "채팅 메시지 내용", example = "안녕하세요! 이 그림을 더 밝게 만들어주세요.", required = true)
+	@NotNull(message = "채팅 메시지 내용은 필수입니다.")
 	String textContent,
 
 	@Schema(description = "첨부할 이미지 ID (선택사항)", example = "123")

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
@@ -135,6 +135,7 @@ public class AiImageCreatedListener {
 			.aiChatRoomId(requestChatMessage.getAiChatRoomId())
 			.messageOrder(messageOrder)
 			.senderType(SenderType.AI)
+			.textContent("")
 			.textContent(message.textContext())
 			.aiChatImageId(null)
 			.requestId(message.requestId())

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
@@ -135,7 +135,6 @@ public class AiImageCreatedListener {
 			.aiChatRoomId(requestChatMessage.getAiChatRoomId())
 			.messageOrder(messageOrder)
 			.senderType(SenderType.AI)
-			.textContent("")
 			.textContent(message.textContext())
 			.aiChatImageId(null)
 			.requestId(message.requestId())

--- a/src/main/java/hanium/modic/backend/domain/post/entity/PostEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/post/entity/PostEntity.java
@@ -21,84 +21,86 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostEntity extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
 
-    @Column(name = "title", nullable = false)
-    private String title;
+	@Column(name = "title", nullable = false)
+	private String title;
 
-    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
-    private String description;
+	@Column(name = "description", columnDefinition = "TEXT", nullable = false)
+	private String description;
 
-    @Column(name = "commercial_price", nullable = false)
-    private Long commercialPrice;
+	@Column(name = "commercial_price", nullable = false)
+	private Long commercialPrice;
 
-    @Column(name = "non_commercial_price", nullable = false)
-    private Long nonCommercialPrice;
+	@Column(name = "non_commercial_price", nullable = false)
+	private Long nonCommercialPrice;
 
-    @Column(name = "ticket_price", nullable = false)
-    private Long ticketPrice;
+	@Column(name = "ticket_price", nullable = false)
+	private Long ticketPrice;
 
-    @Column(name = "is_ai_derived_post", nullable = false)
-    private Boolean isAiDerivedPost;
+	@Column(name = "parent_post_id")
+	private Long parentPostId;
 
-    @Column(name = "parent_post_id")
-    private Long parentPostId;
+	@Column(name = "post_status", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private PostStatus postStatus;
 
-    @Column(name = "derived_post_status")
-    @Enumerated(EnumType.STRING)
-    private PostStatus derivedPostStatus;
+	@Column(name = "thumbnail_image_id", nullable = false)
+	private Long thumbnailImageId;
 
-    @Builder
-    public PostEntity(
-        Long userId,
-        String title,
-        String description,
-        Long commercialPrice,
-        Long nonCommercialPrice,
-        Long ticketPrice,
-        Boolean isAiDerivedPost,
-        Long parentPostId,
-        PostStatus derivedPostStatus
-    ) {
-        this.userId = userId;
-        this.title = title;
-        this.description = description;
-        this.commercialPrice = commercialPrice;
-        this.nonCommercialPrice = nonCommercialPrice;
-        this.ticketPrice = ticketPrice;
-        this.isAiDerivedPost = isAiDerivedPost != null ? isAiDerivedPost : false;
-        this.parentPostId = parentPostId;
-        this.derivedPostStatus = derivedPostStatus;
-    }
+	@Builder
+	public PostEntity(
+		Long userId,
+		String title,
+		String description,
+		Long commercialPrice,
+		Long nonCommercialPrice,
+		Long ticketPrice,
+		Long parentPostId,
+		PostStatus postStatus,
+		Long thumbnailImageId
+	) {
+		this.userId = userId;
+		this.title = title;
+		this.description = description;
+		this.commercialPrice = commercialPrice;
+		this.nonCommercialPrice = nonCommercialPrice;
+		this.ticketPrice = ticketPrice;
+		this.parentPostId = parentPostId;
+		this.postStatus = postStatus;
+		this.thumbnailImageId = thumbnailImageId;
+	}
 
-    public void updateTitle(String title) {
-        this.title = title;
-    }
-    public void updateDescription(String description) {
-        this.description = description;
-    }
-    public void updateCommercialPrice(Long commercialPrice) {
-        this.commercialPrice = commercialPrice;
-    }
-    public void updateNonCommercialPrice(Long nonCommercialPrice) {
-        this.nonCommercialPrice = nonCommercialPrice;
-    }
-    public void updateTicketPrice(Long ticketPrice) {
-        this.ticketPrice = ticketPrice;
-    }
-    
-    /**
-     * AI 파생 게시물의 상태를 업데이트합니다.
-     * 투표 시스템에서 투표 완료 시 호출됩니다.
-     * 
-     * @param status 새로운 상태 (PENDING, APPROVED, REJECTED)
-     */
-    public void updateDerivedPostStatus(PostStatus status) {
-        this.derivedPostStatus = status;
-    }
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateDescription(String description) {
+		this.description = description;
+	}
+
+	public void updateCommercialPrice(Long commercialPrice) {
+		this.commercialPrice = commercialPrice;
+	}
+
+	public void updateNonCommercialPrice(Long nonCommercialPrice) {
+		this.nonCommercialPrice = nonCommercialPrice;
+	}
+
+	public void updateTicketPrice(Long ticketPrice) {
+		this.ticketPrice = ticketPrice;
+	}
+
+	public void updateDerivedPostStatus(PostStatus status) {
+		this.postStatus = status;
+	}
+
+	public void updateThumbnailImageId(Long thumbnailImageId) {
+		this.thumbnailImageId = thumbnailImageId;
+	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/enums/PostStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/post/enums/PostStatus.java
@@ -6,18 +6,20 @@ package hanium.modic.backend.domain.post.enums;
  */
 public enum PostStatus {
 
+	ORIGINAL,
+
 	/**
 	 * 투표 진행 중 - 파생 게시물 생성 후 투표 결과 대기 중
 	 */
-	PENDING,
+	DERIVED_PENDING,
 
 	/**
 	 * 승인됨 - 투표 결과 과반수가 APPROVE로 결정
 	 */
-	APPROVED,
+	DERIVED_APPROVED,
 
 	/**
 	 * 거부됨 - 투표 결과 과반수가 DENY로 결정
 	 */
-	REJECTED
+	DERIVED_REJECTED
 }

--- a/src/main/java/hanium/modic/backend/domain/post/repository/PostEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/post/repository/PostEntityRepository.java
@@ -9,18 +9,21 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 
 public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 	long countByUserId(Long userId);
 
 	Page<PostEntity> findAllByUserId(Long userId, Pageable pageable);
 
-	Page<PostEntity> findAllByIsAiDerivedPost(Boolean isAiDerivedPost, Pageable pageable);
+	Page<PostEntity> findAllByPostStatus(PostStatus postStatus, Pageable pageable);
 
-	List<Long> findIdsByParentPostIdOrderByIdDesc(Long parentPostId);
+	Page<PostEntity> findAllByPostStatusIn(List<PostStatus> postStatuses, Pageable pageable);
+
+	List<PostEntity> findAllByParentPostIdAndPostStatusOrderByIdDesc(Long parentPostId, PostStatus postStatus);
 
 	/**
-	 * 특정 포스트를 포함한 모든 하위 트리 노드를 재귀적으로 조회
+	 * 특정 포스트를 포함한 모든 하위 트리 노드를 재귀적으로 조회, 승인된 파생 포스트만 포함
 	 * MySQL의 CTE(Common Table Expression)를 사용하여 재귀 쿼리 수행
 	 *
 	 * @param postId 트리의 루트 포스트 ID
@@ -29,18 +32,19 @@ public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 	@Query(value = """
 		WITH RECURSIVE post_tree AS (
 			SELECT id, user_id, title, description, commercial_price, non_commercial_price,
-			       ticket_price, is_ai_derived_post, parent_post_id, derived_post_status,
+			       ticket_price, is_ai_derived_post, parent_post_id, post_status,
 			       create_at, update_at
 			FROM post
 			WHERE id = :postId
-
+		
 			UNION ALL
-
+		
 			SELECT p.id, p.user_id, p.title, p.description, p.commercial_price, p.non_commercial_price,
-			       p.ticket_price, p.is_ai_derived_post, p.parent_post_id, p.derived_post_status,
+			       p.ticket_price, p.is_ai_derived_post, p.parent_post_id, p.post_status,
 			       p.create_at, p.update_at
 			FROM post p
 			INNER JOIN post_tree pt ON p.parent_post_id = pt.id
+			WHERE p.post_status = 'DERIVED_APPROVED'
 		)
 		SELECT * FROM post_tree ORDER BY id
 		""", nativeQuery = true)

--- a/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
@@ -8,7 +8,6 @@ import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.aiServer.entity.AiChatImageEntity;
 import hanium.modic.backend.domain.ai.aiServer.repository.AiChatImageRepository;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
-import hanium.modic.backend.domain.image.util.ImageUtil;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.enums.PostStatus;
@@ -33,10 +32,8 @@ public class AiDerivedPostService {
 	private final AiChatImageRepository AiChatImageRepository;
 	private final PostEntityRepository postEntityRepository;
 	private final PostImageEntityRepository postImageEntityRepository;
-	private final PostService postService;
 	private final AsyncPostStatisticsService asyncPostStatisticsService;
-	private final ImageUtil imageUtil;
-	
+
 	// 투표 시스템 관련 의존성
 	private final SimilarityVoteRepository similarityVoteRepository;
 	private final SimilarityVoteSummaryRepository voteSummaryRepository;
@@ -45,7 +42,6 @@ public class AiDerivedPostService {
 	 * AI 파생 포스트 생성 (투표 시스템 연동)
 	 * @param userId 사용자 ID
 	 * @param createdAiImageId 생성된 AI 이미지 ID
-	 * @param originalImageId 비교할 원본 이미지 ID (투표용)
 	 * @param title 포스트 제목
 	 * @param description 포스트 설명
 	 * @param commercialPrice 상업적 가격
@@ -57,20 +53,25 @@ public class AiDerivedPostService {
 	public CreatePostResponse createAiDerivedPost(
 		Long userId,
 		Long createdAiImageId,
-		Long originalImageId,
 		String title,
 		String description,
 		Long commercialPrice,
 		Long nonCommercialPrice,
 		Long ticketPrice
 	) {
-		// 생성된 AI 이미지 조회 후 및 소유자 검증
+		// 생성된 AI 이미지 조회
 		AiChatImageEntity createdAiImage = AiChatImageRepository.findById(createdAiImageId)
 			.orElseThrow(() -> new AppException(ErrorCode.AI_IMAGE_NOT_FOUND_EXCEPTION));
 
+		// 소유자 검증
 		if (!createdAiImage.getUserId().equals(userId)) {
 			throw new AppException(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION);
 		}
+
+		// 원본 이미지 ID
+		Long originalImageId = postEntityRepository.findById(createdAiImage.getPostId())
+			.orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION))
+			.getThumbnailImageId();
 
 		// AI 파생 포스트 생성 - PENDING 상태로 생성 (투표 대기)
 		PostEntity aiDerivedPost = PostEntity.builder()
@@ -80,11 +81,10 @@ public class AiDerivedPostService {
 			.commercialPrice(commercialPrice)
 			.nonCommercialPrice(nonCommercialPrice)
 			.ticketPrice(ticketPrice)
-			.isAiDerivedPost(true) // AI 파생 포스트로 설정
 			.parentPostId(createdAiImage.getPostId()) // 원본 포스트 ID 설정
-			.derivedPostStatus(PostStatus.PENDING) // 투표 대기 상태로 설정
+			.postStatus(PostStatus.DERIVED_PENDING) // 투표 대기 상태로 설정
+			.thumbnailImageId(createdAiImageId) // 썸네일은 생성된 AI 이미지로 설정
 			.build();
-
 		PostEntity savedPost = postEntityRepository.save(aiDerivedPost);
 
 		// 파생 포스트 이미지 저장
@@ -94,9 +94,8 @@ public class AiDerivedPostService {
 			.imageName(createdAiImage.getImageName())
 			.extension(createdAiImage.getExtension())
 			.imagePurpose(ImagePrefix.POST)
+			.postEntity(savedPost)
 			.build();
-		postImage.updatePost(savedPost);
-
 		postImageEntityRepository.save(postImage);
 
 		// 투표 시스템 연동: SimilarityVoteEntity 생성 (PENDING 상태)
@@ -107,7 +106,6 @@ public class AiDerivedPostService {
 			.voteType(VoteType.SIMILARITY_CHECK)
 			.status(VoteStatus.PENDING) // AI 평가 대기 상태
 			.build();
-
 		SimilarityVoteEntity savedVote = similarityVoteRepository.save(similarityVote);
 
 		// 투표 집계 초기화: SimilarityVoteSummaryEntity 생성 (기본값 0)
@@ -119,36 +117,11 @@ public class AiDerivedPostService {
 			.aiDecision(VoteDecision.PENDING) // AI 평가 결과 대기
 			.finalDecision(VoteDecision.PENDING) // 최종 결정 대기
 			.build();
-
 		voteSummaryRepository.save(voteSummary);
 
 		// 게시글 통계 초기화 (비동기)
 		asyncPostStatisticsService.initializeStatistics(savedPost.getId());
 
 		return CreatePostResponse.of(savedPost.getId());
-	}
-
-	/**
-	 * AI 파생 포스트 삭제
-	 * @param userId 사용자 ID
-	 * @param postId 삭제할 포스트 ID
-	 */
-	@Transactional
-	public void deleteAiDerivedPost(Long userId, Long postId) {
-		PostEntity post = postEntityRepository.findById(postId)
-			.orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION));
-
-		// 포스트 작성자 검증
-		if (!post.getUserId().equals(userId)) {
-			throw new AppException(ErrorCode.POST_ACCESS_DENIED_EXCEPTION);
-		}
-
-		// AI 파생 포스트인지 검증
-		if (!post.getIsAiDerivedPost()) {
-			throw new AppException(ErrorCode.NOT_AI_DERIVED_POST_EXCEPTION);
-		}
-
-		// 기존 PostService의 deletePost 메서드 활용
-		postService.deletePost(userId, postId);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package hanium.modic.backend.domain.post.service;
 
 import static hanium.modic.backend.common.error.ErrorCode.*;
+import static hanium.modic.backend.domain.post.enums.PostStatus.*;
 import static org.springframework.data.domain.Sort.Direction.*;
 
 import java.util.LinkedHashMap;
@@ -29,9 +30,8 @@ import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse.ImageDto;
-import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
-import hanium.modic.backend.web.post.dto.response.GetSimplePostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -61,8 +61,12 @@ public class PostService {
 		final Long commercialPrice,
 		final Long nonCommercialPrice,
 		final Long ticketPrice,
-		final List<Long> imageIds
+		final List<Long> imageIds,
+		final Long thumbnailImageId
 	) {
+		// 썸네일 이미지가 이미지 목록에 포함되어 있는지 검증
+		validateThumbnailInImages(thumbnailImageId, imageIds);
+
 		PostEntity postEntity = PostEntity.builder()
 			.userId(userId)
 			.title(title)
@@ -70,8 +74,9 @@ public class PostService {
 			.commercialPrice(commercialPrice)
 			.nonCommercialPrice(nonCommercialPrice)
 			.ticketPrice(ticketPrice)
-			.isAiDerivedPost(false)
 			.parentPostId(null) // 일반 포스트는 부모가 없음
+			.postStatus(ORIGINAL) // 일반 포스트는 상태가 없음
+			.thumbnailImageId(thumbnailImageId)
 			.build();
 
 		PostEntity post = postEntityRepository.save(postEntity);
@@ -115,28 +120,20 @@ public class PostService {
 		// 현재 인증된 사용자의 좋아요 여부 확인
 		Boolean isLikedByCurrentUser = postLikeService.isLikedByUser(currentUserId, id);
 
-		// AI 파생 포스트의 id와 ImageUrl 조회
-		List<Long> derivedPostIds = postEntityRepository.findIdsByParentPostIdOrderByIdDesc(id);
+		// AI 파생 포스트의 id와 ImageUrl 조회, 오직 승인된 파생포스트만 조회
+		List<PostEntity> derivedPosts = postEntityRepository.findAllByParentPostIdAndPostStatusOrderByIdDesc(id,
+			DERIVED_APPROVED);
 
-		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(derivedPostIds);
-
-		// 포스트ID별로 첫 번째 이미지 URL 찾기
-		Map<Long, String> firstImageByPostId = new LinkedHashMap<>();
-		for (PostImageEntity image : allPostImages) {
-			firstImageByPostId.computeIfAbsent(
-				image.getPostId(),
-				pid -> imageUtil.createImageGetUrl(image.getImagePath())
-			);
-		}
-		List<GetPostResponse.SimplePostDto> derivedPosts = derivedPostIds.stream()
-			.map(postId -> {
-				String firstImageUrl = firstImageByPostId.get(postId);
-				return new GetPostResponse.SimplePostDto(postId, firstImageUrl);
+		// 파생 포스트 별로 postId와 대표 이미지 URL 찾기
+		List<GetPostResponse.SimplePostDto> simpleDerivedPostDtos = derivedPosts.stream()
+			.map(derivedPost -> {
+				String firstImageUrl = postImageService.createImageGetUrl(derivedPost.getThumbnailImageId());
+				return new GetPostResponse.SimplePostDto(derivedPost.getId(), firstImageUrl);
 			})
 			.toList();
 
 		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
-			isLikedByCurrentUser, derivedPosts);
+			isLikedByCurrentUser, simpleDerivedPostDtos);
 	}
 
 	@Transactional(readOnly = true)
@@ -165,41 +162,29 @@ public class PostService {
 		Boolean isLikedByCurrentUser = false;
 
 		// AI 파생 포스트의 id와 ImageUrl 조회
-		List<Long> derivedPostIds = postEntityRepository.findIdsByParentPostIdOrderByIdDesc(id);
+		List<PostEntity> derivedPosts = postEntityRepository.findAllByParentPostIdAndPostStatusOrderByIdDesc(id,
+			DERIVED_APPROVED);
 
-		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(derivedPostIds);
-
-		// 포스트ID별로 첫 번째 이미지 URL 찾기
-		Map<Long, String> firstImageByPostId = new LinkedHashMap<>();
-		for (PostImageEntity image : allPostImages) {
-			firstImageByPostId.computeIfAbsent(
-				image.getPostId(),
-				pid -> imageUtil.createImageGetUrl(image.getImagePath())
-			);
-		}
-		List<GetPostResponse.SimplePostDto> derivedPosts = derivedPostIds.stream()
-			.map(postId -> {
-				String firstImageUrl = firstImageByPostId.get(postId);
-				return new GetPostResponse.SimplePostDto(postId, firstImageUrl);
+		// 파생 포스트 별로 postId와 대표 이미지 URL 찾기
+		List<GetPostResponse.SimplePostDto> simpleDerivedPostDtos = derivedPosts.stream()
+			.map(derivedPost -> {
+				String firstImageUrl = postImageService.createImageGetUrl(derivedPost.getThumbnailImageId());
+				return new GetPostResponse.SimplePostDto(derivedPost.getId(), firstImageUrl);
 			})
 			.toList();
 
 		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
-			isLikedByCurrentUser, derivedPosts);
+			isLikedByCurrentUser, simpleDerivedPostDtos);
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<GetPostsResponse> getPosts(final String sort, final int page, final int size,
-		final PostType postType) {
-
-		// Todo: sort 기능 추가
-
+	public PageResponse<GetPostsResponse> getPosts(
+		final int page,
+		final int size,
+		final PostType postType
+	) {
 		Pageable pageable = PageRequest.of(page, size, SORT_DIRECTION, SORT_CRITERIA);
 		Page<PostEntity> posts = getPostsByType(pageable, postType);
-
-		if (posts.isEmpty()) {
-			throw new AppException(POST_NOT_FOUND_EXCEPTION);
-		}
 
 		// 게시글 ID 목록 추출
 		List<Long> postIds = posts.getContent().stream()
@@ -216,6 +201,7 @@ public class PostService {
 			.collect(Collectors.groupingBy(PostImageEntity::getPostId));
 
 		Page<GetPostsResponse> responsePages = posts.map(post -> {
+			// Todo: 대표이미지 어떻게 앞으로 넣지
 			List<GetPostsResponse.ImageDto> postImages = imagesByPostId.getOrDefault(post.getId(), List.of())
 				.stream()
 				.map(image -> new GetPostsResponse.ImageDto(
@@ -230,6 +216,48 @@ public class PostService {
 		});
 
 		return PageResponse.of(responsePages);
+	}
+
+	// 유저 포스트 목록 조회
+	@Transactional(readOnly = true)
+	public Page<GetPostsResponse> getUserPosts(
+		final long userId,
+		final int page,
+		final int size
+	) {
+		// 1. 포스트 목록 조회 (DERIVED_PENDING, DERIVED_REJECTED 상태의 포스트도 포함)
+		Page<PostEntity> posts = postEntityRepository.findAllByUserId(userId, PageRequest.of(page, size));
+
+		// 2. 이미지 조회
+		// 게시글 ID 목록 추출
+		List<Long> postIds = posts.getContent().stream()
+			.map(PostEntity::getId)
+			.toList();
+
+		// 배치로 모든 포스트 이미지 조회 (N+1 문제 해결)
+		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(postIds);
+
+		// 포스트ID별로 그룹화
+		Map<Long, List<PostImageEntity>> imagesByPostId = allPostImages.stream()
+			.collect(Collectors.groupingBy(PostImageEntity::getPostId));
+
+		// 3. 여러 게시글의 하트 수 조회 (한 번의 쿼리로 성능 최적화)
+		Map<Long, Long> likeCounts = postLikeService.getLikeCounts(postIds);
+
+		// 4. 응답 생성
+		return posts.map(post -> {
+			List<GetPostsResponse.ImageDto> postImages = imagesByPostId.getOrDefault(post.getId(), List.of())
+				.stream()
+				.map(image -> new GetPostsResponse.ImageDto(
+					imageUtil.createImageGetUrl(image.getImagePath()),
+					image.getId()
+				))
+				.toList();
+
+			long likeCount = likeCounts.getOrDefault(post.getId(), 0L);
+
+			return new GetPostsResponse(post.getId(), post.getTitle(), post.getPostStatus(), postImages, likeCount);
+		});
 	}
 
 	@Transactional
@@ -253,18 +281,22 @@ public class PostService {
 		final Long commercialPrice,
 		final Long nonCommercialPrice,
 		final Long ticketPrice,
-		final List<Long> imageIds
+		final List<Long> imageIds,
+		final Long thumbnailImageId
 	) {
 		PostEntity post = postEntityRepository.findById(postId)
 			.orElseThrow(() -> new AppException(POST_NOT_FOUND_EXCEPTION));
 
 		validatePostRole(userId, post.getUserId());
+		validateThumbnailInImages(thumbnailImageId, imageIds);
 
+		// 포스트 정보 업데이트
 		post.updateTitle(title);
 		post.updateDescription(description);
 		post.updateCommercialPrice(commercialPrice);
 		post.updateNonCommercialPrice(nonCommercialPrice);
 		post.updateTicketPrice(ticketPrice);
+		post.updateThumbnailImageId(thumbnailImageId);
 		postEntityRepository.save(post);
 
 		List<PostImageEntity> postImages = postImageEntityRepository.findAllByPostId(postId);
@@ -278,61 +310,6 @@ public class PostService {
 		// 새로 추가된 이미지에 PostId 업데이트
 		postImageEntityRepository.findAllByIds(imageIds)
 			.forEach(postImageEntity -> postImageEntity.updatePost(post));
-	}
-
-	// 포스트 권한 검증
-	// Todo : 권한 검증 로직 개선 필요, AOP 등등
-	private void validatePostRole(
-		final long userId,
-		final long postUserId
-	) {
-		if (userId != postUserId) {
-			throw new AppException(POST_ROLE_EXCEPTION);
-		}
-	}
-
-	// 단순 포스트 목록 조회
-	@Transactional(readOnly = true)
-	public Page<GetSimplePostsResponse> getSimplePosts(final long userId, final int page, final int size) {
-		Page<PostEntity> posts = postEntityRepository.findAllByUserId(userId, PageRequest.of(page, size));
-
-		if (posts.isEmpty()) {
-			return Page.empty();
-		}
-
-		// 게시글 ID 목록 추출
-		List<Long> postIds = posts.getContent().stream()
-			.map(PostEntity::getId)
-			.toList();
-
-		// 배치로 모든 포스트 이미지 조회 (N+1 문제 해결)
-		List<PostImageEntity> allPostImages = postImageEntityRepository.findAllByPostIdIn(postIds);
-
-		// 포스트ID별로 그룹화
-		Map<Long, List<PostImageEntity>> imagesByPostId = allPostImages.stream()
-			.collect(Collectors.groupingBy(PostImageEntity::getPostId));
-
-		return posts.map(post -> {
-			List<GetSimplePostsResponse.ImageDto> postImages = imagesByPostId.getOrDefault(post.getId(), List.of())
-				.stream()
-				.map(image -> new GetSimplePostsResponse.ImageDto(
-					imageUtil.createImageGetUrl(image.getImagePath()),
-					image.getId()
-				))
-				.toList();
-
-			return new GetSimplePostsResponse(post.getId(), postImages);
-		});
-	}
-
-	// 포스트 타입에 따라 포스트 목록을 조회
-	private Page<PostEntity> getPostsByType(Pageable pageable, PostType postType) {
-		return switch (postType) {
-			// Todo: AI_DERIVED 조회시 PostStatus 필터링 구현 필요
-			case ORIGINAL -> postEntityRepository.findAllByIsAiDerivedPost(false, pageable);
-			case AI_DERIVED -> postEntityRepository.findAllByIsAiDerivedPost(true, pageable);
-			case ALL -> postEntityRepository.findAll(pageable);
-		};
 	}
 
 	/**
@@ -382,5 +359,32 @@ public class PostService {
 				return GetPostTreeResponse.of(post, representativeImageUrl);
 			})
 			.toList();
+	}
+
+	// 포스트 타입에 따라 포스트 목록을 조회(승인되지 않은 파생 포스트는 모두 제외)
+	private Page<PostEntity> getPostsByType(Pageable pageable, PostType postType) {
+		return switch (postType) {
+			case ORIGINAL -> postEntityRepository.findAllByPostStatus(ORIGINAL, pageable);
+			case AI_DERIVED -> postEntityRepository.findAllByPostStatus(DERIVED_APPROVED, pageable);
+			case ALL -> postEntityRepository.findAllByPostStatusIn(List.of(ORIGINAL, DERIVED_APPROVED), pageable);
+		};
+	}
+
+	// 포스트 권한 검증
+	// Todo : 권한 검증 로직 개선 필요, AOP 등등
+	private void validatePostRole(
+		final long userId,
+		final long postUserId
+	) {
+		if (userId != postUserId) {
+			throw new AppException(POST_ROLE_EXCEPTION);
+		}
+	}
+
+	// 썸네일 이미지가 이미지 목록에 포함되어 있는지 검증
+	private void validateThumbnailInImages(Long thumbnailImageId, List<Long> imageIds) {
+		if (!imageIds.contains(thumbnailImageId)) {
+			throw new AppException(THUMBNAIL_IMAGE_NOT_IN_IMAGE_LIST_EXCEPTION);
+		}
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
@@ -189,7 +189,7 @@ public class VotingService {
 
 			// 3. 파생 포스트 조회
 			PostEntity derivedPost = postEntityRepository.findById(derivedPostId).orElse(null);
-			if (derivedPost == null || !derivedPost.getIsAiDerivedPost()) {
+			if (derivedPost == null || derivedPost.getPostStatus() == PostStatus.ORIGINAL) {
 				log.warn("유효하지 않은 파생 포스트: postId={}, voteId={}", derivedPostId, voteId);
 				return;
 			}
@@ -200,8 +200,8 @@ public class VotingService {
 
 			// 5. 투표 결과에 따른 포스트 상태 업데이트
 			PostStatus newStatus = (voteSummary.getFinalDecision() == VoteDecision.APPROVE)
-				? PostStatus.APPROVED
-				: PostStatus.REJECTED;
+				? PostStatus.DERIVED_APPROVED
+				: PostStatus.DERIVED_REJECTED;
 
 			derivedPost.updateDerivedPostStatus(newStatus);
 			postEntityRepository.save(derivedPost);

--- a/src/main/java/hanium/modic/backend/web/post/controller/AiDerivedPostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/AiDerivedPostController.java
@@ -2,8 +2,6 @@ package hanium.modic.backend.web.post.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,11 +39,9 @@ public class AiDerivedPostController {
 		@CurrentUser UserEntity currentUser,
 		@Valid @RequestBody CreateAiDerivedPostRequest request
 	) {
-
 		CreatePostResponse response = aiDerivedPostService.createAiDerivedPost(
 			currentUser.getId(),
 			request.createdAiImageId(),
-			request.originalImageId(),
 			request.title(),
 			request.description(),
 			request.commercialPrice(),
@@ -55,21 +51,5 @@ public class AiDerivedPostController {
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(AppResponse.ok(response));
-	}
-
-	@Operation(summary = "AI 파생 포스트 삭제", description = "AI 파생 포스트를 삭제합니다. 생성자만 삭제할 수 있습니다.")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "400", description = "AI 파생 포스트가 아닙니다.[P-004]"),
-		@ApiResponse(responseCode = "403", description = "포스트에 대한 접근 권한이 없습니다.[P-003]"),
-		@ApiResponse(responseCode = "404", description = "해당 포스트를 찾을 수 없습니다.[P-001]")
-	})
-	@DeleteMapping("/{postId}")
-	public ResponseEntity<AppResponse<Void>> deleteAiDerivedPost(
-		@CurrentUser UserEntity currentUser,
-		@PathVariable Long postId) {
-
-		aiDerivedPostService.deleteAiDerivedPost(currentUser.getId(), postId);
-
-		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/PostController.java
@@ -27,8 +27,8 @@ import hanium.modic.backend.web.post.dto.request.CreatePostRequest;
 import hanium.modic.backend.web.post.dto.request.UpdatePostRequest;
 import hanium.modic.backend.web.post.dto.response.CreatePostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
-import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 import hanium.modic.backend.web.postReview.dto.response.CanReviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -48,21 +48,41 @@ public class PostController {
 	private final PostReviewAuthorizationService postReviewAuthorizationService;
 
 	@PostMapping
-	@Operation(summary = "게시글 작성 API", description = "게시글을 작성합니다. 작성자는 인증된 사용자여야 합니다.", responses = {
-		@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-		@ApiResponse(responseCode = "404", description = "해당 이미지를 찾을 수 없습니다.[I-002]")})
+	@Operation(
+		summary = "게시글 작성 API",
+		description = "게시글을 작성합니다. 작성자는 인증된 사용자여야 합니다. 이미지 목록에도 썸네일 이미지 id가 포함되어야 합니다.",
+		responses = {
+			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
+			@ApiResponse(responseCode = "404", description = "해당 이미지를 찾을 수 없습니다.[I-002]"),
+			@ApiResponse(responseCode = "400", description = "썸네일 이미지는 이미지 목록에 포함되어야 합니다.[P-005]"),
+		}
+	)
 	public ResponseEntity<AppResponse<CreatePostResponse>> createPost(@CurrentUser UserEntity user,
 		@RequestBody @Valid CreatePostRequest request) {
 
 		return ResponseEntity.status(CREATED)
 			.body(AppResponse.created(CreatePostResponse.of(
-				postService.createPost(user.getId(), request.title(), request.description(), request.commercialPrice(),
-					request.nonCommercialPrice(), request.ticketPrice(), request.imageIds()))));
+				postService.createPost(
+					user.getId(),
+					request.title(),
+					request.description(),
+					request.commercialPrice(),
+					request.nonCommercialPrice(),
+					request.ticketPrice(),
+					request.imageIds(),
+					request.thumbnailImageId()
+				)))
+			);
 	}
 
 	@GetMapping("/{id}")
-	@Operation(summary = "게시글 조회 API", description = "게시글을 조회합니다. 게시글 ID를 입력받습니다.", responses = {
-		@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")})
+	@Operation(
+		summary = "게시글 조회 API",
+		description = "게시글을 조회합니다. 게시글 ID를 입력받습니다.",
+		responses = {
+			@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")
+		}
+	)
 	public ResponseEntity<AppResponse<GetPostResponse>> getPost(@PathVariable Long id, @CurrentUser UserEntity user) {
 		GetPostResponse response = postService.getPost(id, user.getId());
 		return ResponseEntity.ok(AppResponse.ok(response));
@@ -80,17 +100,16 @@ public class PostController {
 		}
 	)
 	public ResponseEntity<AppResponse<PageResponse<GetPostsResponse>>> getPosts(
-		@RequestParam(required = false, defaultValue = "LATEST") String sort,
 		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다") Integer page,
 		@RequestParam(required = false, defaultValue = "10") @Min(value = 10, message = "페이지 크기는 10 이상이어야 합니다.") @Max(value = 20, message = "페이지 크기는 20 이하여야 합니다.") Integer size,
 		@RequestParam(required = false, defaultValue = "ALL") PostType postType
 	) {
-		PageResponse<GetPostsResponse> response = postService.getPosts(sort, page, size, postType);
+		PageResponse<GetPostsResponse> response = postService.getPosts(page, size, postType);
 		return ResponseEntity.ok(AppResponse.ok(response));
 	}
 
 	@DeleteMapping("/{id}")
-	@Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다. 작성자만 삭제할 수 있습니다.", responses = {
+	@Operation(summary = "포스트, 파생포스트 삭제 API", description = "게시글을 삭제합니다. 작성자만 삭제할 수 있습니다.", responses = {
 		@ApiResponse(responseCode = "403", description = "포스트에 대한 권한이 없습니다.[P-002]"),
 		@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")})
 	public ResponseEntity<AppResponse<Void>> deletePost(@CurrentUser UserEntity user, @PathVariable Long id) {
@@ -99,14 +118,32 @@ public class PostController {
 	}
 
 	@PutMapping("/{id}")
-	@Operation(summary = "게시글 수정 API", description = "게시글을 수정합니다. 작성자만 수정할 수 있습니다.", responses = {
-		@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-		@ApiResponse(responseCode = "403", description = "포스트에 대한 권한이 없습니다.[P-002]"),
-		@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]")})
-	public ResponseEntity<AppResponse<Void>> updatePost(@CurrentUser UserEntity user, @PathVariable long id,
-		@RequestBody @Valid UpdatePostRequest request) {
-		postService.updatePost(user.getId(), id, request.title(), request.description(), request.commercialPrice(),
-			request.nonCommercialPrice(), request.ticketPrice(), request.imageIds());
+	@Operation(
+		summary = "게시글 수정 API",
+		description = "게시글을 수정합니다. 작성자만 수정할 수 있습니다. 이미지 목록에도 썸네일 이미지 id가 포함되어야 합니다.",
+		responses = {
+			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
+			@ApiResponse(responseCode = "403", description = "포스트에 대한 권한이 없습니다.[P-002]"),
+			@ApiResponse(responseCode = "404", description = "해당 게시글을 찾을 수 없습니다.[P-001]"),
+			@ApiResponse(responseCode = "400", description = "썸네일 이미지는 이미지 목록에 포함되어야 합니다.[P-005]"),
+		}
+	)
+	public ResponseEntity<AppResponse<Void>> updatePost(
+		@CurrentUser UserEntity user,
+		@PathVariable long id,
+		@RequestBody @Valid UpdatePostRequest request
+	) {
+		postService.updatePost(
+			user.getId(),
+			id,
+			request.title(),
+			request.description(),
+			request.commercialPrice(),
+			request.nonCommercialPrice(),
+			request.ticketPrice(),
+			request.imageIds(),
+			request.thumbnailImageId()
+		);
 
 		return ResponseEntity.status(NO_CONTENT).body(AppResponse.noContent());
 	}

--- a/src/main/java/hanium/modic/backend/web/post/dto/request/CreateAiDerivedPostRequest.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/request/CreateAiDerivedPostRequest.java
@@ -12,10 +12,6 @@ public record CreateAiDerivedPostRequest(
 	@Schema(description = "생성된 AI 이미지 ID", example = "1")
 	Long createdAiImageId,
 
-	@NotNull(message = "원본 이미지 ID는 필수입니다.")
-	@Schema(description = "비교할 원본 이미지 ID (투표 시스템에서 사용)", example = "2")
-	Long originalImageId,
-
 	@NotBlank(message = "제목은 필수입니다.")
 	@Schema(description = "게시물 제목", example = "멋진 AI 아트")
 	String title,

--- a/src/main/java/hanium/modic/backend/web/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/request/CreatePostRequest.java
@@ -1,36 +1,41 @@
 package hanium.modic.backend.web.post.dto.request;
 
+import java.util.List;
+
+import org.hibernate.validator.constraints.Length;
+
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
-import org.hibernate.validator.constraints.Length;
 
 public record CreatePostRequest(
-        @NotBlank(message = "제목은 필수입니다.")
-        @Length(min = 1, max = 20)
-        String title,
+	@NotBlank(message = "제목은 필수입니다.")
+	@Length(min = 1, max = 20)
+	String title,
 
-        @NotBlank(message = "설명은 필수입니다.")
-        @Length(min = 1, max = 10000, message = "설명은 최대 10000자까지 가능합니다.")
-        String description,
+	@NotBlank(message = "설명은 필수입니다.")
+	@Length(min = 1, max = 10000, message = "설명은 최대 10000자까지 가능합니다.")
+	String description,
 
-        @NotNull(message = "상업적 가격은 필수입니다.")
-        @Min(value = 0, message = "상업적 가격은 0 이상이어야 합니다.")
-        Long commercialPrice,
+	@NotNull(message = "상업적 가격은 필수입니다.")
+	@Min(value = 0, message = "상업적 가격은 0 이상이어야 합니다.")
+	Long commercialPrice,
 
-        @NotNull(message = "비상업적 가격은 필수입니다.")
-        @Min(value = 0, message = "비상업적 가격은 0 이상이어야 합니다.")
-        Long nonCommercialPrice,
+	@NotNull(message = "비상업적 가격은 필수입니다.")
+	@Min(value = 0, message = "비상업적 가격은 0 이상이어야 합니다.")
+	Long nonCommercialPrice,
 
-        @NotNull(message = "티켓 가격은 필수입니다.")
-        @Min(value = 0, message = "티켓 가격은 0 이상이어야 합니다.")
-        Long ticketPrice,
+	@NotNull(message = "티켓 가격은 필수입니다.")
+	@Min(value = 0, message = "티켓 가격은 0 이상이어야 합니다.")
+	Long ticketPrice,
 
-        @NotNull(message = "이미지는 필수입니다.")
-        @Size(min = 1, message = "이미지는 최소 1개 이상이어야 합니다.")
-        @Size(max = 8, message = "이미지는 최대 8개까지 업로드 가능합니다.")
-        List<Long> imageIds
+	@NotNull(message = "이미지는 필수입니다.")
+	@Size(min = 1, message = "이미지는 최소 1개 이상이어야 합니다.")
+	@Size(max = 8, message = "이미지는 최대 8개까지 업로드 가능합니다.")
+	List<Long> imageIds,
+
+	@NotNull(message = "썸네일 이미지 ID는 필수입니다.")
+	Long thumbnailImageId
 ) {
 }

--- a/src/main/java/hanium/modic/backend/web/post/dto/request/UpdatePostRequest.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/request/UpdatePostRequest.java
@@ -33,6 +33,9 @@ public record UpdatePostRequest(
 	@NotNull(message = "이미지는 필수입니다.")
 	@Size(min = 1, message = "이미지는 최소 1개 이상이어야 합니다.")
 	@Size(max = 8, message = "이미지는 최대 8개까지 업로드 가능합니다.")
-	List<Long> imageIds
+	List<Long> imageIds,
+
+	@NotNull(message = "썸네일 이미지는 필수입니다.")
+	Long thumbnailImageId
 ) {
 }

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public record GetPostResponse(
 	Long commercialPrice,
 	Long nonCommercialPrice,
 	Long ticketPrice,
-	Boolean isAiDerivedPost,
+	PostStatus postStatus,
 	List<ImageDto> images,
 	// 하트 관련 필드
 	long likeCount,
@@ -33,30 +34,6 @@ public record GetPostResponse(
 	List<SimplePostDto> derivedPosts
 
 ) {
-	// 기존 메서드 (하트 정보 없음 - 하위호환성)
-	public static GetPostResponse of(
-		String userName,
-		boolean hasUserImage,
-		String userImageUrl,
-		String userEmail,
-		PostEntity postEntity,
-		List<ImageDto> images) {
-		return of(userName, hasUserImage, userImageUrl, userEmail, postEntity, images, 0L, null, List.of());
-	}
-
-	// 하트 정보 포함 메서드 (파생포스트 정보 없음 - 하위호환성)
-	public static GetPostResponse of(
-		String userName,
-		boolean hasUserImage,
-		String userImageUrl,
-		String userEmail,
-		PostEntity postEntity,
-		List<ImageDto> imageDtos,
-		long likeCount,
-		Boolean isLikedByCurrentUser) {
-		return of(userName, hasUserImage, userImageUrl, userEmail, postEntity, imageDtos, likeCount, isLikedByCurrentUser, List.of());
-	}
-
 	// 파생포스트 정보까지 포함한 완전한 메서드
 	public static GetPostResponse of(
 		String userName,
@@ -82,7 +59,7 @@ public record GetPostResponse(
 			postEntity.getCommercialPrice(),
 			postEntity.getNonCommercialPrice(),
 			postEntity.getTicketPrice(),
-			postEntity.getIsAiDerivedPost(),
+			postEntity.getPostStatus(),
 			imageDtos,
 			likeCount,
 			isLikedByCurrentUser,

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostTreeResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostTreeResponse.java
@@ -27,7 +27,7 @@ public record GetPostTreeResponse(
 			postEntity.getTitle(),
 			postEntity.getParentPostId(),
 			representativeImageUrl,
-			postEntity.getDerivedPostStatus()
+			postEntity.getPostStatus()
 		);
 	}
 }

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostsResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetPostsResponse.java
@@ -3,44 +3,32 @@ package hanium.modic.backend.web.post.dto.response;
 import java.util.List;
 
 import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public record GetPostsResponse(
 	Long postId,
-	Long userId,
 	String title,
-	String description,
-	Long commercialPrice,
-	Long nonCommercialPrice,
-	Boolean isAiDerivedPost,
+	PostStatus postStatus,
 	List<ImageDto> images,
 	// 하트 수
-	long likeCount) {
-	// 기존 메서드 (하트 정보 없음 - 하위호환성)
-	public static GetPostsResponse of(
-		PostEntity postEntity,
-		List<ImageDto> images) {
-		return of(postEntity, images, 0L);
-	}
-
+	long likeCount
+) {
 	// 하트 수 포함 메서드
 	public static GetPostsResponse of(
 		PostEntity postEntity,
-		List<ImageDto> imageDtos,
-		long likeCount) {
-
+		List<ImageDto> images,
+		long likeCount
+	) {
 		return new GetPostsResponse(
 			postEntity.getId(),
-			postEntity.getUserId(),
 			postEntity.getTitle(),
-			postEntity.getDescription(),
-			postEntity.getCommercialPrice(),
-			postEntity.getNonCommercialPrice(),
-			postEntity.getIsAiDerivedPost(),
-			imageDtos,
-			likeCount);
+			postEntity.getPostStatus(),
+			images,
+			likeCount
+		);
 	}
 
 	@Getter

--- a/src/main/java/hanium/modic/backend/web/post/dto/response/GetSimplePostsResponse.java
+++ b/src/main/java/hanium/modic/backend/web/post/dto/response/GetSimplePostsResponse.java
@@ -2,13 +2,18 @@ package hanium.modic.backend.web.post.dto.response;
 
 import java.util.List;
 
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public record GetSimplePostsResponse(
 	Long postId,
-	List<ImageDto> images
+	String title,
+	PostStatus postStatus,
+	List<ImageDto> images,
+	// 하트 수
+	long likeCount
 ) {
 	@Getter
 	@AllArgsConstructor(access = AccessLevel.PUBLIC)

--- a/src/main/java/hanium/modic/backend/web/profile/controller/ProfileController.java
+++ b/src/main/java/hanium/modic/backend/web/profile/controller/ProfileController.java
@@ -13,7 +13,7 @@ import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.post.service.PostService;
 import hanium.modic.backend.domain.profile.service.ProfileService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
-import hanium.modic.backend.web.post.dto.response.GetSimplePostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 import hanium.modic.backend.web.profile.dto.GetMyProfileResponse;
 import hanium.modic.backend.web.profile.dto.GetProfileResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,12 +56,12 @@ public class ProfileController {
 		summary = "내 게시글 목록 조회",
 		description = "로그인한 사용자의 게시글 목록을 조회합니다. 페이지네이션을 지원합니다."
 	)
-	public ResponseEntity<AppResponse<PageResponse<GetSimplePostsResponse>>> getMyPosts(
+	public ResponseEntity<AppResponse<PageResponse<GetPostsResponse>>> getMyPosts(
 		@CurrentUser UserEntity me,
 		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
 		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
 	) {
-		return ResponseEntity.ok(AppResponse.ok(PageResponse.of(postService.getSimplePosts(me.getId(), page, size))));
+		return ResponseEntity.ok(AppResponse.ok(PageResponse.of(postService.getUserPosts(me.getId(), page, size))));
 	}
 
 	@GetMapping("/posts")
@@ -69,11 +69,11 @@ public class ProfileController {
 		summary = "게시글 목록 조회",
 		description = "로그인한 사용자의 게시글 목록을 조회합니다. 페이지네이션을 지원합니다."
 	)
-	public ResponseEntity<AppResponse<PageResponse<GetSimplePostsResponse>>> getPosts(
+	public ResponseEntity<AppResponse<PageResponse<GetPostsResponse>>> getPosts(
 		@RequestParam(required = true) long userId,
 		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
 		@RequestParam(required = false, defaultValue = "10") @Max(value = 30, message = "최대 크기는 30입니다.") int size
 	) {
-		return ResponseEntity.ok(AppResponse.ok(PageResponse.of(postService.getSimplePosts(userId, page, size))));
+		return ResponseEntity.ok(AppResponse.ok(PageResponse.of(postService.getUserPosts(userId, page, size))));
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/post/entityfactory/PostFactory.java
+++ b/src/test/java/hanium/modic/backend/domain/post/entityfactory/PostFactory.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 import org.mockito.Mockito;
 
 import hanium.modic.backend.domain.post.entity.PostEntity;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
 public class PostFactory {
@@ -17,7 +18,8 @@ public class PostFactory {
 			.commercialPrice(10000L)
 			.nonCommercialPrice(5000L)
 			.ticketPrice(3L)
-			.isAiDerivedPost(false)
+			.thumbnailImageId(1L)
+			.postStatus(PostStatus.ORIGINAL)
 			.parentPostId(null)
 			.build();
 
@@ -35,7 +37,8 @@ public class PostFactory {
 			.commercialPrice(10000L)
 			.nonCommercialPrice(5000L)
 			.ticketPrice(3L)
-			.isAiDerivedPost(false)
+			.thumbnailImageId(1L)
+			.postStatus(PostStatus.ORIGINAL)
 			.parentPostId(null)
 			.build();
 	}
@@ -48,7 +51,8 @@ public class PostFactory {
 			.commercialPrice(15000L)
 			.nonCommercialPrice(8000L)
 			.ticketPrice(5L)
-			.isAiDerivedPost(true)
+			.thumbnailImageId(1L)
+			.postStatus(PostStatus.ORIGINAL)
 			.parentPostId(1L) // 기본적으로 포스트 ID 1을 부모로 설정
 			.build();
 
@@ -66,7 +70,8 @@ public class PostFactory {
 			.commercialPrice(15000L)
 			.nonCommercialPrice(8000L)
 			.ticketPrice(5L)
-			.isAiDerivedPost(true)
+			.thumbnailImageId(1L)
+			.postStatus(PostStatus.ORIGINAL)
 			.parentPostId(parentPostId)
 			.build();
 
@@ -84,7 +89,8 @@ public class PostFactory {
 			.commercialPrice(15000L)
 			.nonCommercialPrice(8000L)
 			.ticketPrice(5L)
-			.isAiDerivedPost(true)
+			.thumbnailImageId(1L)
+			.postStatus(PostStatus.ORIGINAL)
 			.parentPostId(1L) // 기본적으로 포스트 ID 1을 부모로 설정
 			.build();
 	}

--- a/src/test/java/hanium/modic/backend/domain/post/service/AiDerivedPostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/AiDerivedPostServiceTest.java
@@ -78,13 +78,15 @@ class AiDerivedPostServiceTest {
 		Long commercialPrice = 2000L;
 		Long nonCommercialPrice = 1000L;
 		Long ticketPrice = 300L;
+		Long postId = 1L;
 
 		UserEntity mockUser = UserFactory.createMockUser(userId);
 		AiChatImageEntity mockAiImage = createMockCreatedAiImageWithId(
-			createdAiImageId, userId, 1L, "request-123");
-		PostEntity mockSavedPost = createMockPostWithId(1L, mockUser);
+			createdAiImageId, userId, postId, "request-123");
+		PostEntity mockSavedPost = createMockPostWithId(postId, mockUser);
 
 		when(createdAiImageRepository.findById(createdAiImageId)).thenReturn(Optional.of(mockAiImage));
+		when(postEntityRepository.findById(anyLong())).thenReturn(Optional.of(mockSavedPost));
 		when(postEntityRepository.save(any(PostEntity.class))).thenReturn(mockSavedPost);
 		doNothing().when(asyncPostStatisticsService).initializeStatistics(anyLong());
 		when(similarityVoteRepository.save(any(SimilarityVoteEntity.class))).thenAnswer(invocation -> {
@@ -100,7 +102,7 @@ class AiDerivedPostServiceTest {
 
 		// when
 		CreatePostResponse response = aiDerivedPostService.createAiDerivedPost(
-			userId, createdAiImageId, originalImageId, title, description, commercialPrice, nonCommercialPrice, ticketPrice);
+			userId, createdAiImageId, title, description, commercialPrice, nonCommercialPrice, ticketPrice);
 
 		// then
 		assertThat(response).isNotNull();
@@ -116,7 +118,6 @@ class AiDerivedPostServiceTest {
 		assertThat(savedPost.getCommercialPrice()).isEqualTo(commercialPrice);
 		assertThat(savedPost.getNonCommercialPrice()).isEqualTo(nonCommercialPrice);
 		assertThat(savedPost.getTicketPrice()).isEqualTo(ticketPrice);
-		assertThat(savedPost.getIsAiDerivedPost()).isTrue();
 		assertThat(savedPost.getParentPostId()).isEqualTo(mockAiImage.getPostId()); // 부모 포스트 ID 검증
 
 		// PostImageEntity 저장 검증
@@ -150,7 +151,7 @@ class AiDerivedPostServiceTest {
 		// when & then
 		AppException exception = assertThrows(AppException.class,
 			() -> aiDerivedPostService.createAiDerivedPost(
-				userId, nonExistentAiImageId, originalImageId, title, description,
+				userId, nonExistentAiImageId, title, description,
 				commercialPrice, nonCommercialPrice, ticketPrice));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AI_IMAGE_NOT_FOUND_EXCEPTION);
@@ -182,93 +183,12 @@ class AiDerivedPostServiceTest {
 		// when & then
 		AppException exception = assertThrows(AppException.class,
 			() -> aiDerivedPostService.createAiDerivedPost(
-				userId, createdAiImageId, originalImageId, title, description,
+				userId, createdAiImageId, title, description,
 				commercialPrice, nonCommercialPrice, ticketPrice));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION);
 		verify(createdAiImageRepository, times(1)).findById(createdAiImageId);
 		verify(postEntityRepository, never()).save(any());
 		verify(postImageEntityRepository, never()).save(any());
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 성공")
-	void deleteAiDerivedPost_Success() {
-		// given
-		Long userId = 1L;
-		Long postId = 1L;
-
-		UserEntity mockUser = UserFactory.createMockUser(userId);
-		PostEntity mockPost = createMockAiDerivedPostWithId(postId, mockUser);
-
-		when(postEntityRepository.findById(mockPost.getId())).thenReturn(Optional.of(mockPost));
-
-		// when
-		aiDerivedPostService.deleteAiDerivedPost(mockUser.getId(), mockPost.getId());
-
-		// then
-		verify(postEntityRepository, times(1)).findById(postId);
-		verify(postService, times(1)).deletePost(userId, postId);
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 실패 - 존재하지 않는 포스트")
-	void deleteAiDerivedPost_PostNotFound_ShouldThrowException() {
-		// given
-		Long userId = 1L;
-		Long nonExistentPostId = 999L;
-
-		when(postEntityRepository.findById(nonExistentPostId)).thenReturn(Optional.empty());
-
-		// when & then
-		AppException exception = assertThrows(AppException.class,
-			() -> aiDerivedPostService.deleteAiDerivedPost(userId, nonExistentPostId));
-
-		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.POST_NOT_FOUND_EXCEPTION);
-		verify(postEntityRepository, times(1)).findById(nonExistentPostId);
-		verify(postService, never()).deletePost(anyLong(), anyLong());
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 실패 - 포스트 접근 권한 없음")
-	void deleteAiDerivedPost_AccessDenied_ShouldThrowException() {
-		// given
-		Long userId = 1L;
-		Long otherUserId = 2L;
-		Long postId = 1L;
-
-		UserEntity otherUser = UserFactory.createMockUser(otherUserId);
-		PostEntity mockPost = createMockAiDerivedPostWithId(postId, otherUser);
-
-		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
-
-		// when & then
-		AppException exception = assertThrows(AppException.class,
-			() -> aiDerivedPostService.deleteAiDerivedPost(userId, mockPost.getId()));
-
-		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.POST_ACCESS_DENIED_EXCEPTION);
-		verify(postEntityRepository, times(1)).findById(postId);
-		verify(postService, never()).deletePost(anyLong(), anyLong());
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 실패 - AI 파생 포스트가 아님")
-	void deleteAiDerivedPost_NotAiDerivedPost_ShouldThrowException() {
-		// given
-		Long userId = 1L;
-		Long postId = 1L;
-
-		UserEntity mockUser = UserFactory.createMockUser(userId);
-		PostEntity mockPost = createMockPostWithId(postId, mockUser); // 일반 포스트
-
-		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
-
-		// when & then
-		AppException exception = assertThrows(AppException.class,
-			() -> aiDerivedPostService.deleteAiDerivedPost(mockUser.getId(), mockPost.getId()));
-
-		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_AI_DERIVED_POST_EXCEPTION);
-		verify(postEntityRepository, times(1)).findById(postId);
-		verify(postService, never()).deletePost(anyLong(), anyLong());
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -1,6 +1,7 @@
 package hanium.modic.backend.domain.post.service;
 
 import static hanium.modic.backend.domain.post.entityfactory.PostFactory.*;
+import static hanium.modic.backend.domain.post.enums.PostStatus.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -34,6 +35,7 @@ import hanium.modic.backend.domain.image.util.ImageUtil;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.entityfactory.PostFactory;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.post.enums.PostType;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
@@ -43,9 +45,8 @@ import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
-import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
-import hanium.modic.backend.web.post.dto.response.GetSimplePostsResponse;
+import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -82,20 +83,23 @@ class PostServiceTest {
 		Long commercialPrice = 1000L;
 		Long nonCommercialPrice = 500L;
 		Long ticketPrice = 200L;
+		// 이미지 생성
+		List<Long> imageIds = List.of(1L);
+		List<PostImageEntity> postImageEntities = List.of(
+			ImageFactory.createMockPostImageWithId(null, 1L)
+		);
 
-		List<Long> imageIds = new ArrayList<>();
-		List<PostImageEntity> postImageEntities = ImageFactory.createMockPostImages(null, 2);
-
-		for (int i = 0; i < postImageEntities.size(); i++) {
-			imageIds.add((long)i);
-			when(postImageEntityRepository.findById((long)i))
-				.thenReturn(Optional.of(postImageEntities.get(i)));
-		}
+		// 포스트 생성
 		PostEntity mockPost = createMockPostWithId(1L, mockUser);
+		mockPost.updateThumbnailImageId(1L);
+
+		// mocking
 		when(postEntityRepository.save(any())).thenReturn(mockPost);
+		when(postImageEntityRepository.findById(1L)).thenReturn(Optional.of(postImageEntities.get(0)));
 
 		// when
-		postService.createPost(userId, title, description, commercialPrice, nonCommercialPrice, ticketPrice, imageIds);
+		postService.createPost(userId, title, description, commercialPrice, nonCommercialPrice, ticketPrice, imageIds,
+			postImageEntities.get(0).getId());
 
 		// then - PostEntity 저장 확인
 		ArgumentCaptor<PostEntity> postCaptor = ArgumentCaptor.forClass(PostEntity.class);
@@ -105,14 +109,13 @@ class PostServiceTest {
 		assertThat(savedPost.getDescription()).isEqualTo(description);
 		assertThat(savedPost.getCommercialPrice()).isEqualTo(commercialPrice);
 		assertThat(savedPost.getNonCommercialPrice()).isEqualTo(nonCommercialPrice);
-		assertThat(savedPost.getIsAiDerivedPost()).isFalse();
 
 		// then - PostImageEntity 저장 확인
 		ArgumentCaptor<List<PostImageEntity>> imageCaptor = ArgumentCaptor.forClass(List.class);
 		verify(postImageEntityRepository, times(1)).saveAll(imageCaptor.capture());
 
 		List<PostImageEntity> savedImages = imageCaptor.getValue();
-		assertThat(savedImages).hasSize(2);
+		assertThat(savedImages).hasSize(1);
 		assertThat(savedImages).allMatch(image -> Objects.equals(image.getPostId(), savedPost.getId()));
 	}
 
@@ -136,7 +139,8 @@ class PostServiceTest {
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn(URL);
 		when(postLikeService.getLikeCount(postId)).thenReturn(10L);
 		when(postLikeService.isLikedByUser(currentUserId, postId)).thenReturn(true);
-		when(postEntityRepository.findIdsByParentPostIdOrderByIdDesc(postId)).thenReturn(List.of());
+		when(postEntityRepository.findAllByParentPostIdAndPostStatusOrderByIdDesc(postId,
+			PostStatus.DERIVED_APPROVED)).thenReturn(List.of());
 
 		// when
 		GetPostResponse response = postService.getPost(postId, currentUserId);
@@ -148,7 +152,6 @@ class PostServiceTest {
 		assertThat(response.description()).isEqualTo(mockPost.getDescription());
 		assertThat(response.commercialPrice()).isEqualTo(mockPost.getCommercialPrice());
 		assertThat(response.nonCommercialPrice()).isEqualTo(mockPost.getNonCommercialPrice());
-		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(10L);
 		assertThat(response.isLikedByCurrentUser()).isTrue();
 		assertThat(response.images()).hasSize(2);
@@ -160,7 +163,8 @@ class PostServiceTest {
 		verify(imageUtil, times(2)).createImageGetUrl(anyString());
 		verify(postLikeService).getLikeCount(postId);
 		verify(postLikeService).isLikedByUser(currentUserId, postId);
-		verify(postEntityRepository).findIdsByParentPostIdOrderByIdDesc(postId);
+		verify(postEntityRepository).findAllByParentPostIdAndPostStatusOrderByIdDesc(postId,
+			PostStatus.DERIVED_APPROVED);
 	}
 
 	@Test
@@ -179,14 +183,14 @@ class PostServiceTest {
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn("https://signed-url.com/image.jpg");
 		when(postLikeService.getLikeCount(postId)).thenReturn(5L);
 		when(postLikeService.isLikedByUser(currentUserId, postId)).thenReturn(false);
-		when(postEntityRepository.findIdsByParentPostIdOrderByIdDesc(postId)).thenReturn(List.of());
+		when(postEntityRepository.findAllByParentPostIdAndPostStatusOrderByIdDesc(postId,
+			PostStatus.DERIVED_APPROVED)).thenReturn(List.of());
 
 		// when
 		GetPostResponse response = postService.getPost(postId, currentUserId);
 
 		// then
 		assertThat(response).isNotNull();
-		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(5L);
 		assertThat(response.isLikedByCurrentUser()).isFalse();
 		assertThat(response.derivedPosts()).isEmpty(); // 파생포스트 없음
@@ -197,7 +201,8 @@ class PostServiceTest {
 		verify(imageUtil, times(2)).createImageGetUrl(anyString());
 		verify(postLikeService).getLikeCount(postId);
 		verify(postLikeService).isLikedByUser(currentUserId, postId);
-		verify(postEntityRepository).findIdsByParentPostIdOrderByIdDesc(postId);
+		verify(postEntityRepository).findAllByParentPostIdAndPostStatusOrderByIdDesc(postId,
+			PostStatus.DERIVED_APPROVED);
 	}
 
 	@Test
@@ -245,7 +250,6 @@ class PostServiceTest {
 		assertThat(response.description()).isEqualTo(mockPost.getDescription());
 		assertThat(response.commercialPrice()).isEqualTo(mockPost.getCommercialPrice());
 		assertThat(response.nonCommercialPrice()).isEqualTo(mockPost.getNonCommercialPrice());
-		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(15L);
 		assertThat(response.isLikedByCurrentUser()).isFalse(); // 비로그인 사용자이므로 false
 		assertThat(response.images()).hasSize(expectedImages.size());
@@ -288,8 +292,8 @@ class PostServiceTest {
 		int size = 10;
 		String sort = "createdAt";
 
-		UserEntity mockUser = UserFactory.createMockUser(1L);
-		List<PostEntity> mockPosts = Arrays.asList(
+		UserEntity mockUser = UserFactory.createMockUser(1L); // 사용자 생성
+		List<PostEntity> mockPosts = Arrays.asList( // 게시글 생성
 			createMockPostWithId(1L, mockUser),
 			createMockPostWithId(2L, mockUser));
 
@@ -307,7 +311,7 @@ class PostServiceTest {
 		// 하트 수 배치 조회 설정
 		Map<Long, Long> mockLikeCounts = Map.of(1L, 5L, 2L, 8L);
 
-		when(postEntityRepository.findAll(any(Pageable.class))).thenReturn(mockPostPage);
+		when(postEntityRepository.findAllByPostStatusIn(eq(List.of(ORIGINAL, DERIVED_APPROVED)), any(Pageable.class))).thenReturn(mockPostPage);
 		when(postImageEntityRepository.findAllByPostIdIn(Arrays.asList(1L, 2L)))
 			.thenReturn(allMockImages);
 		when(postLikeService.getLikeCounts(Arrays.asList(1L, 2L)))
@@ -315,7 +319,7 @@ class PostServiceTest {
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn("https://signed-url.com/image.jpg");
 
 		// when
-		PageResponse<GetPostsResponse> response = postService.getPosts(sort, page, size, PostType.ALL);
+		PageResponse<GetPostsResponse> response = postService.getPosts(page, size, PostType.ALL);
 
 		// then
 		assertThat(response).isNotNull();
@@ -329,7 +333,7 @@ class PostServiceTest {
 		assertThat(secondPost.likeCount()).isEqualTo(8L);
 
 		// 배치 조회 메서드 호출 검증
-		verify(postEntityRepository).findAll(any(Pageable.class));
+		verify(postEntityRepository).findAllByPostStatusIn(eq(List.of(ORIGINAL, DERIVED_APPROVED)), any(Pageable.class));
 		verify(postImageEntityRepository).findAllByPostIdIn(Arrays.asList(1L, 2L));
 		verify(postLikeService).getLikeCounts(Arrays.asList(1L, 2L));
 	}
@@ -359,13 +363,13 @@ class PostServiceTest {
 
 		Map<Long, Long> mockLikeCounts = Map.of(1L, 3L, 2L, 7L);
 
-		when(postEntityRepository.findAll(any(Pageable.class))).thenReturn(mockPostPage);
-		when(postImageEntityRepository.findAllByPostIdIn(Arrays.asList(1L, 2L))).thenReturn(allMockImages);
+		// When
+		when(postEntityRepository.findAllByPostStatusIn(eq(List.of(ORIGINAL, DERIVED_APPROVED)), any(Pageable.class))).thenReturn(mockPostPage);
 		when(postLikeService.getLikeCounts(Arrays.asList(1L, 2L))).thenReturn(mockLikeCounts);
+		when(postImageEntityRepository.findAllByPostIdIn(Arrays.asList(1L, 2L))).thenReturn(allMockImages);
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn("https://signed-url.com/image.jpg");
 
-		// When
-		PageResponse<GetPostsResponse> response = postService.getPosts(sort, page, size, PostType.ALL);
+		PageResponse<GetPostsResponse> response = postService.getPosts(page, size, PostType.ALL);
 
 		// Then
 		assertThat(response).isNotNull();
@@ -374,37 +378,14 @@ class PostServiceTest {
 		assertEquals(size, response.getSize());
 		assertEquals(1, response.getTotalPages());
 
-		verify(postEntityRepository, times(1)).findAll(any(Pageable.class));
+		verify(postEntityRepository, times(1)).findAllByPostStatusIn(eq(List.of(ORIGINAL, DERIVED_APPROVED)),any(Pageable.class));
 		verify(postImageEntityRepository, times(1)).findAllByPostIdIn(Arrays.asList(1L, 2L));
 		verify(postLikeService, times(1)).getLikeCounts(Arrays.asList(1L, 2L));
 	}
 
 	@Test
-	@DisplayName("게시글 목록 조회 실패: 게시글 없는 경우")
-	void getPosts_NotFound() {
-		// Given
-		int page = 0;
-		int size = 10;
-		String sort = "createdAt";
-
-		Page<PostEntity> emptyPage = new PageImpl<>(Collections.emptyList(),
-			PageRequest.of(page, size, SORT_DIRECTION, SORT_CRITERIA), 0);
-
-		when(postEntityRepository.findAll(any(Pageable.class))).thenReturn(emptyPage);
-
-		// When & Then
-		AppException exception = assertThrows(AppException.class,
-			() -> postService.getPosts(sort, page, size, PostType.ALL));
-		assertEquals(ErrorCode.POST_NOT_FOUND_EXCEPTION, exception.getErrorCode());
-
-		verify(postEntityRepository, times(1)).findAll(any(Pageable.class));
-		verify(postImageEntityRepository, never()).findAllByPostIdIn(any());
-		verify(postLikeService, never()).getLikeCounts(any());
-	}
-
-	@Test
 	@DisplayName("단순 게시글 목록 조회 성공 - 사용자 게시글 존재")
-	void getSimplePosts_WithUserPosts_ShouldReturnSimplePostsPage() {
+	void getSimplePosts_WithUserPosts_ShouldReturnUserPostsPage() {
 		// given
 		Long userId = 1L;
 		int page = 0;
@@ -438,19 +419,19 @@ class PostServiceTest {
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn("https://signed-url.com/image.jpg");
 
 		// when
-		Page<GetSimplePostsResponse> result = postService.getSimplePosts(userId, page, size);
+		Page<GetPostsResponse> result = postService.getUserPosts(userId, page, size);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getContent()).hasSize(2);
 
-		GetSimplePostsResponse firstPost = result.getContent().get(0);
+		GetPostsResponse firstPost = result.getContent().get(0);
 		assertThat(firstPost.postId()).isEqualTo(1L);
 		assertThat(firstPost.images()).isNotEmpty();
 		assertThat(firstPost.images().get(0).getImageUrl()).isNotNull();
 		assertThat(firstPost.images().get(0).getImageId()).isNotNull();
 
-		GetSimplePostsResponse secondPost = result.getContent().get(1);
+		GetPostsResponse secondPost = result.getContent().get(1);
 		assertThat(secondPost.postId()).isEqualTo(2L);
 		assertThat(secondPost.images()).isNotEmpty();
 		assertThat(secondPost.images().get(0).getImageUrl()).isNotNull();
@@ -461,33 +442,8 @@ class PostServiceTest {
 	}
 
 	@Test
-	@DisplayName("단순 게시글 목록 조회 성공 - 게시글 없음")
-	void getSimplePosts_NoUserPosts_ShouldReturnEmptyPage() {
-		// given
-		Long userId = 1L;
-		int page = 0;
-		int size = 10;
-
-		Page<PostEntity> emptyPage = Page.empty(PageRequest.of(page, size));
-
-		when(postEntityRepository.findAllByUserId(userId, PageRequest.of(page, size)))
-			.thenReturn(emptyPage);
-
-		// when
-		Page<GetSimplePostsResponse> result = postService.getSimplePosts(userId, page, size);
-
-		// then
-		assertThat(result).isNotNull();
-		assertThat(result.getContent()).isEmpty();
-		assertThat(result.getTotalElements()).isZero();
-
-		verify(postEntityRepository).findAllByUserId(userId, PageRequest.of(page, size));
-		verify(postImageEntityRepository, never()).findAllByPostIdIn(any());
-	}
-
-	@Test
 	@DisplayName("단순 게시글 목록 조회 성공 - 이미지 없는 게시글 처리")
-	void getSimplePosts_PostsWithoutImages_ShouldReturnNullImageUrl() {
+	void getUserPosts_PostsWithoutImages_ShouldReturnNullImageUrl() {
 		// given
 		Long userId = 1L;
 		int page = 0;
@@ -504,13 +460,13 @@ class PostServiceTest {
 			.thenReturn(Collections.emptyList()); // 이미지 없음
 
 		// when
-		Page<GetSimplePostsResponse> result = postService.getSimplePosts(userId, page, size);
+		Page<GetPostsResponse> result = postService.getUserPosts(userId, page, size);
 
 		// then
 		assertThat(result).isNotNull();
 		assertThat(result.getContent()).hasSize(1);
 
-		GetSimplePostsResponse response = result.getContent().get(0);
+		GetPostsResponse response = result.getContent().get(0);
 		assertThat(response.postId()).isEqualTo(1L);
 		assertThat(response.images()).isEmpty();
 
@@ -576,7 +532,7 @@ class PostServiceTest {
 
 		// When
 		postService.updatePost(userId, postId, newTitle, newDescription, newCommercialPrice, newNonCommercialPrice,
-			ticketPrice, newImageIds);
+			ticketPrice, newImageIds, anotherPostImageId1);
 
 		// Then
 		verify(postEntityRepository, times(1)).findById(postId);
@@ -609,7 +565,7 @@ class PostServiceTest {
 		// When & Then
 		AppException exception = assertThrows(AppException.class,
 			() -> postService.updatePost(userId, postId, newTitle, newDescription, newCommercialPrice,
-				newNonCommercialPrice, ticketPrice, newImageIds)
+				newNonCommercialPrice, ticketPrice, newImageIds, 3L)
 		);
 		assertEquals(ErrorCode.POST_NOT_FOUND_EXCEPTION, exception.getErrorCode());
 
@@ -628,7 +584,10 @@ class PostServiceTest {
 		Long currentUserId = 2L;
 		PostEntity mockPost = createMockPostWithId(postId, mockUser);
 		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost, 1);
-		List<Long> derivedPostIds = List.of(10L, 11L, 12L); // 파생포스트 ID들
+		List<PostEntity> derivedPostIds = List.of(
+			createMockAiDerivedPostWithId(2L, mockUser, postId),
+			createMockAiDerivedPostWithId(3L, mockUser, postId)
+		);
 
 		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
 		when(userEntityRepository.findById(mockPost.getUserId())).thenReturn(Optional.of(mockUser));
@@ -636,7 +595,8 @@ class PostServiceTest {
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn(URL);
 		when(postLikeService.getLikeCount(postId)).thenReturn(15L);
 		when(postLikeService.isLikedByUser(currentUserId, postId)).thenReturn(false);
-		when(postEntityRepository.findIdsByParentPostIdOrderByIdDesc(postId)).thenReturn(derivedPostIds);
+		when(postEntityRepository.findAllByParentPostIdAndPostStatusOrderByIdDesc(postId, PostStatus.DERIVED_APPROVED))
+			.thenReturn(derivedPostIds);
 
 		// when
 		GetPostResponse response = postService.getPost(postId, currentUserId);
@@ -644,17 +604,17 @@ class PostServiceTest {
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.postId()).isEqualTo(mockPost.getId());
-		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(15L);
 		assertThat(response.isLikedByCurrentUser()).isFalse();
-		assertThat(response.derivedPosts()).hasSize(3);
+		assertThat(response.derivedPosts()).hasSize(2);
 
 		verify(postEntityRepository).findById(postId);
 		verify(userEntityRepository).findById(mockPost.getUserId());
 		verify(postImageEntityRepository).findAllByPostId(postId);
 		verify(postLikeService).getLikeCount(postId);
 		verify(postLikeService).isLikedByUser(currentUserId, postId);
-		verify(postEntityRepository).findIdsByParentPostIdOrderByIdDesc(postId);
+		verify(postEntityRepository).findAllByParentPostIdAndPostStatusOrderByIdDesc(postId,
+			PostStatus.DERIVED_APPROVED);
 	}
 
 	@Test
@@ -681,7 +641,6 @@ class PostServiceTest {
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.postId()).isEqualTo(mockAiDerivedPost.getId());
-		assertThat(response.isAiDerivedPost()).isTrue();
 		assertThat(response.likeCount()).isEqualTo(3L);
 		assertThat(response.isLikedByCurrentUser()).isTrue();
 		assertThat(response.derivedPosts()).isEmpty(); // AI 파생 포스트이므로 빈 배열
@@ -701,13 +660,15 @@ class PostServiceTest {
 		Long postId = 1L;
 		PostEntity mockPost = createMockPostWithId(postId, mockUser);
 		List<PostImageEntity> mockImages = ImageFactory.createMockPostImages(mockPost, 1);
-		List<Long> derivedPostIds = List.of(20L, 21L);
+		List<PostEntity> derivedPostIds = List.of(createMockAiDerivedPostWithId(20L, mockUser),
+			createMockAiDerivedPostWithId(21L, mockUser));
 
 		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
 		when(userEntityRepository.findById(mockPost.getUserId())).thenReturn(Optional.of(mockUser));
 		when(postImageEntityRepository.findAllByPostId(postId)).thenReturn(mockImages);
 		when(postLikeService.getLikeCount(postId)).thenReturn(25L);
-		when(postEntityRepository.findIdsByParentPostIdOrderByIdDesc(postId)).thenReturn(derivedPostIds);
+		when(postEntityRepository.findAllByParentPostIdAndPostStatusOrderByIdDesc(postId, PostStatus.DERIVED_APPROVED))
+			.thenReturn(derivedPostIds);
 
 		// when
 		GetPostResponse response = postService.getPostForPublic(postId);
@@ -715,7 +676,6 @@ class PostServiceTest {
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.postId()).isEqualTo(mockPost.getId());
-		assertThat(response.isAiDerivedPost()).isFalse();
 		assertThat(response.likeCount()).isEqualTo(25L);
 		assertThat(response.isLikedByCurrentUser()).isFalse(); // 비로그인 사용자
 		assertThat(response.derivedPosts()).hasSize(2);
@@ -724,7 +684,8 @@ class PostServiceTest {
 		verify(userEntityRepository).findById(mockPost.getUserId());
 		verify(postImageEntityRepository).findAllByPostId(postId);
 		verify(postLikeService).getLikeCount(postId);
-		verify(postEntityRepository).findIdsByParentPostIdOrderByIdDesc(postId);
+		verify(postEntityRepository).findAllByParentPostIdAndPostStatusOrderByIdDesc(postId,
+			PostStatus.DERIVED_APPROVED);
 		// 비로그인 사용자이므로 isLikedByUser는 호출되지 않음
 		verify(postLikeService, never()).isLikedByUser(any(), any());
 	}
@@ -764,7 +725,7 @@ class PostServiceTest {
 		assertThat(rootResponse.title()).isEqualTo(rootPost.getTitle());
 		assertThat(rootResponse.parentPostId()).isNull();
 		assertThat(rootResponse.representativeImageUrl()).isEqualTo("http://example.com/image.jpg");
-		assertThat(rootResponse.postStatus()).isEqualTo(rootPost.getDerivedPostStatus());
+		assertThat(rootResponse.postStatus()).isEqualTo(rootPost.getPostStatus());
 
 		GetPostTreeResponse child1Response = result.get(1);
 		assertThat(child1Response.postId()).isEqualTo(2L);

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImagePermissionControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImagePermissionControllerIntegrationTest.java
@@ -15,6 +15,7 @@ import hanium.modic.backend.base.BaseIntegrationTest;
 import hanium.modic.backend.base.login.WithCustomUser;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatRoomEntity;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatRoomRepository;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.ticket.entity.TicketEntity;
 import hanium.modic.backend.domain.ticket.repository.TicketRepository;
 import hanium.modic.backend.domain.post.entity.PostEntity;
@@ -45,6 +46,8 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 			.commercialPrice(10000L)
 			.nonCommercialPrice(5000L)
 			.ticketPrice(3L)
+			.postStatus(PostStatus.ORIGINAL)
+			.thumbnailImageId(1L)
 			.build());
 	}
 

--- a/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import hanium.modic.backend.domain.image.domain.ImageExtension;
 import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
+import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
@@ -60,10 +61,23 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 			// given
 			UserEntity currentUser = ContextHolderUtil.getCurrentUser();
 
+			// PostEntity 생성 및 저장
+			PostEntity postEntity = PostEntity.builder()
+				.userId(currentUser.getId())
+				.title("Original Post")
+				.description("This is the original post description")
+				.commercialPrice(1000L)
+				.nonCommercialPrice(500L)
+				.ticketPrice(100L)
+				.postStatus(PostStatus.ORIGINAL)
+				.thumbnailImageId(1L) // 임시 값
+				.build();
+			postEntity = postEntityRepository.save(postEntity);
+
 			// AiChatImageEntity 생성 및 저장
 			AiChatImageEntity createdAiImage = AiChatImageEntity.builder()
 				.userId(currentUser.getId())
-				.postId(999L) // 임시 값
+				.postId(postEntity.getId()) // 임시 값
 				.aiChatRoomId(999L) // 임시 값
 				.imagePath("imagePath")
 				.fullImageName("ai-image-full.png")
@@ -78,7 +92,6 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 
 			CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
 				createdAiImage.getId(),
-				999L, // originalImageId 임시 값
 				"AI Generated Post",
 				"This is an AI derived post created from integration test",
 				2000L,
@@ -110,7 +123,6 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 			assertThat(savedPost.getCommercialPrice()).isEqualTo(2000L);
 			assertThat(savedPost.getNonCommercialPrice()).isEqualTo(1000L);
 			assertThat(savedPost.getTicketPrice()).isEqualTo(300L);
-			assertThat(savedPost.getIsAiDerivedPost()).isTrue();
 
 			// 포스트 이미지 검증
 			PostImageEntity savedPostImage = postImageEntityRepository.findAllByPostId(savedPost.getId()).get(0);
@@ -132,7 +144,6 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 		// given
 		CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
 			999L, // 존재하지 않는 AI 이미지 ID
-			888L, // originalImageId 임시 값
 			"AI Generated Post",
 			"This is an AI derived post",
 			2000L,
@@ -187,7 +198,6 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 
 		CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
 			otherUserAiImage.getId(),
-			777L, // originalImageId 임시 값
 			"AI Generated Post",
 			"This is an AI derived post",
 			2000L,
@@ -211,137 +221,11 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 
 	@Test
 	@WithCustomUser(email = "test@email.com")
-	@DisplayName("AI 파생 포스트 삭제 성공 - 통합 테스트")
-	void deleteAiDerivedPost_Success_IntegrationTest() throws Exception {
-		// given
-		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
-
-		// AI 파생 포스트 생성
-		PostEntity aiDerivedPost = PostEntity.builder()
-			.userId(currentUser.getId())
-			.title("AI Generated Post to Delete")
-			.description("This AI derived post will be deleted")
-			.commercialPrice(1500L)
-			.nonCommercialPrice(800L)
-			.ticketPrice(250L)
-			.isAiDerivedPost(true)
-			.build();
-		aiDerivedPost = postEntityRepository.save(aiDerivedPost);
-
-		// 포스트 이미지 생성
-		PostImageEntity postImage = PostImageEntity.builder()
-			.imagePath("test/ai-post-image.png")
-			.fullImageName("ai-post-image.png")
-			.imageName("ai-post-image")
-			.extension(ImageExtension.PNG)
-			.imagePurpose(ImagePrefix.AI_RESPONSE)
-			.build();
-		postImage.updatePost(aiDerivedPost);
-		postImageEntityRepository.save(postImage);
-
-		// when
-		ResultActions result = mockMvc.perform(delete("/api/ai/derived-posts/{postId}", aiDerivedPost.getId()));
-
-		// then
-		result.andExpect(status().isOk());
-
-		// 포스트가 삭제되었는지 확인
-		boolean postExists = postEntityRepository.existsById(aiDerivedPost.getId());
-		assertThat(postExists).isFalse();
-
-		// 포스트 이미지도 삭제되었는지 확인
-		long imageCount = postImageEntityRepository.findAllByPostId(aiDerivedPost.getId()).size();
-		assertThat(imageCount).isEqualTo(0);
-	}
-
-	@Test
-	@WithCustomUser(email = "test@email.com")
-	@DisplayName("AI 파생 포스트 삭제 실패 - 존재하지 않는 포스트")
-	void deleteAiDerivedPost_PostNotFound_IntegrationTest() throws Exception {
-		// given
-		Long nonExistentPostId = 999L;
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", nonExistentPostId))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND_EXCEPTION.getMessage()));
-	}
-
-	@Test
-	@WithCustomUser(email = "test@email.com")
-	@DisplayName("AI 파생 포스트 삭제 실패 - 포스트 접근 권한 없음")
-	void deleteAiDerivedPost_PostAccessDenied_IntegrationTest() throws Exception {
-		// given
-		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
-
-		// 다른 사용자 생성
-		UserEntity otherUser = UserEntity.builder()
-			.email("other2@test.com")
-			.password("password123")
-			.name("Other User 2")
-			.uniqueId("other_user_2")
-			.build();
-		otherUser = userEntityRepository.save(otherUser);
-
-		// 다른 사용자의 AI 파생 포스트 생성
-		PostEntity otherUserPost = PostEntity.builder()
-			.userId(otherUser.getId())
-			.title("Other User's AI Post")
-			.description("This is other user's AI derived post")
-			.commercialPrice(2000L)
-			.nonCommercialPrice(1000L)
-			.ticketPrice(300L)
-			.isAiDerivedPost(true)
-			.build();
-		otherUserPost = postEntityRepository.save(otherUserPost);
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", otherUserPost.getId()))
-			.andExpect(status().isForbidden())
-			.andExpect(jsonPath("$.message").value(ErrorCode.POST_ACCESS_DENIED_EXCEPTION.getMessage()));
-
-		// 포스트가 삭제되지 않았는지 확인
-		boolean postExists = postEntityRepository.existsById(otherUserPost.getId());
-		assertThat(postExists).isTrue();
-	}
-
-	@Test
-	@WithCustomUser(email = "test@email.com")
-	@DisplayName("AI 파생 포스트 삭제 실패 - AI 파생 포스트가 아님")
-	void deleteAiDerivedPost_NotAiDerivedPost_IntegrationTest() throws Exception {
-		// given
-		UserEntity currentUser = ContextHolderUtil.getCurrentUser();
-
-		// 일반 포스트 생성 (AI 파생이 아님)
-		PostEntity regularPost = PostEntity.builder()
-			.userId(currentUser.getId())
-			.title("Regular Post")
-			.description("This is a regular post")
-			.commercialPrice(1000L)
-			.nonCommercialPrice(500L)
-			.ticketPrice(200L)
-			.isAiDerivedPost(false) // AI 파생이 아님
-			.build();
-		regularPost = postEntityRepository.save(regularPost);
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", regularPost.getId()))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value(ErrorCode.NOT_AI_DERIVED_POST_EXCEPTION.getMessage()));
-
-		// 포스트가 삭제되지 않았는지 확인
-		boolean postExists = postEntityRepository.existsById(regularPost.getId());
-		assertThat(postExists).isTrue();
-	}
-
-	@Test
-	@WithCustomUser(email = "test@email.com")
 	@DisplayName("AI 파생 포스트 생성 요청 검증 실패 - 잘못된 입력 데이터")
 	void createAiDerivedPost_InvalidInputData_IntegrationTest() throws Exception {
 		// given
 		CreateAiDerivedPostRequest invalidRequest = new CreateAiDerivedPostRequest(
 			null, // AI 이미지 ID 누락
-			null, // originalImageId 누락
 			null, // 제목 누락
 			null, // 설명 누락
 			-1L,  // 음수 상업적 가격
@@ -359,7 +243,6 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 			.andExpect(jsonPath("$.reason").isArray())
 			.andExpect(jsonPath("$.reason[*]").value(Matchers.hasItems(
 				"생성된 AI 이미지 ID는 필수입니다.",
-				"원본 이미지 ID는 필수입니다.",
 				"제목은 필수입니다.",
 				"설명은 필수입니다.",
 				"상업적 가격은 0 이상이어야 합니다.",

--- a/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerTest.java
@@ -56,7 +56,7 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			.andExpect(jsonPath("$.reason[0]").value(expectedErrorMessage));
 
 		verify(aiDerivedPostService, never()).createAiDerivedPost(
-			anyLong(), anyLong(), anyLong(), anyString(), anyString(), anyLong(), anyLong(), anyLong());
+			anyLong(), anyLong(), anyString(), anyString(), anyLong(), anyLong(), anyLong());
 	}
 
 	static Stream<Arguments> invalidCreateAiDerivedPostRequests() {
@@ -64,7 +64,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
 					null,
-					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
 					2000L,
@@ -76,7 +75,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			),
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
-					1L,
 					1L,
 					null,
 					"This is an AI derived post",
@@ -90,7 +88,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
 					1L,
-					1L,
 					"",
 					"This is an AI derived post",
 					2000L,
@@ -102,7 +99,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			),
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
-					1L,
 					1L,
 					"AI Generated Post",
 					null,
@@ -116,7 +112,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
 					1L,
-					1L,
 					"AI Generated Post",
 					"",
 					2000L,
@@ -128,7 +123,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			),
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
-					1L,
 					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
@@ -142,7 +136,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
 					1L,
-					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
 					-1L,
@@ -154,7 +147,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			),
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
-					1L,
 					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
@@ -168,7 +160,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
 					1L,
-					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
 					2000L,
@@ -181,7 +172,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
 					1L,
-					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
 					2000L,
@@ -193,7 +183,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 			),
 			Arguments.of(
 				new CreateAiDerivedPostRequest(
-					1L,
 					1L,
 					"AI Generated Post",
 					"This is an AI derived post",
@@ -213,7 +202,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 		// given
 		CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
 			999L,
-			1L,
 			"AI Generated Post",
 			"This is an AI derived post",
 			2000L,
@@ -222,7 +210,7 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 		);
 
 		when(aiDerivedPostService.createAiDerivedPost(
-			anyLong(), eq(request.createdAiImageId()), eq(request.originalImageId()), eq(request.title()),
+			anyLong(), eq(request.createdAiImageId()), eq(request.title()),
 			eq(request.description()), eq(request.commercialPrice()),
 			eq(request.nonCommercialPrice()), eq(request.ticketPrice())
 		)).thenThrow(new AppException(ErrorCode.AI_IMAGE_NOT_FOUND_EXCEPTION));
@@ -243,7 +231,6 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 		// given
 		CreateAiDerivedPostRequest request = new CreateAiDerivedPostRequest(
 			1L,
-			1L,
 			"AI Generated Post",
 			"This is an AI derived post",
 			2000L,
@@ -252,7 +239,7 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 		);
 
 		when(aiDerivedPostService.createAiDerivedPost(
-			anyLong(), eq(request.createdAiImageId()), eq(request.originalImageId()), eq(request.title()),
+			anyLong(), eq(request.createdAiImageId()), eq(request.title()),
 			eq(request.description()), eq(request.commercialPrice()),
 			eq(request.nonCommercialPrice()), eq(request.ticketPrice())
 		)).thenThrow(new AppException(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION));
@@ -265,65 +252,5 @@ class AiDerivedPostControllerTest extends BaseControllerTest {
 				.content(json))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.message").value(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION.getMessage()));
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 성공")
-	void deleteAiDerivedPost_Success() throws Exception {
-		// given
-		Long postId = 1L;
-
-		doNothing().when(aiDerivedPostService).deleteAiDerivedPost(anyLong(), eq(postId));
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", postId))
-			.andExpect(status().isOk());
-
-		verify(aiDerivedPostService, times(1)).deleteAiDerivedPost(anyLong(), eq(postId));
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 실패 - 포스트를 찾을 수 없음")
-	void deleteAiDerivedPost_PostNotFound_ShouldReturn404() throws Exception {
-		// given
-		Long nonExistentPostId = 999L;
-
-		doThrow(new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION))
-			.when(aiDerivedPostService).deleteAiDerivedPost(anyLong(), eq(nonExistentPostId));
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", nonExistentPostId))
-			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("$.message").value(ErrorCode.POST_NOT_FOUND_EXCEPTION.getMessage()));
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 실패 - 포스트 접근 권한 없음")
-	void deleteAiDerivedPost_PostAccessDenied_ShouldReturn403() throws Exception {
-		// given
-		Long postId = 1L;
-
-		doThrow(new AppException(ErrorCode.POST_ACCESS_DENIED_EXCEPTION))
-			.when(aiDerivedPostService).deleteAiDerivedPost(anyLong(), eq(postId));
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", postId))
-			.andExpect(status().isForbidden())
-			.andExpect(jsonPath("$.message").value(ErrorCode.POST_ACCESS_DENIED_EXCEPTION.getMessage()));
-	}
-
-	@Test
-	@DisplayName("AI 파생 포스트 삭제 실패 - AI 파생 포스트가 아님")
-	void deleteAiDerivedPost_NotAiDerivedPost_ShouldReturn400() throws Exception {
-		// given
-		Long postId = 1L;
-
-		doThrow(new AppException(ErrorCode.NOT_AI_DERIVED_POST_EXCEPTION))
-			.when(aiDerivedPostService).deleteAiDerivedPost(anyLong(), eq(postId));
-
-		// when & then
-		mockMvc.perform(delete("/api/ai/derived-posts/{postId}", postId))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value(ErrorCode.NOT_AI_DERIVED_POST_EXCEPTION.getMessage()));
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerIntegrationTest.java
@@ -85,7 +85,8 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 			10000L,
 			5000L,
 			0L,
-			List.of(image1.getId(), image2.getId())
+			List.of(image1.getId(), image2.getId()),
+			image1.getId()
 		);
 		String json = objectMapper.writeValueAsString(request);
 
@@ -146,7 +147,8 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 			20000L,
 			10000L,
 			0L,
-			postImageIds
+			postImageIds,
+			postImageIds.get(0)
 		);
 		String json = objectMapper.writeValueAsString(request);
 
@@ -188,7 +190,8 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 			20000L,
 			10000L,
 			0L,
-			List.of(otherPersonsImage.getId())
+			List.of(otherPersonsImage.getId()),
+			otherPersonsImage.getId()
 		);
 		String json = objectMapper.writeValueAsString(request);
 
@@ -230,7 +233,8 @@ class PostControllerIntegrationTest extends BaseIntegrationTest {
 				20000L,
 				10000L,
 				0L,
-				List.of(imageToKeep.getId()) // 첫 번째 이미지만 남기고 나머지는 삭제
+				List.of(imageToKeep.getId()), // 첫 번째 이미지만 남기고 나머지는 삭제
+				imageToKeep.getId()
 			);
 			String json = objectMapper.writeValueAsString(request);
 

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -133,7 +133,7 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					null,
-					null
+					1L
 				),
 				"이미지는 필수입니다.",
 				"이미지 누락"

--- a/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PostControllerTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.post.enums.PostType;
 import hanium.modic.backend.domain.postReview.service.PostReviewAuthorizationService;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -79,7 +80,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"제목은 필수입니다.",
 				"제목 누락"
@@ -91,7 +93,8 @@ class PostControllerTest extends BaseControllerTest {
 					null,
 					0L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"상업적 가격은 필수입니다.",
 				"상업적 가격 누락"
@@ -103,7 +106,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					null,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"비상업적 가격은 필수입니다.",
 				"비상업적 가격 누락"
@@ -115,7 +119,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					-1L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"비상업적 가격은 0 이상이어야 합니다.",
 				"비상업적 가격 음수"
@@ -127,6 +132,7 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
+					null,
 					null
 				),
 				"이미지는 필수입니다.",
@@ -139,7 +145,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
-					Collections.nCopies(9, 1L)
+					Collections.nCopies(9, 1L),
+					1L
 				),
 				"이미지는 최대 8개까지 업로드 가능합니다.",
 				"이미지 개수 초과"
@@ -153,7 +160,7 @@ class PostControllerTest extends BaseControllerTest {
 		// given
 		Long postId = 1L;
 		GetPostResponse response = new GetPostResponse(
-			"이름", false, null, "chanho@naver.com", 1L, 1L, "제목", "설명", 10000L, 5000L, 0L, false,
+			"이름", false, null, "chanho@naver.com", 1L, 1L, "제목", "설명", 10000L, 5000L, 0L, PostStatus.ORIGINAL,
 			List.of(new GetPostResponse.ImageDto("http://img1.jpg", 1L)),
 			10L, true, List.of());
 
@@ -193,15 +200,15 @@ class PostControllerTest extends BaseControllerTest {
 	void getPosts_DefaultParams_Success() throws Exception {
 		// given
 		GetPostsResponse post1 = new GetPostsResponse(
-			1L, 1L, "제목1", "설명1", 10000L, 5000L, false, List.of(new GetPostsResponse.ImageDto("http://img1.jpg", 1L)), 5L);
+			1L, "제목1", PostStatus.ORIGINAL, List.of(new GetPostsResponse.ImageDto("http://img1.jpg", 1L)), 5L);
 		GetPostsResponse post2 = new GetPostsResponse(
-			2L, 2L, "제목2", "설명2", 20000L, 8000L, false, List.of(new GetPostsResponse.ImageDto("http://img2.jpg", 2L)), 8L);
+			2L, "제목2", PostStatus.ORIGINAL, List.of(new GetPostsResponse.ImageDto("http://img2.jpg", 2L)), 8L);
 
 		List<GetPostsResponse> content = List.of(post1, post2);
 		Page<GetPostsResponse> page = new PageImpl<>(content, PageRequest.of(0, 10), 2);
 		PageResponse<GetPostsResponse> pageResponse = PageResponse.of(page);
 
-		when(postService.getPosts(any(String.class), anyInt(), anyInt(), eq(PostType.ALL))).thenReturn(pageResponse);
+		when(postService.getPosts(anyInt(), anyInt(), eq(PostType.ALL))).thenReturn(pageResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/posts")
@@ -222,13 +229,14 @@ class PostControllerTest extends BaseControllerTest {
 		throws Exception {
 		// given
 		GetPostsResponse post = new GetPostsResponse(
-			1L, 1L, "제목", "설명", 10000L, 5000L, false, List.of(new GetPostsResponse.ImageDto("http://img1.jpg", 1L)), 3L);
+			1L, "제목", PostStatus.ORIGINAL, List.of(new GetPostsResponse.ImageDto("http://img1.jpg", 1L)),
+			3L);
 
 		List<GetPostsResponse> content = List.of(post);
 		Page<GetPostsResponse> page = new PageImpl<>(content, PageRequest.of(pageNumber, size), totalElements);
 		PageResponse<GetPostsResponse> pageResponse = PageResponse.of(page);
 
-		when(postService.getPosts(sort, pageNumber, size, PostType.ALL)).thenReturn(pageResponse);
+		when(postService.getPosts(pageNumber, size, PostType.ALL)).thenReturn(pageResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/posts")
@@ -295,7 +303,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"제목은 필수입니다.",
 				"제목 누락"
@@ -307,7 +316,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"설명은 필수입니다.",
 				"설명 누락"
@@ -319,7 +329,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"설명은 필수입니다.",
 				"설명 비어있음"
@@ -332,7 +343,8 @@ class PostControllerTest extends BaseControllerTest {
 					null,
 					0L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"상업적 가격은 필수입니다.",
 				"상업적 가격 누락"
@@ -344,7 +356,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					null,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"비상업적 가격은 필수입니다.",
 				"비상업적 가격 누락"
@@ -356,7 +369,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					-1L,
 					0L,
-					List.of(1L)
+					List.of(1L),
+					1L
 				),
 				"비상업적 가격은 0 이상이어야 합니다.",
 				"비상업적 가격 음수"
@@ -368,6 +382,7 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
+					null,
 					null
 				),
 				"이미지는 필수입니다.",
@@ -380,7 +395,8 @@ class PostControllerTest extends BaseControllerTest {
 					0L,
 					0L,
 					0L,
-					Collections.nCopies(9, 1L)
+					Collections.nCopies(9, 1L),
+					1L
 				),
 				"이미지는 최대 8개까지 업로드 가능합니다.",
 				"이미지 개수 초과"
@@ -394,9 +410,12 @@ class PostControllerTest extends BaseControllerTest {
 		// given
 		Long postId = 1L;
 		List<GetPostTreeResponse> mockResponse = List.of(
-			new GetPostTreeResponse(1L, "Root Post", null, "http://example.com/image1.jpg", PostStatus.APPROVED),
-			new GetPostTreeResponse(2L, "Child Post 1", 1L, "http://example.com/image2.jpg", PostStatus.PENDING),
-			new GetPostTreeResponse(3L, "Child Post 2", 1L, "http://example.com/image3.jpg", PostStatus.APPROVED)
+			new GetPostTreeResponse(1L, "Root Post", null, "http://example.com/image1.jpg",
+				PostStatus.DERIVED_APPROVED),
+			new GetPostTreeResponse(2L, "Child Post 1", 1L, "http://example.com/image2.jpg",
+				PostStatus.DERIVED_PENDING),
+			new GetPostTreeResponse(3L, "Child Post 2", 1L, "http://example.com/image3.jpg",
+				PostStatus.DERIVED_APPROVED)
 		);
 
 		when(postService.getPostTree(postId)).thenReturn(mockResponse);
@@ -412,13 +431,13 @@ class PostControllerTest extends BaseControllerTest {
 			.andExpect(jsonPath("$.data[0].title").value("Root Post"))
 			.andExpect(jsonPath("$.data[0].parentPostId").doesNotExist())
 			.andExpect(jsonPath("$.data[0].representativeImageUrl").value("http://example.com/image1.jpg"))
-			.andExpect(jsonPath("$.data[0].postStatus").value("APPROVED"))
+			.andExpect(jsonPath("$.data[0].postStatus").value("DERIVED_APPROVED"))
 			.andExpect(jsonPath("$.data[1].postId").value(2))
 			.andExpect(jsonPath("$.data[1].parentPostId").value(1))
-			.andExpect(jsonPath("$.data[1].postStatus").value("PENDING"))
+			.andExpect(jsonPath("$.data[1].postStatus").value("DERIVED_PENDING"))
 			.andExpect(jsonPath("$.data[2].postId").value(3))
 			.andExpect(jsonPath("$.data[2].parentPostId").value(1))
-			.andExpect(jsonPath("$.data[2].postStatus").value("APPROVED"));
+			.andExpect(jsonPath("$.data[2].postStatus").value("DERIVED_APPROVED"));
 
 		verify(postService).getPostTree(postId);
 	}
@@ -446,7 +465,8 @@ class PostControllerTest extends BaseControllerTest {
 		// given
 		Long postId = 1L;
 		List<GetPostTreeResponse> mockResponse = List.of(
-			new GetPostTreeResponse(1L, "Single Post", null, "http://example.com/image.jpg", PostStatus.APPROVED)
+			new GetPostTreeResponse(1L, "Single Post", null, "http://example.com/image.jpg",
+				PostStatus.DERIVED_APPROVED)
 		);
 
 		when(postService.getPostTree(postId)).thenReturn(mockResponse);
@@ -462,7 +482,7 @@ class PostControllerTest extends BaseControllerTest {
 			.andExpect(jsonPath("$.data[0].title").value("Single Post"))
 			.andExpect(jsonPath("$.data[0].parentPostId").doesNotExist())
 			.andExpect(jsonPath("$.data[0].representativeImageUrl").value("http://example.com/image.jpg"))
-			.andExpect(jsonPath("$.data[0].postStatus").value("APPROVED"));
+			.andExpect(jsonPath("$.data[0].postStatus").value("DERIVED_APPROVED"));
 
 		verify(postService).getPostTree(postId);
 	}

--- a/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
@@ -65,7 +65,7 @@ class PublicPostControllerTest extends BaseControllerTest {
 			mockPost.getCommercialPrice(),
 			mockPost.getNonCommercialPrice(),
 			mockPost.getTicketPrice(),
-			mockPost.getIsAiDerivedPost(),
+			mockPost.getPostStatus(),
 			mockImages,
 			10L, // likeCount
 			false,
@@ -84,7 +84,6 @@ class PublicPostControllerTest extends BaseControllerTest {
 			.andExpect(jsonPath("$.data.description").value(mockPost.getDescription()))
 			.andExpect(jsonPath("$.data.commercialPrice").value(mockPost.getCommercialPrice()))
 			.andExpect(jsonPath("$.data.nonCommercialPrice").value(mockPost.getNonCommercialPrice()))
-			.andExpect(jsonPath("$.data.isAiDerivedPost").value(false))
 			.andExpect(jsonPath("$.data.likeCount").value(10))
 			.andExpect(jsonPath("$.data.isLikedByCurrentUser").value(false)) // null 값 확인
 			.andExpect(jsonPath("$.data.images").isArray())


### PR DESCRIPTION
## 🧩 작업 내용 요약
- PostEntity에 thumbnailImageId와 PostStatus 적용, 원본/파생 포스트 흐름에 맞게 서비스/레포지토리 전반을 재구성
- 게시글 생성/수정 요청 DTO와 컨트롤러 swagger 문서에 썸네일 필수 검증 및 관련 에러 코드 노출
- AI 파생 포스트 생성 서비스가 생성 이미지를 썸네일로 사용하고 투표 생성·통계 초기화를 묶어 처리하며, 파생 포스트 상태를 투표 결과에 맞춰 갱신
- AI 이미지 생성 실패 시 텍스트 응답이 null인 경우를 대비해 SSE 응답 기본값을 보강
- 포스트/AI 파생 포스트 관련 단위·통합 테스트를 최신 도메인 모델에 맞추어 정리하고 PostFactory 등을 정비

---

## 🔍 관련 이슈
- Resolves: #188 

---

## 🧠 변경 이유 및 주요 포인트
- 기존 boolean 기반 파생 포스트 식별을 Enum(PostStatus)으로 전환해 ORIGINAL과 파생 승인 상태(DERIVED_PENDING/APPROVED/REJECTED)를 명확하게 구분했습니다. 
- 게시글 생성·수정 시 썸네일 이미지를 반드시 업로드 목록 안에서 선택하도록 검증을 추가하고, 위반 시 THUMBNAIL_IMAGE_NOT_IN_IMAGE_LIST_EXCEPTION을 반환합니다. Swagger 문서에도 동일한 예외를 기재했습니다. 
- AI 파생 포스트 생성 흐름에서 생성된 이미지 ID를 썸네일로 저장하고 투표/통계 초기화를 함께 수행하도록 재구성했으며, 투표 완료 시 파생 포스트 상태가 승인/거절로 자동 반영되도록 했습니다. 
- AI 이미지 생성 실패 응답의 	extContent가 null인 경우에도 공백 문자열로 안전하게 처리해 SSE 전송 중 NPE를 방지했습니다. 
- 변경된 도메인/검증 로직을 반영하도록 서비스·컨트롤러 테스트 및 팩토리 코드를 대폭 정리했습니다. 

---

## 🧪 테스트 및 검증
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과
- [x] 로컬 서버 정상 구동 확인
- [x] Swagger 또는 Postman 테스트 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 게시글 생성/수정 시 썸네일 이미지를 지정할 수 있습니다(목록 내 포함 여부 검증).
  - 내 게시글 조회 API가 추가되었습니다.
- 리팩터링
  - 게시글 상태 체계를 ORIGINAL/DERIVED_PENDING/DERIVED_APPROVED/DERIVED_REJECTED로 통합했습니다.
  - 목록 조회 API에서 sort 파라미터가 제거되고 응답 필드가 간소화되었습니다(상태, 이미지, 좋아요 수 중심).
  - 파생 게시글(생성형 AI) 생성 시 원본 이미지 ID 입력이 불필요해졌습니다.
- 검증/에러
  - 채팅 메시지 내용 필수 검증 추가.
  - 썸네일이 이미지 목록에 없을 때의 에러 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->