### PR TITLE
 [Feature] 투표 streak 조회 API 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
@@ -12,6 +12,7 @@ import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.common.error.exception.LockException;
 import hanium.modic.backend.common.property.property.VoteProperties;
 import hanium.modic.backend.common.redis.distributedLock.LockManager;
+import hanium.modic.backend.domain.user.service.UserVoteStreakService;
 import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
 import hanium.modic.backend.domain.vote.entity.SimilarityVoteResultEntity;
 import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
@@ -24,6 +25,7 @@ import hanium.modic.backend.domain.post.entity.PostEntity;
 import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.web.vote.dto.response.VoteParticipationResponse;
+import hanium.modic.backend.web.vote.dto.response.GetVoteStreakResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,6 +47,21 @@ public class VotingService {
 	private final VoteProperties voteProperties;
 	private final VoteRewardService voteRewardService;
 	private final VoteCompletionRewardService voteCompletionRewardService;
+	private final UserVoteStreakService userVoteStreakService;
+
+	/**
+	 * 사용자의 투표 연속 정답 정보를 조회합니다.
+	 *
+	 * @param userId 조회 대상 사용자 ID
+	 * @return 현재 연속 정답 수와 리워드 임계치를 담은 응답
+	 */
+	@Transactional(readOnly = true)
+	public GetVoteStreakResponse getVoteStreak(final Long userId) {
+		int streakCount = userVoteStreakService.getStreakCount(userId);
+		int rewardThreshold = voteProperties.getStreakRewardCount();
+		return GetVoteStreakResponse.of(streakCount, rewardThreshold);
+	}
+
 
 	/**
 	 * 투표 참여 메서드

--- a/src/main/java/hanium/modic/backend/web/vote/controller/VoteController.java
+++ b/src/main/java/hanium/modic/backend/web/vote/controller/VoteController.java
@@ -18,6 +18,7 @@ import hanium.modic.backend.domain.vote.service.VoteQueryService;
 import hanium.modic.backend.domain.vote.service.VotingService;
 import hanium.modic.backend.web.vote.dto.request.VoteParticipationRequest;
 import hanium.modic.backend.web.vote.dto.response.VoteParticipationResponse;
+import hanium.modic.backend.web.vote.dto.response.GetVoteStreakResponse;
 import hanium.modic.backend.web.vote.dto.response.VoteDetailResponse;
 import hanium.modic.backend.web.vote.dto.response.VoteSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,6 +53,26 @@ public class VoteController {
 		@PathVariable @Min(1) Long voteId
 	) {
 		VoteSummaryResponse response = voteQueryService.getVoteResults(voteId);
+		return ok(AppResponse.ok(response));
+	}
+
+	/**
+	 * 현재 로그인한 사용자의 투표 연속 정답 수를 조회합니다.
+	 *
+	 * @param user 인증된 사용자
+	 * @return 사용자의 현재 연속 정답 정보
+	 */
+	@GetMapping("/streak")
+	@Operation(
+		summary = "투표 연속 정답 수 조회",
+		description = "현재 로그인한 사용자의 투표 연속 정답 현황을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "연속 정답 수 조회 성공"),
+			@ApiResponse(responseCode = "401", description = "인증이 필요합니다.[C-003]")
+		}
+	)
+	public ResponseEntity<AppResponse<GetVoteStreakResponse>> getVoteStreak(@CurrentUser UserEntity user) {
+		GetVoteStreakResponse response = votingService.getVoteStreak(user.getId());
 		return ok(AppResponse.ok(response));
 	}
 

--- a/src/main/java/hanium/modic/backend/web/vote/dto/response/GetVoteStreakResponse.java
+++ b/src/main/java/hanium/modic/backend/web/vote/dto/response/GetVoteStreakResponse.java
@@ -1,0 +1,20 @@
+package hanium.modic.backend.web.vote.dto.response;
+
+/**
+ * 사용자 투표 연속 정답 정보를 제공하는 응답 DTO.
+ */
+public record GetVoteStreakResponse(
+	int currentStreak,
+	int rewardThreshold
+) {
+	/**
+	 * 현재 연속 정답 수와 리워드 임계치를 기반으로 응답 객체를 생성합니다.
+	 *
+	 * @param currentStreak 사용자 연속 정답 수
+	 * @param rewardThreshold 리워드 지급 임계치
+	 * @return 연속 정답 정보를 담은 응답
+	 */
+	public static GetVoteStreakResponse of(int currentStreak, int rewardThreshold) {
+		return new GetVoteStreakResponse(currentStreak, rewardThreshold);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/vote/service/VotingServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/vote/service/VotingServiceTest.java
@@ -1,0 +1,62 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.property.property.VoteProperties;
+import hanium.modic.backend.common.redis.distributedLock.LockManager;
+import hanium.modic.backend.domain.post.repository.PostEntityRepository;
+import hanium.modic.backend.domain.user.service.UserVoteStreakService;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteResultRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+import hanium.modic.backend.web.vote.dto.response.GetVoteStreakResponse;
+
+@ExtendWith(MockitoExtension.class)
+class VotingServiceTest {
+
+	@Mock
+	private SimilarityVoteRepository similarityVoteRepository;
+	@Mock
+	private SimilarityVoteResultRepository voteResultRepository;
+	@Mock
+	private SimilarityVoteSummaryRepository voteSummaryRepository;
+	@Mock
+	private PostEntityRepository postEntityRepository;
+	@Mock
+	private LockManager lockManager;
+	@Mock
+	private VoteProperties voteProperties;
+	@Mock
+	private VoteRewardService voteRewardService;
+	@Mock
+	private VoteCompletionRewardService voteCompletionRewardService;
+	@Mock
+	private UserVoteStreakService userVoteStreakService;
+
+	@InjectMocks
+	private VotingService votingService;
+
+	@Test
+	@DisplayName("투표 연속 정답 조회")
+	void getVoteStreak_underThreshold() {
+		// given
+		Long userId = 1L;
+		given(userVoteStreakService.getStreakCount(userId)).willReturn(2);
+		given(voteProperties.getStreakRewardCount()).willReturn(3);
+
+		// when
+		GetVoteStreakResponse response = votingService.getVoteStreak(userId);
+
+		// then
+		assertThat(response.currentStreak()).isEqualTo(2);
+		assertThat(response.rewardThreshold()).isEqualTo(3);
+	}
+}


### PR DESCRIPTION


## 🧩 작업 내용 요약
투표 streak 조회 API 구현

## 🔍 관련 이슈

- Resolves: #193 

---

## 🧠 변경 이유 및 주요 포인트
- 사용자의 현재 streak 조회 API 구현

## 🧪 테스트 및 검증
- [x] 단위 테스트 통과
- [x] 통합 테스트 통과
- [x] 로컬 서버 정상 구동 확인
- [x] Swagger 또는 Postman 테스트 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인 사용자를 위한 투표 연속 기록 조회 API 추가(/api/votes/streak). 현재 연속 투표 횟수와 보상 임계값을 반환하여 연속 보상 진행 상황을 확인할 수 있습니다.
- 테스트
  - 투표 연속 기록 조회 로직에 대한 단위 테스트를 추가해 기본 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->