### PR TITLE
[Feature] 로그 및 CloudWatch 연동 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,9 @@ dependencies {
     // api 이중화를 위한 circuit breaker
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
     implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.2.0'
+
+    // LOG
+    implementation group: 'ca.pjer', name: 'logback-awslogs-appender', version: '1.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java
@@ -1,11 +1,7 @@
 package hanium.modic.backend.common.error.exception.handler;
 
-import hanium.modic.backend.common.error.ErrorCode;
-import hanium.modic.backend.common.error.exception.AppException;
-import hanium.modic.backend.common.response.ErrorResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.ConstraintViolationException;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -19,75 +15,112 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.util.List;
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(AppException.class)
-    public ResponseEntity<ErrorResponse> handleAppException(AppException e) {
-        log.error("AppException 발생: errorCode={}, message={}", e.getErrorCode().getCode(), e.getMessage());
+	@ExceptionHandler(AppException.class)
+	public ResponseEntity<ErrorResponse> handleAppException(AppException e) {
+		log.error(
+			"AppException 발생: status={}, errorCode={}, message={}",
+			e.getErrorCode().getStatus(),
+			e.getErrorCode().getCode(),
+			e.getMessage(),
+			e
+		);
 
-        ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
+		ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
 
-        return ResponseEntity
-                .status(e.getErrorCode().getStatus())
-                .body(errorResponse);
-    }
+		return ResponseEntity
+			.status(e.getErrorCode().getStatus())
+			.body(errorResponse);
+	}
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("처리되지 않은 예외 발생: ", e);
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("처리되지 않은 예외 발생: status=500", e);
 
-        ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
+		ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
 
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(errorResponse);
-    }
+		return ResponseEntity
+			.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(errorResponse);
+	}
 
-    @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
-                                                                  HttpHeaders headers, HttpStatusCode status,
-                                                                  WebRequest request) {
-        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
-        HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
-        String requestURI = httpServletRequest.getRequestURI();
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(
+		MethodArgumentNotValidException ex,
+		HttpHeaders headers,
+		HttpStatusCode status,
+		WebRequest request
+	) {
+		ServletWebRequest servletWebRequest = (ServletWebRequest)request;
+		HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
+		String requestURI = httpServletRequest.getRequestURI();
 
-        List<String> messages = ex.getBindingResult().getFieldErrors().stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .toList();
+		List<String> messages = ex.getBindingResult().getFieldErrors().stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.toList();
 
-        log.error("MethodArgumentNotValidException 발생: requestURI={}, error={}", requestURI, ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorCode.USER_INPUT_EXCEPTION, messages));
-    }
+		log.error(
+			"MethodArgumentNotValidException 발생: status=400, requestURI={}, error={}",
+			requestURI,
+			ex.getMessage(),
+			ex
+		);
 
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleConstraintViolation(
-            ConstraintViolationException ex, WebRequest request) {
-        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
-        HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
-        String requestURI = httpServletRequest.getRequestURI();
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.of(ErrorCode.USER_INPUT_EXCEPTION, messages));
+	}
 
-        List<String> messages = ex.getConstraintViolations().stream()
-                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
-                .toList();
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorResponse> handleConstraintViolation(
+		ConstraintViolationException ex,
+		WebRequest request
+	) {
+		ServletWebRequest servletWebRequest = (ServletWebRequest)request;
+		HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
+		String requestURI = httpServletRequest.getRequestURI();
 
-        log.error("ConstraintViolationException 발생: requestURI={}, error={}", requestURI, ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorCode.USER_INPUT_EXCEPTION, messages));
-    }
+		List<String> messages = ex.getConstraintViolations().stream()
+			.map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+			.toList();
 
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(
-            MethodArgumentTypeMismatchException ex, WebRequest request) {
-        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
-        HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
-        String requestURI = httpServletRequest.getRequestURI();
+		log.error(
+			"ConstraintViolationException 발생: status=400, requestURI={}, error={}",
+			requestURI,
+			ex.getMessage(),
+			ex
+		);
 
-        String message = String.format("잘못된 타입의 인자입니다. 경로: %s, 잘못된 값: %s", ex.getName(), ex.getValue());
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse.of(ErrorCode.USER_INPUT_EXCEPTION, messages));
+	}
 
-        log.error("MethodArgumentTypeMismatchException 발생: requestURI={}, error={}", requestURI, message);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(ErrorCode.USER_INPUT_EXCEPTION));
-    }
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(
+		MethodArgumentTypeMismatchException ex,
+		WebRequest request
+	) {
+		ServletWebRequest servletWebRequest = (ServletWebRequest)request;
+		HttpServletRequest httpServletRequest = servletWebRequest.getRequest();
+		String requestURI = httpServletRequest.getRequestURI();
+
+		String message = String.format("잘못된 타입의 인자입니다. 경로: %s, 잘못된 값: %s", ex.getName(), ex.getValue());
+		log.error(
+			"MethodArgumentTypeMismatchException 발생: status=400, requestURI={}, error={}",
+			requestURI,
+			message,
+			ex
+		);
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(ErrorCode.USER_INPUT_EXCEPTION));
+	}
 }

--- a/src/main/java/hanium/modic/backend/common/jwt/SecurityExceptionFilter.java
+++ b/src/main/java/hanium/modic/backend/common/jwt/SecurityExceptionFilter.java
@@ -28,8 +28,11 @@ public class SecurityExceptionFilter extends OncePerRequestFilter {
 	private final ObjectMapper objectMapper;
 
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-		FilterChain filterChain) throws ServletException, IOException {
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
 
 		try {
 			filterChain.doFilter(request, response);
@@ -45,16 +48,28 @@ public class SecurityExceptionFilter extends OncePerRequestFilter {
 	}
 
 	private void handleAppException(HttpServletResponse response, AppException e) throws IOException {
-		log.error("AppException 발생 in Security Filter: errorCode={}, message={}",
-			e.getErrorCode().getCode(), e.getMessage());
+		log.error(
+			"AppException 발생 in Security Filter: status={}, errorCode={}, message={}",
+			e.getErrorCode().getStatus(),
+			e.getErrorCode().getCode(),
+			e.getMessage()
+		);
 
 		ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
 		writeErrorResponse(response, e.getErrorCode().getStatus().value(), errorResponse);
 	}
 
-	private void handleSecurityException(HttpServletResponse response, ErrorCode errorCode, Exception e)
-		throws IOException {
-		log.error("Security Exception 발생: errorCode={}, message={}", errorCode.getCode(), e.getMessage());
+	private void handleSecurityException(
+		HttpServletResponse response,
+		ErrorCode errorCode,
+		Exception e
+	) throws IOException {
+		log.error(
+			"Security Exception 발생: status={}, errorCode={}, message={}",
+			errorCode.getStatus(),
+			errorCode.getCode(),
+			e.getMessage()
+		);
 
 		ErrorResponse errorResponse = ErrorResponse.from(errorCode);
 		writeErrorResponse(response, errorCode.getStatus().value(), errorResponse);
@@ -67,8 +82,11 @@ public class SecurityExceptionFilter extends OncePerRequestFilter {
 		writeErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value(), errorResponse);
 	}
 
-	private void writeErrorResponse(HttpServletResponse response, int status, ErrorResponse errorResponse)
-		throws IOException {
+	private void writeErrorResponse(
+		HttpServletResponse response,
+		int status,
+		ErrorResponse errorResponse
+	) throws IOException {
 		response.setStatus(status);
 		response.setContentType("application/json;charset=UTF-8");
 		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));

--- a/src/main/resources/logback/cloudwatch-appender.xml
+++ b/src/main/resources/logback/cloudwatch-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="CLOUDWATCH" class="ca.pjer.logback.AwsLogsAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <layout>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %thread %level %logger{36} - %msg%n</pattern>
+        </layout>
+
+        <!-- CloudWatch 설정 -->
+        <logGroupName>modic-log</logGroupName> <!-- 공통 그룹명 -->
+        <logStreamUuidPrefix>${ACTIVE_PROFILE:-unknown}-</logStreamUuidPrefix> <!-- 프로필별 스트림 구분 -->
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>30</retentionTimeDays>
+    </appender>
+</included>

--- a/src/main/resources/logback/console-appender.xml
+++ b/src/main/resources/logback/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback/file-info-appender.xml
+++ b/src/main/resources/logback/file-info-appender.xml
@@ -1,0 +1,13 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback/logback-spring.xml
+++ b/src/main/resources/logback/logback-spring.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="60 seconds">
+    <!-- Spring 프로필 속성 먼저 선언 -->
+    <springProperty name="ACTIVE_PROFILE" source="spring.profiles.active"/>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- 로그 패턴 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%5level) %cyan(%logger{36}) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger{36} - %msg%n"/>
+
+    <!-- 외부 Appender 분리 -->
+    <include resource="logback/console-appender.xml"/>
+    <include resource="logback/file-info-appender.xml"/>
+    <include resource="logback/cloudwatch-appender.xml"/>
+
+    <!-- 환경별 설정 -->
+    <springProfile name="local">
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="CLOUDWATCH"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="main">
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="CLOUDWATCH"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
 ## 🧩 작업 내용 요약                                                                                                                             
                                                                                                                                                   
  - build.gradle:96에 logback-awslogs-appender 의존성을 추가해 CloudWatch 전송을 지원했습니다.                                                     
  - src/main/resources/logback/logback-spring.xml:4 및 하위 포함 파일에서 프로필별 콘솔·파일·CloudWatch 로그 구성과 패턴을 정의했습니다.           
  - src/main/java/hanium/modic/backend/common/error/exception/handler/GlobalExceptionHandler.java:29에서 예외 로그를 상태 코드와 스택 트레이스까지 포함하도록 확장했습니다.                                                                                                                       
  - src/main/java/hanium/modic/backend/common/jwt/SecurityExceptionFilter.java:50에서 보안 예외 로그에도 HTTP 상태와 에러 코드를 명시했습니다.     
                                                                                                                                                   
  ———                                                                                                                                              
                                                                                                                                                   
  ## 🔍 관련 이슈                                                                                                                                  
                                                                                                                                                   
  - Resolves: #61                                                                                                                                  
                                                                                                                                                   
  ———                                                                                                                                              
                                                                                                                                                   
  ## 🧠 변경 이유 및 주요 포인트                                                                                                                   
                                                                                                                                                   
  - 환경별 로그 채널을 분리하고(logback-spring.xml:20) CloudWatch로 ERROR 로그를 전송해 모니터링 대응성을 높였습니다.                              
  - 애플리케이션 및 보안 예외 로그에 상태·코드 정보를 포함시켜 원인 파악을 빠르게 할 수 있도록 했습니다(GlobalExceptionHandler.java:31,            
    SecurityExceptionFilter.java:52).                                                                                                              
  - 파일 롤링 정책을 설정해(file-info-appender.xml:6) 장기 로그 축적 시 디스크 사용량을 제어합니다.                                                
                                                                                                                                                   
  ———                                                                                                                                              
                                                                                                                                                   
  ## 🧪 테스트 및 검증                                                                                                                             
                                                                                                                                                   
  - [x] 단위 테스트 통과                                                                                                                           
  - [x] 통합 테스트 통과                                                                                                                           
  - [x] 로컬 서버 정상 구동 확인                                                                                                                   
  - [x] Swagger 또는 Postman 테스트 완료                                                                                                           
                                                                                                                                                   
  결과 요약:                                                                                                                                       
                                                                                                                                                   
  - 로그백 설정이 로컬/운영 프로필에 맞게 분기되며 CloudWatch ERROR 로그 전송을 준비했습니다.                                                      
  - 예외 처리기와 보안 필터에서 로그 세부 정보가 보강되어 장애 원인 추적이 용이합니다.                                                             
                                                                                                                                                     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - CloudWatch 로그 전송 지원 추가 및 환경별 로깅 프로필(local/dev/main) 구성
  - 콘솔/파일 로그 출력 패턴 적용과 파일 로그 롤링 설정 제공
- 리팩터링
  - 예외 처리 로깅 상세화(상태, 요청 경로 등)로 기록 일관성 강화
  - 유효성 검증 오류 응답 메시지 포맷을 일관화
- 작업
  - 로깅 관련 라이브러리 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->