### PR TITLE
랜덤 투표 조회 시 사용자 참여 이력 필터링 기능 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/vote/repository/SimilarityVoteRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/repository/SimilarityVoteRepository.java
@@ -25,6 +25,25 @@ public interface SimilarityVoteRepository extends JpaRepository<SimilarityVoteEn
 	Optional<SimilarityVoteEntity> findRandomVoteForParticipation();
 
 	/**
+	 * 사용자가 참여하지 않은 랜덤 투표 조회
+	 * IN_PROGRESS 상태이면서 해당 사용자가 아직 투표하지 않은 투표 중 1건만 반환
+	 *
+	 * @param userId 투표 참여 이력을 확인할 사용자 ID
+	 * @return 조건을 만족하는 랜덤 투표
+	 */
+	@Query(value = "SELECT * FROM similarity_vote sv " +
+		"WHERE sv.status = 'IN_PROGRESS' " +
+		"AND NOT EXISTS (" +
+		"  SELECT 1 FROM similarity_vote_result svr " +
+		"  WHERE svr.vote_id = sv.id " +
+		"  AND svr.user_id = :userId" +
+		") " +
+		"ORDER BY RAND() " +
+		"LIMIT 1",
+		nativeQuery = true)
+	Optional<SimilarityVoteEntity> findRandomUnparticipatedVote(@Param("userId") Long userId);
+
+	/**
 	 * 파생 이미지 생성자 ID 조회 (타입 안전)
 	 * @param voteId 투표 ID
 	 * @return 파생 이미지 생성자의 사용자 ID

--- a/src/main/java/hanium/modic/backend/domain/vote/service/VoteQueryService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VoteQueryService.java
@@ -46,11 +46,15 @@ public class VoteQueryService {
 
 	/**
 	 * 참여 가능한 랜덤 투표 1건을 조회합니다.
-	 * IN_PROGRESS 상태의 투표만 대상이며, 이미지 URL을 포함한 상세 정보를 반환합니다.
+	 * IN_PROGRESS 상태이면서 해당 사용자가 참여하지 않은 투표만 대상이며, 이미지 URL을 포함한 상세 정보를 반환합니다.
+	 *
+	 * @param userId 현재 인증된 사용자 ID (non-null, 인증 필수)
+	 * @return 투표 상세 정보
+	 * @throws AppException NO_AVAILABLE_VOTES_EXCEPTION - 참여 가능한 투표가 없는 경우
 	 */
-	public VoteDetailResponse getRandomVoteForParticipation() {
-		// 랜덤 투표 1건 조회 (IN_PROGRESS 상태만)
-		SimilarityVoteEntity vote = similarityVoteRepository.findRandomVoteForParticipation()
+	public VoteDetailResponse getRandomVoteForParticipation(Long userId) {
+		// 사용자가 참여하지 않은 랜덤 투표 조회
+		SimilarityVoteEntity vote = similarityVoteRepository.findRandomUnparticipatedVote(userId)
 			.orElseThrow(() -> new AppException(NO_AVAILABLE_VOTES_EXCEPTION));
 
 		// 투표 집계 정보 조회

--- a/src/main/java/hanium/modic/backend/web/vote/controller/VoteController.java
+++ b/src/main/java/hanium/modic/backend/web/vote/controller/VoteController.java
@@ -37,11 +37,17 @@ public class VoteController {
 	private final VotingService votingService;
 
 	@GetMapping("/random")
-	@Operation(summary = "랜덤 투표 조회", description = "참여 가능한 랜덤한 투표 1건을 조회합니다. 원본 이미지(A)와 생성된 이미지(B)의 presigned URL을 포함합니다.")
+	@Operation(
+		summary = "랜덤 투표 조회",
+		description = "참여 가능한 랜덤한 투표 1건을 조회합니다. 원본 이미지(A)와 생성된 이미지(B)의 presigned URL을 포함합니다. 인증된 사용자가 아직 참여하지 않은 투표만 조회됩니다."
+	)
 	@ApiResponse(responseCode = "200", description = "투표 조회 성공")
+	@ApiResponse(responseCode = "401", description = "인증이 필요합니다.[C-003]")
 	@ApiResponse(responseCode = "404", description = "참여 가능한 투표가 없습니다.[V-009]")
-	public ResponseEntity<AppResponse<VoteDetailResponse>> getRandomVote() {
-		VoteDetailResponse response = voteQueryService.getRandomVoteForParticipation();
+	public ResponseEntity<AppResponse<VoteDetailResponse>> getRandomVote(
+		@CurrentUser UserEntity user
+	) {
+		VoteDetailResponse response = voteQueryService.getRandomVoteForParticipation(user.getId());
 		return ok(AppResponse.ok(response));
 	}
 

--- a/src/test/java/hanium/modic/backend/domain/vote/service/VoteQueryServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/vote/service/VoteQueryServiceTest.java
@@ -1,0 +1,144 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.aiServer.entity.AiChatImageEntity;
+import hanium.modic.backend.domain.ai.aiServer.repository.AiChatImageRepository;
+import hanium.modic.backend.domain.image.util.ImageUtil;
+import hanium.modic.backend.domain.post.entity.PostImageEntity;
+import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteStatus;
+import hanium.modic.backend.domain.vote.enums.VoteType;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+import hanium.modic.backend.web.vote.dto.response.VoteDetailResponse;
+
+@ExtendWith(MockitoExtension.class)
+class VoteQueryServiceTest {
+
+	@Mock
+	private SimilarityVoteRepository similarityVoteRepository;
+
+	@Mock
+	private SimilarityVoteSummaryRepository voteSummaryRepository;
+
+	@Mock
+	private PostImageEntityRepository postImageEntityRepository;
+
+	@Mock
+	private AiChatImageRepository aiChatImageRepository;
+
+	@Mock
+	private ImageUtil imageUtil;
+
+	@InjectMocks
+	private VoteQueryService voteQueryService;
+
+	@Test
+	@DisplayName("사용자가 참여하지 않은 투표를 조회한다")
+	void getRandomVoteForParticipation_Success() {
+		// Given
+		Long userId = 1L;
+		Long voteId = 100L;
+		SimilarityVoteEntity mockVote = mock(SimilarityVoteEntity.class);
+		SimilarityVoteSummaryEntity mockSummary = createMockSummary();
+		PostImageEntity mockPostImage = mock(PostImageEntity.class);
+		AiChatImageEntity mockAiImage = mock(AiChatImageEntity.class);
+
+		when(mockVote.getId()).thenReturn(voteId);
+		when(mockVote.getOriginalImageId()).thenReturn(1L);
+		when(mockVote.getDerivedImageId()).thenReturn(2L);
+		when(mockVote.getStatus()).thenReturn(VoteStatus.IN_PROGRESS);
+
+		when(similarityVoteRepository.findRandomUnparticipatedVote(userId))
+			.thenReturn(Optional.of(mockVote));
+		when(voteSummaryRepository.findByVoteId(voteId))
+			.thenReturn(Optional.of(mockSummary));
+		when(postImageEntityRepository.findById(1L))
+			.thenReturn(Optional.of(mockPostImage));
+		when(aiChatImageRepository.findById(2L))
+			.thenReturn(Optional.of(mockAiImage));
+		when(mockPostImage.getImagePath()).thenReturn("original/path");
+		when(mockAiImage.getImagePath()).thenReturn("derived/path");
+		when(imageUtil.createImageGetUrl("original/path")).thenReturn("https://example.com/original.jpg");
+		when(imageUtil.createImageGetUrl("derived/path")).thenReturn("https://example.com/derived.jpg");
+
+		// When
+		VoteDetailResponse response = voteQueryService.getRandomVoteForParticipation(userId);
+
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.voteId()).isEqualTo(voteId);
+		assertThat(response.originalImageUrl()).isEqualTo("https://example.com/original.jpg");
+		assertThat(response.derivedImageUrl()).isEqualTo("https://example.com/derived.jpg");
+		assertThat(response.status()).isEqualTo(VoteStatus.IN_PROGRESS);
+		verify(similarityVoteRepository).findRandomUnparticipatedVote(userId);
+	}
+
+	@Test
+	@DisplayName("참여 가능한 투표가 없으면 예외 발생")
+	void getRandomVoteForParticipation_NoVotes() {
+		// Given
+		Long userId = 1L;
+		when(similarityVoteRepository.findRandomUnparticipatedVote(userId))
+			.thenReturn(Optional.empty());
+
+		// When & Then
+		assertThatThrownBy(() -> voteQueryService.getRandomVoteForParticipation(userId))
+			.isInstanceOf(AppException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AVAILABLE_VOTES_EXCEPTION);
+	}
+
+	@Test
+	@DisplayName("투표 집계 정보가 없으면 예외 발생")
+	void getRandomVoteForParticipation_NoSummary() {
+		// Given
+		Long userId = 1L;
+		Long voteId = 100L;
+		SimilarityVoteEntity mockVote = mock(SimilarityVoteEntity.class);
+
+		when(mockVote.getId()).thenReturn(voteId);
+		when(similarityVoteRepository.findRandomUnparticipatedVote(userId))
+			.thenReturn(Optional.of(mockVote));
+		when(voteSummaryRepository.findByVoteId(voteId))
+			.thenReturn(Optional.empty());
+
+		// When & Then
+		assertThatThrownBy(() -> voteQueryService.getRandomVoteForParticipation(userId))
+			.isInstanceOf(AppException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.VOTE_SUMMARY_NOT_FOUND_EXCEPTION);
+	}
+
+	private SimilarityVoteEntity createMockVote(Long voteId) {
+		return SimilarityVoteEntity.builder()
+			.originalImageId(1L)
+			.derivedImageId(2L)
+			.voteType(VoteType.SIMILARITY_CHECK)
+			.status(VoteStatus.IN_PROGRESS)
+			.build();
+	}
+
+	private SimilarityVoteSummaryEntity createMockSummary() {
+		return SimilarityVoteSummaryEntity.builder()
+			.voteId(100L)
+			.approveWeight(50L)
+			.denyWeight(30L)
+			.totalWeight(80L)
+			.build();
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/vote/controller/VoteControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/vote/controller/VoteControllerTest.java
@@ -1,0 +1,81 @@
+package hanium.modic.backend.web.vote.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import hanium.modic.backend.base.BaseControllerTest;
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.vote.enums.VoteStatus;
+import hanium.modic.backend.domain.vote.service.VoteQueryService;
+import hanium.modic.backend.domain.vote.service.VotingService;
+import hanium.modic.backend.web.vote.dto.response.VoteDetailResponse;
+
+@WebMvcTest(controllers = VoteController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class VoteControllerTest extends BaseControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private VoteQueryService voteQueryService;
+
+	@MockitoBean
+	private VotingService votingService;
+
+	@Test
+	@DisplayName("랜덤 투표 조회 성공")
+	void getRandomVote_Success() throws Exception {
+		// Given
+		Long userId = 1L;
+		VoteDetailResponse mockResponse = new VoteDetailResponse(
+			100L,
+			"https://example.com/original.jpg",
+			"https://example.com/derived.jpg",
+			50L,
+			30L,
+			80L,
+			VoteStatus.IN_PROGRESS
+		);
+
+		when(voteQueryService.getRandomVoteForParticipation(userId))
+			.thenReturn(mockResponse);
+
+		// When & Then
+		mockMvc.perform(get("/api/votes/random"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.voteId").value(100L))
+			.andExpect(jsonPath("$.data.originalImageUrl").value("https://example.com/original.jpg"))
+			.andExpect(jsonPath("$.data.derivedImageUrl").value("https://example.com/derived.jpg"))
+			.andExpect(jsonPath("$.data.status").value("IN_PROGRESS"));
+
+		verify(voteQueryService).getRandomVoteForParticipation(userId);
+	}
+
+	@Test
+	@DisplayName("랜덤 투표 조회 실패 - 참여 가능한 투표 없음")
+	void getRandomVote_NoAvailableVotes() throws Exception {
+		// Given
+		Long userId = 1L;
+		when(voteQueryService.getRandomVoteForParticipation(userId))
+			.thenThrow(new AppException(ErrorCode.NO_AVAILABLE_VOTES_EXCEPTION));
+
+		// When & Then
+		mockMvc.perform(get("/api/votes/random"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("V-009"))
+			.andExpect(jsonPath("$.message").value("참여 가능한 투표가 없습니다."));
+
+		verify(voteQueryService).getRandomVoteForParticipation(userId);
+	}
+}


### PR DESCRIPTION
## 변경 사항
사용자가 이미 참여한 투표는 랜덤 조회에서 제외되도록 필터링 기능을 추가했습니다.

## 구현 내용
### Repository Layer
- `findRandomUnparticipatedVote(userId)` 메서드 추가
- NOT EXISTS 서브쿼리로 사용자 참여 이력 필터링

### Service Layer
- `getRandomVoteForParticipation(Long userId)` 메서드 시그니처 변경
- 사용자가 참여하지 않은 투표만 조회하도록 로직 수정

### Controller Layer
- `@CurrentUser`로 인증된 사용자 정보 전달
- API 응답 명세에 401 추가

## 테스트
- VoteQueryServiceTest: 3개 단위 테스트 추가 ✅
- VoteControllerTest: 2개 단위 테스트 추가 ✅
- 모든 테스트 통과 (5/5)

## 참고
- 설계 문서: docs/vote-participation-filter-design.md

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 랜덤 투표 조회가 로그인한 사용자 기준으로 아직 참여하지 않은 진행 중 투표만 제공
  - 참여 가능한 투표가 없을 때 사용자에게 404 오류로 안내
  - 응답의 이미지 URL 및 상태 정보 제공 유지

- 문서
  - API 문서에 인증 필요 및 401 가능성, 미참여 투표 대상 반환 설명 추가

- 테스트
  - 서비스/컨트롤러 테스트 추가: 성공, 참여 가능 투표 없음, 요약 누락 시 오류 처리 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->