### PR TITLE
[Fix] 사용자 이미지 Signed URL 조회 방식 전환

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/follow/dto/FollowerWithStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/dto/FollowerWithStatus.java
@@ -1,9 +1,9 @@
 package hanium.modic.backend.domain.follow.dto;
 
-public interface FollowerWithStatus {
-	Long getId();
-	String getName();
-	String getEmail();
-	String getUserImageUrl();
-	Boolean getIsFollowing();
+public record FollowerWithStatus(
+	Long id,
+	String name,
+	String email,
+	Boolean isFollowing
+) {
 }

--- a/src/main/java/hanium/modic/backend/domain/follow/dto/FollowingWithStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/dto/FollowingWithStatus.java
@@ -1,9 +1,9 @@
 package hanium.modic.backend.domain.follow.dto;
 
-public interface FollowingWithStatus {
-	Long getId();
-	String getName();
-	String getEmail();
-	String getUserImageUrl();
-	Boolean getIsFollowing();
+public record FollowingWithStatus(
+	Long id,
+	String name,
+	String email,
+	Boolean isFollowing
+) {
 }

--- a/src/main/java/hanium/modic/backend/domain/follow/repository/FollowEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/repository/FollowEntityRepository.java
@@ -50,8 +50,12 @@ public interface FollowEntityRepository extends JpaRepository<FollowEntity, Long
 
 	// 팔로워 목록 조회 (팔로우 상태 포함)
 	@Query("""
-		    SELECT u.id as id, u.name as name, u.email as email, u.userImageUrl as userImageUrl,
-		           CASE WHEN f2.id IS NOT NULL THEN true ELSE false END as isFollowing
+		    SELECT new hanium.modic.backend.domain.follow.dto.FollowerWithStatus(
+		        u.id,
+		        u.name,
+		        u.email,
+		        CASE WHEN (f2.id IS NOT NULL) THEN true ELSE false END
+		    )
 		    FROM FollowEntity f
 		    JOIN UserEntity u ON f.myId = u.id
 		    LEFT JOIN FollowEntity f2 ON f2.myId = :currentUserId AND f2.followingId = u.id
@@ -66,8 +70,12 @@ public interface FollowEntityRepository extends JpaRepository<FollowEntity, Long
 
 	// 팔로잉 목록 조회 (팔로우 상태 포함)
 	@Query("""
-		    SELECT u.id as id, u.name as name, u.email as email, u.userImageUrl as userImageUrl,
-		           CASE WHEN f2.id IS NOT NULL THEN true ELSE false END as isFollowing
+		    SELECT new hanium.modic.backend.domain.follow.dto.FollowingWithStatus(
+		        u.id,
+		        u.name,
+		        u.email,
+		        CASE WHEN (f2.id IS NOT NULL) THEN true ELSE false END
+		    )
 		    FROM FollowEntity f
 		    JOIN UserEntity u ON f.followingId = u.id
 		    LEFT JOIN FollowEntity f2 ON f2.myId = :currentUserId AND f2.followingId = u.id

--- a/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
@@ -2,6 +2,8 @@ package hanium.modic.backend.domain.follow.service;
 
 import static hanium.modic.backend.domain.follow.dto.FollowType.*;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,7 @@ import hanium.modic.backend.domain.follow.dto.FollowType;
 import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersWithStatusResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
@@ -24,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class FollowService {
 	private final FollowEntityRepository followRepository;
 	private final UserEntityRepository userRepository;
+	private final UserImageService userImageService;
 
 	// 팔로우 또는 언팔로우 처리
 	@Transactional
@@ -50,31 +54,41 @@ public class FollowService {
 
 	// TODO : 정렬 기준 고려
 	// 팔로워 목록 조회 (미인증 유저용)
+	@Transactional(readOnly = true)
 	public Page<GetFollowersResponse> getFollowers(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
 		return followRepository.findFollowersOrderByCreatedAt(userId, PageRequest.of(page, size))
 			.map(u -> {
-				final String userImageUrl = u.getUserImageUrl();
-				final boolean hasUserImage = userImageUrl != null;
-				return new GetFollowersResponse(u.getId(), hasUserImage, userImageUrl, u.getName(), u.getEmail());
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final boolean hasUserImage = userImageUrl.isPresent();
+
+				return new GetFollowersResponse(
+					u.getId(),
+					hasUserImage,
+					userImageUrl.orElse(null),
+					u.getName(),
+					u.getEmail()
+				);
 			});
 	}
 
 	// TODO : 정렬 기준 고려
 	// 내 팔로워 목록 조회 (인증 유저용 - 팔로우 상태 포함)
+	@Transactional(readOnly = true)
 	public Page<GetFollowersWithStatusResponse> getMyFollowers(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
 		return followRepository.findFollowersWithStatusOrderByCreatedAt(userId, userId, PageRequest.of(page, size))
 			.map(u -> {
-				final String userImageUrl = u.getUserImageUrl();
-				final boolean hasUserImage = userImageUrl != null;
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final boolean hasUserImage = userImageUrl.isPresent();
+
 				return new GetFollowersWithStatusResponse(
-					u.getId(), 
-					hasUserImage, 
-					userImageUrl, 
-					u.getName(), 
+					u.getId(),
+					hasUserImage,
+					userImageUrl.orElse(null),
+					u.getName(),
 					u.getEmail(),
 					u.getIsFollowing()
 				);
@@ -83,23 +97,26 @@ public class FollowService {
 
 	// TODO : 정렬 기준 고려
 	// 팔로워 목록 조회 (인증 유저용 - 팔로우 상태 포함)
+	@Transactional(readOnly = true)
 	public Page<GetFollowersWithStatusResponse> getFollowersWithStatus(
-		final long currentUserId, 
-		final long targetUserId, 
-		final int page, 
+		final long currentUserId,
+		final long targetUserId,
+		final int page,
 		final int size
 	) {
 		validateUserExists(targetUserId);
 
-		return followRepository.findFollowersWithStatusOrderByCreatedAt(targetUserId, currentUserId, PageRequest.of(page, size))
+		return followRepository.findFollowersWithStatusOrderByCreatedAt(targetUserId, currentUserId,
+				PageRequest.of(page, size))
 			.map(u -> {
-				final String userImageUrl = u.getUserImageUrl();
-				final boolean hasUserImage = userImageUrl != null;
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final boolean hasUserImage = userImageUrl.isPresent();
+
 				return new GetFollowersWithStatusResponse(
-					u.getId(), 
-					hasUserImage, 
-					userImageUrl, 
-					u.getName(), 
+					u.getId(),
+					hasUserImage,
+					userImageUrl.orElse(null),
+					u.getName(),
 					u.getEmail(),
 					u.getIsFollowing()
 				);
@@ -108,30 +125,40 @@ public class FollowService {
 
 	// TODO : 정렬 기준 고려
 	// 팔로잉 목록 조회 (미인증 유저용)
+	@Transactional(readOnly = true)
 	public Page<GetFollowingsResponse> getFollowings(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
 		return followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size))
 			.map(u -> {
-				final String userImageUrl = u.getUserImageUrl();
-				final boolean hasUserImage = userImageUrl != null;
-				return new GetFollowingsResponse(u.getId(), hasUserImage, userImageUrl, u.getName(), u.getEmail());
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final boolean hasUserImage = userImageUrl.isPresent();
+
+				return new GetFollowingsResponse(
+					u.getId(),
+					hasUserImage,
+					userImageUrl.orElse(null),
+					u.getName(),
+					u.getEmail()
+				);
 			});
 	}
 
 	// TODO : 정렬 기준 고려
 	// 내 팔로잉 목록 조회 (인증 유저용 - isFollowing 항상 true)
+	@Transactional(readOnly = true)
 	public Page<GetFollowingsWithStatusResponse> getMyFollowings(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
 		return followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size))
 			.map(u -> {
-				final String userImageUrl = u.getUserImageUrl();
-				final boolean hasUserImage = userImageUrl != null;
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final boolean hasUserImage = userImageUrl.isPresent();
+
 				return new GetFollowingsWithStatusResponse(
 					u.getId(),
 					hasUserImage,
-					userImageUrl,
+					userImageUrl.orElse(null),
 					u.getName(),
 					u.getEmail(),
 					true // 내 팔로잉 목록이므로 항상 true
@@ -141,6 +168,7 @@ public class FollowService {
 
 	// TODO : 정렬 기준 고려
 	// 팔로잉 목록 조회 (인증 유저용 - 팔로우 상태 포함)
+	@Transactional(readOnly = true)
 	public Page<GetFollowingsWithStatusResponse> getFollowingsWithStatus(
 		final long currentUserId,
 		final long targetUserId,
@@ -149,14 +177,16 @@ public class FollowService {
 	) {
 		validateUserExists(targetUserId);
 
-		return followRepository.findFollowingsWithStatusOrderByCreatedAt(targetUserId, currentUserId, PageRequest.of(page, size))
+		return followRepository.findFollowingsWithStatusOrderByCreatedAt(targetUserId, currentUserId,
+				PageRequest.of(page, size))
 			.map(u -> {
-				final String userImageUrl = u.getUserImageUrl();
-				final boolean hasUserImage = userImageUrl != null;
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final boolean hasUserImage = userImageUrl.isPresent();
+
 				return new GetFollowingsWithStatusResponse(
 					u.getId(),
 					hasUserImage,
-					userImageUrl,
+					userImageUrl.orElse(null),
 					u.getName(),
 					u.getEmail(),
 					u.getIsFollowing()

--- a/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
@@ -12,9 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.follow.dto.FollowType;
+import hanium.modic.backend.domain.follow.dto.FollowerWithStatus;
+import hanium.modic.backend.domain.follow.dto.FollowingWithStatus;
 import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.repository.UserImageEntityRepository;
 import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersWithStatusResponse;
@@ -28,6 +31,8 @@ public class FollowService {
 	private final FollowEntityRepository followRepository;
 	private final UserEntityRepository userRepository;
 	private final UserImageService userImageService;
+	private final UserImageEntityRepository userImageRepository;
+	private final UserImageEntityRepository userImageEntityRepository;
 
 	// 팔로우 또는 언팔로우 처리
 	@Transactional
@@ -58,7 +63,17 @@ public class FollowService {
 	public Page<GetFollowersResponse> getFollowers(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
-		return followRepository.findFollowersOrderByCreatedAt(userId, PageRequest.of(page, size))
+		// 1. 팔로워들 조회
+		Page<UserEntity> followers = followRepository.findFollowersOrderByCreatedAt(userId,
+			PageRequest.of(page, size));
+
+		// 2. userImage N + 1 해결을 위한 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			followers.stream().map(UserEntity::getId).toList()
+		);
+
+		// 3. 응답 생성
+		return followers
 			.map(u -> {
 				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
 				final boolean hasUserImage = userImageUrl.isPresent();
@@ -79,7 +94,16 @@ public class FollowService {
 	public Page<GetFollowersWithStatusResponse> getMyFollowers(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
-		return followRepository.findFollowersWithStatusOrderByCreatedAt(userId, userId, PageRequest.of(page, size))
+		// 1. 팔로워들 조회
+		Page<FollowerWithStatus> followers = followRepository.findFollowersWithStatusOrderByCreatedAt(
+			userId, userId, PageRequest.of(page, size));
+
+		// 2. userImage N + 1 해결을 위한 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			followers.stream().map(FollowerWithStatus::id).toList()
+		);
+
+		return followers
 			.map(u -> {
 				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.id());
 				final boolean hasUserImage = userImageUrl.isPresent();
@@ -106,8 +130,16 @@ public class FollowService {
 	) {
 		validateUserExists(targetUserId);
 
-		return followRepository.findFollowersWithStatusOrderByCreatedAt(targetUserId, currentUserId,
-				PageRequest.of(page, size))
+		// 1. 팔로워들 조회
+		Page<FollowerWithStatus> followers = followRepository.findFollowersWithStatusOrderByCreatedAt(
+			targetUserId, currentUserId, PageRequest.of(page, size));
+
+		// 2. userImage N + 1 해결을 위한 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			followers.stream().map(FollowerWithStatus::id).toList()
+		);
+
+		return followers
 			.map(u -> {
 				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.id());
 				final boolean hasUserImage = userImageUrl.isPresent();
@@ -129,7 +161,17 @@ public class FollowService {
 	public Page<GetFollowingsResponse> getFollowings(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
-		return followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size))
+		// 1. 팔로잉들 조회
+		Page<UserEntity> followings = followRepository.findFollowingOrderByCreatedAt(userId,
+			PageRequest.of(page, size));
+
+		// 2. userImage N + 1 해결을 위한 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			followings.stream().map(UserEntity::getId).toList()
+		);
+
+		// 3. 응답 생성
+		return followings
 			.map(u -> {
 				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
 				final boolean hasUserImage = userImageUrl.isPresent();
@@ -150,6 +192,15 @@ public class FollowService {
 	public Page<GetFollowingsWithStatusResponse> getMyFollowings(final long userId, final int page, final int size) {
 		validateUserExists(userId);
 
+		// 1. 팔로잉들 조회
+		Page<UserEntity> followings = followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size));
+
+		// 2. userImage N + 1 해결을 위한 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			followings.stream().map(UserEntity::getId).toList()
+		);
+
+		// 3. 응답 생성
 		return followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size))
 			.map(u -> {
 				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
@@ -177,8 +228,20 @@ public class FollowService {
 	) {
 		validateUserExists(targetUserId);
 
-		return followRepository.findFollowingsWithStatusOrderByCreatedAt(targetUserId, currentUserId,
-				PageRequest.of(page, size))
+		// 1. 팔로잉들 조회
+		Page<FollowingWithStatus> followings = followRepository.findFollowingsWithStatusOrderByCreatedAt(
+			targetUserId,
+			currentUserId,
+			PageRequest.of(page, size)
+		);
+
+		// 2. userImage N + 1 해결을 위한 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			followings.stream().map(FollowingWithStatus::id).toList()
+		);
+
+		// 3. 응답 생성
+		return followings
 			.map(u -> {
 				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.id());
 				final boolean hasUserImage = userImageUrl.isPresent();

--- a/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
@@ -81,16 +81,16 @@ public class FollowService {
 
 		return followRepository.findFollowersWithStatusOrderByCreatedAt(userId, userId, PageRequest.of(page, size))
 			.map(u -> {
-				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.id());
 				final boolean hasUserImage = userImageUrl.isPresent();
 
 				return new GetFollowersWithStatusResponse(
-					u.getId(),
+					u.id(),
 					hasUserImage,
 					userImageUrl.orElse(null),
-					u.getName(),
-					u.getEmail(),
-					u.getIsFollowing()
+					u.name(),
+					u.email(),
+					u.isFollowing()
 				);
 			});
 	}
@@ -109,16 +109,16 @@ public class FollowService {
 		return followRepository.findFollowersWithStatusOrderByCreatedAt(targetUserId, currentUserId,
 				PageRequest.of(page, size))
 			.map(u -> {
-				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.id());
 				final boolean hasUserImage = userImageUrl.isPresent();
 
 				return new GetFollowersWithStatusResponse(
-					u.getId(),
+					u.id(),
 					hasUserImage,
 					userImageUrl.orElse(null),
-					u.getName(),
-					u.getEmail(),
-					u.getIsFollowing()
+					u.name(),
+					u.email(),
+					u.isFollowing()
 				);
 			});
 	}
@@ -180,16 +180,16 @@ public class FollowService {
 		return followRepository.findFollowingsWithStatusOrderByCreatedAt(targetUserId, currentUserId,
 				PageRequest.of(page, size))
 			.map(u -> {
-				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.getId());
+				final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(u.id());
 				final boolean hasUserImage = userImageUrl.isPresent();
 
 				return new GetFollowingsWithStatusResponse(
-					u.getId(),
+					u.id(),
 					hasUserImage,
 					userImageUrl.orElse(null),
-					u.getName(),
-					u.getEmail(),
-					u.getIsFollowing()
+					u.name(),
+					u.email(),
+					u.isFollowing()
 				);
 			});
 	}

--- a/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/hanium/modic/backend/domain/follow/service/FollowService.java
@@ -32,7 +32,6 @@ public class FollowService {
 	private final UserEntityRepository userRepository;
 	private final UserImageService userImageService;
 	private final UserImageEntityRepository userImageRepository;
-	private final UserImageEntityRepository userImageEntityRepository;
 
 	// 팔로우 또는 언팔로우 처리
 	@Transactional
@@ -68,7 +67,7 @@ public class FollowService {
 			PageRequest.of(page, size));
 
 		// 2. userImage N + 1 해결을 위한 배치 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		userImageRepository.findAllByUserIdIn(
 			followers.stream().map(UserEntity::getId).toList()
 		);
 
@@ -99,7 +98,7 @@ public class FollowService {
 			userId, userId, PageRequest.of(page, size));
 
 		// 2. userImage N + 1 해결을 위한 배치 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		userImageRepository.findAllByUserIdIn(
 			followers.stream().map(FollowerWithStatus::id).toList()
 		);
 
@@ -135,7 +134,7 @@ public class FollowService {
 			targetUserId, currentUserId, PageRequest.of(page, size));
 
 		// 2. userImage N + 1 해결을 위한 배치 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		userImageRepository.findAllByUserIdIn(
 			followers.stream().map(FollowerWithStatus::id).toList()
 		);
 
@@ -166,7 +165,7 @@ public class FollowService {
 			PageRequest.of(page, size));
 
 		// 2. userImage N + 1 해결을 위한 배치 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		userImageRepository.findAllByUserIdIn(
 			followings.stream().map(UserEntity::getId).toList()
 		);
 
@@ -193,10 +192,11 @@ public class FollowService {
 		validateUserExists(userId);
 
 		// 1. 팔로잉들 조회
-		Page<UserEntity> followings = followRepository.findFollowingOrderByCreatedAt(userId, PageRequest.of(page, size));
+		Page<UserEntity> followings = followRepository.findFollowingOrderByCreatedAt(userId,
+			PageRequest.of(page, size));
 
 		// 2. userImage N + 1 해결을 위한 배치 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		userImageRepository.findAllByUserIdIn(
 			followings.stream().map(UserEntity::getId).toList()
 		);
 
@@ -236,7 +236,7 @@ public class FollowService {
 		);
 
 		// 2. userImage N + 1 해결을 위한 배치 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		userImageRepository.findAllByUserIdIn(
 			followings.stream().map(FollowingWithStatus::id).toList()
 		);
 

--- a/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/PostService.java
@@ -7,6 +7,7 @@ import static org.springframework.data.domain.Sort.Direction.*;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -28,6 +29,7 @@ import hanium.modic.backend.domain.postLike.service.AsyncPostStatisticsService;
 import hanium.modic.backend.domain.postLike.service.PostLikeService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse.ImageDto;
 import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
@@ -52,6 +54,7 @@ public class PostService {
 	private static final String SORT_CRITERIA = "id";
 	private static final Sort.Direction SORT_DIRECTION = DESC;
 	private final ImageUtil imageUtil;
+	private final UserImageService userImageService;
 
 	// 일반 포스트 생성
 	@Transactional
@@ -104,8 +107,8 @@ public class PostService {
 		final UserEntity userEntity = userEntityRepository.findById(postEntity.getUserId())
 			.orElseThrow(() -> new AppException(USER_NOT_FOUND_EXCEPTION));
 		final String userName = userEntity.getName();
-		final String userImage = userEntity.getUserImageUrl();
-		final boolean hasUserImage = userImage != null;
+		final Optional<String> userImage = userImageService.createImageGetUrlOptional(userEntity.getId());
+		final boolean hasUserImage = userImage.isPresent();
 		final String userEmail = userEntity.getEmail();
 
 		List<ImageDto> postImages = postImageEntityRepository.findAllByPostId(id)
@@ -134,8 +137,17 @@ public class PostService {
 			})
 			.toList();
 
-		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
-			isLikedByCurrentUser, simpleDerivedPostDtos);
+		return GetPostResponse.of(
+			userName,
+			hasUserImage,
+			userImage.orElse(null),
+			userEmail,
+			postEntity,
+			postImages,
+			likeCount,
+			isLikedByCurrentUser,
+			simpleDerivedPostDtos
+		);
 	}
 
 	// 비로그인 상태에서 단일 포스트 조회
@@ -146,8 +158,8 @@ public class PostService {
 		final UserEntity userEntity = userEntityRepository.findById(postEntity.getUserId())
 			.orElseThrow(() -> new AppException(USER_NOT_FOUND_EXCEPTION));
 		final String userName = userEntity.getName();
-		final String userImage = userEntity.getUserImageUrl();
-		final boolean hasUserImage = userImage != null;
+		final Optional<String> userImage = userImageService.createImageGetUrlOptional(userEntity.getId());
+		final boolean hasUserImage = userImage.isPresent();
 		final String userEmail = userEntity.getEmail();
 
 		List<ImageDto> postImages = postImageEntityRepository.findAllByPostId(id)
@@ -176,8 +188,17 @@ public class PostService {
 			})
 			.toList();
 
-		return GetPostResponse.of(userName, hasUserImage, userImage, userEmail, postEntity, postImages, likeCount,
-			isLikedByCurrentUser, simpleDerivedPostDtos);
+		return GetPostResponse.of(
+			userName,
+			hasUserImage,
+			userImage.orElse(null),
+			userEmail,
+			postEntity,
+			postImages,
+			likeCount,
+			isLikedByCurrentUser,
+			simpleDerivedPostDtos
+		);
 	}
 
 	// 전체 포스트 목록 조회
@@ -193,6 +214,7 @@ public class PostService {
 	}
 
 	// 검색어로 포스트 목록 조회
+
 	/**
 	 * 제목 또는 설명에 검색어가 포함된 게시글 목록을 페이지 단위로 조회합니다.
 	 * 검색 대상은 전달받은 포스트 타입에 해당하는 게시글로 제한됩니다.

--- a/src/main/java/hanium/modic/backend/domain/postReview/dto/PostReviewCommentDto.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/dto/PostReviewCommentDto.java
@@ -1,0 +1,12 @@
+package hanium.modic.backend.domain.postReview.dto;
+
+import java.time.LocalDateTime;
+
+public record PostReviewCommentDto(
+	Long postReviewCommentId,
+	Long userId,
+	String userName,
+	LocalDateTime createdAt,
+	String text
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/postReview/repository/PostReviewCommentRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/repository/PostReviewCommentRepository.java
@@ -5,28 +5,25 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import hanium.modic.backend.domain.postReview.dto.PostReviewCommentDto;
 import hanium.modic.backend.domain.postReview.entity.PostReviewCommentEntity;
-import hanium.modic.backend.web.postReview.dto.response.PostReviewCommentResponse;
 
 public interface PostReviewCommentRepository extends JpaRepository<PostReviewCommentEntity, Long> {
 
-
 	@Query("""
-			SELECT new hanium.modic.backend.web.postReview.dto.response.PostReviewCommentResponse(
+			SELECT new hanium.modic.backend.domain.postReview.dto.PostReviewCommentDto(
 				c.id,
 				c.userId,
 				u.name,
 				c.createAt,
-				c.text,
-				CASE WHEN u.userImageUrl IS NOT NULL THEN true ELSE false END,
-				u.userImageUrl
+				c.text
 			)
 			FROM PostReviewCommentEntity c
 			JOIN UserEntity u ON c.userId = u.id
 			WHERE c.postReviewId = :postReviewId
 			ORDER BY c.createAt DESC
 		""")
-	Page<PostReviewCommentResponse> findAllByPostReviewIdOrderByCreateAtDesc(Long postReviewId, Pageable pageable);
+	Page<PostReviewCommentDto> findAllByPostReviewIdOrderByCreateAtDesc(Long postReviewId, Pageable pageable);
 
 }
 

--- a/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewCommentService.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewCommentService.java
@@ -3,6 +3,7 @@ package hanium.modic.backend.domain.postReview.service;
 import static hanium.modic.backend.common.error.ErrorCode.*;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -10,12 +11,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.postReview.dto.PostReviewCommentDto;
 import hanium.modic.backend.domain.postReview.entity.PostReviewCommentEntity;
 import hanium.modic.backend.domain.postReview.entity.PostReviewEntity;
 import hanium.modic.backend.domain.postReview.repository.PostReviewCommentRepository;
 import hanium.modic.backend.domain.postReview.repository.PostReviewRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.postReview.dto.response.PostReviewCommentResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -26,10 +29,30 @@ public class PostReviewCommentService {
 	private final PostReviewCommentRepository commentRepository;
 	private final PostReviewRepository postReviewRepository;
 	private final UserEntityRepository userEntityRepository;
+	private final UserImageService userImageService;
+	private final PostReviewCommentRepository postReviewCommentRepository;
 
 	// 게시글 리뷰 댓글 목록 조회
 	public Page<PostReviewCommentResponse> getComments(final long postReviewId, final int page, final int size) {
-		return commentRepository.findAllByPostReviewIdOrderByCreateAtDesc(postReviewId, PageRequest.of(page, size));
+		// 댓글 조회
+		Page<PostReviewCommentDto> prcs = postReviewCommentRepository.findAllByPostReviewIdOrderByCreateAtDesc(
+			postReviewId, PageRequest.of(page, size));
+
+		// 댓글 userId에 해당하는 유저들의 프로필 이미지 조회
+		return prcs.map(prc -> {
+			final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(prc.userId());
+			final boolean hasUserImage = userImageUrl.isPresent();
+
+			return new PostReviewCommentResponse(
+				prc.postReviewCommentId(),
+				prc.userId(),
+				prc.userName(),
+				prc.createdAt(),
+				prc.text(),
+				hasUserImage,
+				userImageUrl.orElse(null)
+			);
+		});
 	}
 
 	// 게시글 리뷰 댓글 생성

--- a/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewCommentService.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewCommentService.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostReviewCommentService {
 
-	private final PostReviewCommentRepository commentRepository;
 	private final PostReviewRepository postReviewRepository;
 	private final UserEntityRepository userEntityRepository;
 	private final UserImageService userImageService;
@@ -63,7 +62,7 @@ public class PostReviewCommentService {
 		PostReviewEntity review = postReviewRepository.findById(postReviewId)
 			.orElseThrow(() -> new AppException(POST_REVIEW_NOT_FOUND_EXCEPTION));
 
-		commentRepository.save(PostReviewCommentEntity.builder()
+		postReviewCommentRepository.save(PostReviewCommentEntity.builder()
 			.user(user)
 			.postReview(review)
 			.text(text)
@@ -73,7 +72,7 @@ public class PostReviewCommentService {
 	// 게시글 리뷰 댓글 수정
 	@Transactional
 	public void updateComment(long userId, long commentId, String text) {
-		PostReviewCommentEntity comment = commentRepository.findById(commentId)
+		PostReviewCommentEntity comment = postReviewCommentRepository.findById(commentId)
 			.orElseThrow(() -> new AppException(POST_REVIEW_COMMENT_NOT_FOUND_EXCEPTION));
 
 		validateMyComment(userId, comment.getUserId());
@@ -83,11 +82,11 @@ public class PostReviewCommentService {
 	// 게시글 리뷰 댓글 삭제
 	@Transactional
 	public void deleteComment(long userId, long commentId) {
-		PostReviewCommentEntity comment = commentRepository.findById(commentId)
+		PostReviewCommentEntity comment = postReviewCommentRepository.findById(commentId)
 			.orElseThrow(() -> new AppException(POST_REVIEW_COMMENT_NOT_FOUND_EXCEPTION));
 
 		validateMyComment(userId, comment.getUserId());
-		commentRepository.delete(comment);
+		postReviewCommentRepository.delete(comment);
 	}
 
 	// 댓글 작성자가 본인인지 확인

--- a/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewCommentService.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewCommentService.java
@@ -18,6 +18,7 @@ import hanium.modic.backend.domain.postReview.repository.PostReviewCommentReposi
 import hanium.modic.backend.domain.postReview.repository.PostReviewRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.repository.UserImageEntityRepository;
 import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.postReview.dto.response.PostReviewCommentResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,14 +31,20 @@ public class PostReviewCommentService {
 	private final UserEntityRepository userEntityRepository;
 	private final UserImageService userImageService;
 	private final PostReviewCommentRepository postReviewCommentRepository;
+	private final UserImageEntityRepository userImageEntityRepository;
 
 	// 게시글 리뷰 댓글 목록 조회
 	public Page<PostReviewCommentResponse> getComments(final long postReviewId, final int page, final int size) {
-		// 댓글 조회
+		// 1. 댓글 조회
 		Page<PostReviewCommentDto> prcs = postReviewCommentRepository.findAllByPostReviewIdOrderByCreateAtDesc(
 			postReviewId, PageRequest.of(page, size));
 
-		// 댓글 userId에 해당하는 유저들의 프로필 이미지 조회
+		// 2. N + 1 문제를 해결하기 위한 UserImage 배치 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			prcs.stream().map(PostReviewCommentDto::userId).toList()
+		);
+
+		// 3. 댓글 userId에 해당하는 유저들의 프로필 이미지 조회
 		return prcs.map(prc -> {
 			final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(prc.userId());
 			final boolean hasUserImage = userImageUrl.isPresent();

--- a/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewService.java
+++ b/src/main/java/hanium/modic/backend/domain/postReview/service/PostReviewService.java
@@ -5,6 +5,7 @@ import static hanium.modic.backend.common.error.ErrorCode.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -22,6 +23,7 @@ import hanium.modic.backend.domain.postReview.repository.PostReviewImageReposito
 import hanium.modic.backend.domain.postReview.repository.PostReviewRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.postReview.dto.response.PostReviewDetailResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -35,6 +37,7 @@ public class PostReviewService {
 	private final PostEntityRepository postEntityRepository;
 	private final UserEntityRepository userEntityRepository;
 	private final PostReviewAuthorizationService postReviewAuthorizationService;
+	private final UserImageService userImageService;
 
 	// 포스트 리뷰 생성
 	@Transactional
@@ -120,13 +123,13 @@ public class PostReviewService {
 			.map(image -> postReviewImageService.createImageGetUrl(image.getId()))
 			.toList();
 
-		String userImageUrl = user.getUserImageUrl();
-		boolean hasUserImage = userImageUrl != null;
+		final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
+		final boolean hasUserImage = userImageUrl.isPresent();
 
 		return new PostReviewDetailResponse(
 			user.getName(),
 			hasUserImage,
-			userImageUrl,
+			userImageUrl.orElse(null),
 			postReview.getCreateAt(),
 			postReview.getId(),
 			postReview.getDescription(),
@@ -160,8 +163,8 @@ public class PostReviewService {
 			if (user == null)
 				throw new AppException(USER_NOT_FOUND_EXCEPTION);
 
-			String userImageUrl = user.getUserImageUrl();
-			boolean hasUserImage = userImageUrl != null;
+			final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
+			final boolean hasUserImage = userImageUrl.isPresent();
 
 			List<String> imageUrls = imageMap.getOrDefault(postReview.getId(), List.of()).stream()
 				.map(image -> postReviewImageService.createImageGetUrl(image.getId()))
@@ -170,7 +173,7 @@ public class PostReviewService {
 			return new PostReviewDetailResponse(
 				user.getName(),
 				hasUserImage,
-				userImageUrl,
+				userImageUrl.orElse(null),
 				postReview.getCreateAt(),
 				postReview.getId(),
 				postReview.getDescription(),

--- a/src/main/java/hanium/modic/backend/domain/profile/service/ProfileService.java
+++ b/src/main/java/hanium/modic/backend/domain/profile/service/ProfileService.java
@@ -1,5 +1,7 @@
 package hanium.modic.backend.domain.profile.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import hanium.modic.backend.common.error.ErrorCode;
@@ -8,6 +10,7 @@ import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.profile.dto.GetMyProfileResponse;
 import hanium.modic.backend.web.profile.dto.GetProfileResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,20 +21,22 @@ public class ProfileService {
 	private final UserEntityRepository userRepository;
 	private final PostEntityRepository postRepository;
 	private final FollowEntityRepository followRepository;
+	private final UserImageService userImageService;
 
 	// 내 프로필 조회(코인 함께 조회)
 	public GetMyProfileResponse getMyProfile(final UserEntity user) {
 		final long postCount = postRepository.countByUserId(user.getId()); // TODO: 추후 개선 필요, count 쿼리 없애는 방법
 		final long followingCount = followRepository.countByMyId(user.getId()); // TODO: 추후 개선 필요
 		final long followerCount = followRepository.countByFollowingId(user.getId()); // TODO: 추후 개선 필요
-		final String userImageUrl = user.getUserImageUrl();
+		final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
+		final boolean hasUserImage = userImageUrl.isPresent();
 
 		return new GetMyProfileResponse(
 			user.getId(),
 			user.getEmail(),
 			user.getName(),
-			userImageUrl != null,
-			userImageUrl,
+			hasUserImage,
+			userImageUrl.orElse(null),
 			postCount,
 			followerCount,
 			followingCount,
@@ -47,14 +52,15 @@ public class ProfileService {
 		final long postCount = postRepository.countByUserId(userId); // TODO: 추후 개선 필요, count 쿼리 없애는 방법
 		final long followingCount = followRepository.countByMyId(userId); // TODO: 추후 개선 필요
 		final long followerCount = followRepository.countByFollowingId(userId); // TODO: 추후 개선 필요
-		final String userImageUrl = user.getUserImageUrl();
+		final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(userId);
+		final boolean hasUserImage = userImageUrl.isPresent();
 
 		return new GetProfileResponse(
 			user.getId(),
 			user.getEmail(),
 			user.getName(),
-			userImageUrl != null,
-			userImageUrl,
+			hasUserImage,
+			userImageUrl.orElse(null),
 			postCount,
 			followerCount,
 			followingCount

--- a/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/user/entity/UserEntity.java
@@ -48,9 +48,6 @@ public class UserEntity extends BaseEntity {
 	@Column(name = "coin", nullable = false)
 	private Long coin = 0L;
 
-	@Column(name = "user_image_url")
-	private String userImageUrl;
-
 	@Builder
 	private UserEntity(String email, String password, String name, String uniqueId) {
 		this.email = email;
@@ -77,23 +74,12 @@ public class UserEntity extends BaseEntity {
 		return this;
 	}
 
-	// 유저 이미지 URL 업데이트
-	public void updateUserImage(String userImageUrl) {
-		this.userImageUrl = userImageUrl;
-	}
-
-	// 유저 이미지 URL 삭제
-	public void deleteUserImage() {
-		this.userImageUrl = null;
-	}
-
 	// 유저 이름 업데이트
 	public void updateName(String name) {
 		if (name == null || name.isBlank()) {
 			throw new AppException(USER_INPUT_EXCEPTION);
 		}
 		this.name = name;
-
 	}
 
 	// 유저 비밀번호 업데이트

--- a/src/main/java/hanium/modic/backend/domain/user/repository/UserImageEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/user/repository/UserImageEntityRepository.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.domain.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import hanium.modic.backend.domain.user.entity.UserImageEntity;
@@ -10,4 +11,6 @@ public interface UserImageEntityRepository extends JpaRepository<UserImageEntity
 	Optional<UserImageEntity> findByUserId(Long userId);
 
 	boolean existsByImagePath(String imagePath);
+
+	List<UserImageEntity> findAllByUserIdIn(List<Long> userIds);
 }

--- a/src/main/java/hanium/modic/backend/domain/user/service/UserImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/user/service/UserImageService.java
@@ -2,6 +2,8 @@ package hanium.modic.backend.domain.user.service;
 
 import static hanium.modic.backend.common.error.ErrorCode.*;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,11 +32,21 @@ public class UserImageService extends ImageService {
 		this.userImageRepository = userImageRepository;
 	}
 
+	// 이미지 URL 조회 - Optional 응답
+	@Transactional(readOnly = true)
+	public Optional<String> createImageGetUrlOptional(final long userId) {
+		return userImageRepository.findByUserId(userId)
+			.map(UserImageEntity::getImagePath)
+			.map(imageUtil::createImageGetUrl);
+	}
+
 	// 이미지 URL 조회
+	@Transactional(readOnly = true)
 	public String createImageGetUrl(final long userId) {
-		UserImageEntity userImage = userImageRepository.findByUserId(userId)
+		return userImageRepository.findByUserId(userId)
+			.map(UserImageEntity::getImagePath)
+			.map(imageUtil::createImageGetUrl)
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
-		return imageUtil.createImageGetUrl(userImage.getImagePath());
 	}
 
 	// 이미지 삭제
@@ -42,14 +54,10 @@ public class UserImageService extends ImageService {
 	public void deleteImage(final long userId, final long imageId) {
 		validateUserImageOwnership(userId, imageId);
 
-		UserEntity user = userEntityRepository.findById(userId)
-			.orElseThrow(() -> new AppException(USER_NOT_FOUND_EXCEPTION));
-
 		UserImageEntity image = userImageRepository.findById(imageId)
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
 		userImageRepository.delete(image);
 		imageUtil.deleteImage(image.getImagePath());
-		user.deleteUserImage();
 	}
 
 	// 이미지 저장

--- a/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
+++ b/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package hanium.modic.backend.domain.user.service;
 
+import java.util.Optional;
+
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +26,7 @@ public class UserService {
 	private final BCryptPasswordEncoder passwordEncoder;
 	private final UserUpdateTokenRepository userUpdateTokenRepository;
 	private final AuthService authService;
+	private final UserImageService userImageService;
 
 	// 회원가입
 	@Transactional
@@ -57,7 +60,8 @@ public class UserService {
 
 	// 회원 정보 조회
 	public UserInfoResponse getUserInfo(UserEntity user) {
-		return UserInfoResponse.from(user);
+		Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
+		return UserInfoResponse.of(user, userImageUrl.orElse(null));
 	}
 
 	// 유저 이름 변경

--- a/src/main/java/hanium/modic/backend/web/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/response/UserInfoResponse.java
@@ -14,13 +14,13 @@ public record UserInfoResponse(
 	boolean hasUserImage,
 	String userImageUrl
 ) {
-	public static UserInfoResponse from(UserEntity user) {
+	public static UserInfoResponse of(UserEntity user, String userImageUrl) {
 		return new UserInfoResponse(
 			user.getId(),
 			user.getEmail(),
 			user.getName(),
-			user.getUserImageUrl() != null,
-			user.getUserImageUrl()
+			userImageUrl != null,
+			userImageUrl
 		);
 	}
 }

--- a/src/test/java/hanium/modic/backend/domain/follow/service/FollowMockingServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/follow/service/FollowMockingServiceTest.java
@@ -23,6 +23,7 @@ import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
 
@@ -37,6 +38,9 @@ class FollowMockingServiceTest {
 
 	@Mock
 	private UserEntityRepository userRepository;
+
+	@Mock
+	private UserImageService userImageService;
 
 	@Test
 	@DisplayName("TEST1: 존재하지 않는 유저의 팔로워 목록 조회 시 예외 발생")

--- a/src/test/java/hanium/modic/backend/domain/follow/service/FollowMockingServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/follow/service/FollowMockingServiceTest.java
@@ -23,6 +23,7 @@ import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.repository.UserImageEntityRepository;
 import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.follow.dto.response.GetFollowersResponse;
 import hanium.modic.backend.web.follow.dto.response.GetFollowingsResponse;
@@ -41,6 +42,9 @@ class FollowMockingServiceTest {
 
 	@Mock
 	private UserImageService userImageService;
+
+	@Mock
+	private UserImageEntityRepository userImageEntityRepository;
 
 	@Test
 	@DisplayName("TEST1: 존재하지 않는 유저의 팔로워 목록 조회 시 예외 발생")
@@ -129,6 +133,7 @@ class FollowMockingServiceTest {
 		Page<UserEntity> page = new PageImpl<>(List.of(user2, user3));
 		when(followRepository.findFollowersOrderByCreatedAt(eq(userId), any(PageRequest.class)))
 			.thenReturn(page);
+		when(userImageEntityRepository.findAllByUserIdIn(List.of(2L, 3L))).thenReturn(List.of()); // 프로필 없음
 
 		// when
 		Page<GetFollowersResponse> result = followService.getFollowers(userId, 0, 10);
@@ -157,6 +162,7 @@ class FollowMockingServiceTest {
 
 		Page<UserEntity> page = new PageImpl<>(List.of(user4, user5));
 		when(followRepository.findFollowingOrderByCreatedAt(eq(userId), any(PageRequest.class))).thenReturn(page);
+		when(userImageEntityRepository.findAllByUserIdIn(List.of(2L, 3L))).thenReturn(List.of()); // 프로필 없음
 
 		// when
 		Page<GetFollowingsResponse> result = followService.getFollowings(userId, 0, 10);

--- a/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/PostServiceTest.java
@@ -43,6 +43,7 @@ import hanium.modic.backend.domain.postLike.service.PostLikeService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.post.dto.response.GetPostResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostTreeResponse;
 import hanium.modic.backend.web.post.dto.response.GetPostsResponse;
@@ -64,6 +65,8 @@ class PostServiceTest {
 	private AsyncPostStatisticsService asyncPostStatisticsService;
 	@Mock
 	private ImageUtil imageUtil;
+	@Mock
+	private UserImageService userImageService;
 
 	@InjectMocks
 	private PostService postService;
@@ -178,6 +181,7 @@ class PostServiceTest {
 
 		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockPost));
 		when(userEntityRepository.findById(mockPost.getUserId())).thenReturn(Optional.of(mockUser));
+		when(userImageService.createImageGetUrlOptional(mockPost.getUserId())).thenReturn(Optional.empty());
 		when(postImageEntityRepository.findAllByPostId(postId)).thenReturn(mockImages);
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn("https://signed-url.com/image.jpg");
 		when(postLikeService.getLikeCount(postId)).thenReturn(5L);
@@ -690,6 +694,7 @@ class PostServiceTest {
 
 		when(postEntityRepository.findById(postId)).thenReturn(Optional.of(mockAiDerivedPost));
 		when(userEntityRepository.findById(mockAiDerivedPost.getUserId())).thenReturn(Optional.of(mockUser));
+		when(userImageService.createImageGetUrlOptional(mockAiDerivedPost.getUserId())).thenReturn(Optional.empty());
 		when(postImageEntityRepository.findAllByPostId(postId)).thenReturn(mockImages);
 		when(imageUtil.createImageGetUrl(anyString())).thenReturn(URL);
 		when(postLikeService.getLikeCount(postId)).thenReturn(3L);

--- a/src/test/java/hanium/modic/backend/domain/postReview/service/PostReviewServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/postReview/service/PostReviewServiceTest.java
@@ -24,6 +24,7 @@ import hanium.modic.backend.domain.postReview.repository.PostReviewImageReposito
 import hanium.modic.backend.domain.postReview.repository.PostReviewRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.postReview.dto.response.PostReviewDetailResponse;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +38,8 @@ class PostReviewServiceTest {
 	private PostReviewImageRepository postReviewImageRepository;
 	@Mock
 	private UserEntityRepository userEntityRepository;
+	@Mock
+	private UserImageService userImageService;
 
 	@InjectMocks
 	private PostReviewService postReviewService;
@@ -57,7 +60,7 @@ class PostReviewServiceTest {
 
 		UserEntity mockUser = mock(UserEntity.class);
 		when(mockUser.getName()).thenReturn("testUser");
-		when(mockUser.getUserImageUrl()).thenReturn("https://example.com/user.jpg");
+		when(mockUser.getId()).thenReturn(userId);
 
 		PostReviewImageEntity mockImage1 = mock(PostReviewImageEntity.class);
 		when(mockImage1.getId()).thenReturn(1L);
@@ -72,6 +75,7 @@ class PostReviewServiceTest {
 		when(postReviewImageRepository.findAllByPostReviewId(reviewId)).thenReturn(mockImages);
 		when(postReviewImageService.createImageGetUrl(1L)).thenReturn("https://example.com/image1.jpg");
 		when(postReviewImageService.createImageGetUrl(2L)).thenReturn("https://example.com/image2.jpg");
+		when(userImageService.createImageGetUrlOptional(userId)).thenReturn(Optional.of("https://example.com/user.jpg"));
 
 		// When
 		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);
@@ -141,11 +145,12 @@ class PostReviewServiceTest {
 
 		UserEntity mockUser = mock(UserEntity.class);
 		when(mockUser.getName()).thenReturn("testUser");
-		when(mockUser.getUserImageUrl()).thenReturn("https://example.com/user.jpg");
+		when(mockUser.getId()).thenReturn(userId);
 
 		when(postReviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
 		when(userEntityRepository.findById(userId)).thenReturn(Optional.of(mockUser));
 		when(postReviewImageRepository.findAllByPostReviewId(reviewId)).thenReturn(Collections.emptyList());
+		when(userImageService.createImageGetUrlOptional(userId)).thenReturn(Optional.of("https://example.com/user.jpg"));
 
 		// When
 		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);
@@ -176,11 +181,12 @@ class PostReviewServiceTest {
 
 		UserEntity mockUser = mock(UserEntity.class);
 		when(mockUser.getName()).thenReturn("testUser");
-		when(mockUser.getUserImageUrl()).thenReturn(null);
+		when(mockUser.getId()).thenReturn(userId);
 
 		when(postReviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
 		when(userEntityRepository.findById(userId)).thenReturn(Optional.of(mockUser));
 		when(postReviewImageRepository.findAllByPostReviewId(reviewId)).thenReturn(Collections.emptyList());
+		when(userImageService.createImageGetUrlOptional(userId)).thenReturn(Optional.empty());
 
 		// When
 		PostReviewDetailResponse response = postReviewService.getPostReviewDetail(reviewId);

--- a/src/test/java/hanium/modic/backend/domain/profile/ProfileServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/profile/ProfileServiceTest.java
@@ -21,6 +21,7 @@ import hanium.modic.backend.domain.profile.service.ProfileService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.service.UserImageService;
 import hanium.modic.backend.web.profile.dto.GetMyProfileResponse;
 import hanium.modic.backend.web.profile.dto.GetProfileResponse;
 
@@ -38,6 +39,9 @@ class ProfileServiceTest {
 
 	@Mock
 	private FollowEntityRepository followRepository;
+
+	@Mock
+	private UserImageService userImageService;
 
 	@Test
 	@DisplayName("TEST1: 내 프로필 조회 성공")

--- a/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
@@ -40,6 +40,9 @@ class UserServiceTest {
 	@Mock
 	private AuthService authService;
 
+	@Mock
+	private UserImageService userImageService;
+
 	@Test
 	@DisplayName("유저 회원가입 테스트")
 	void userCreateTest() {

--- a/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/PublicPostControllerTest.java
@@ -55,8 +55,8 @@ class PublicPostControllerTest extends BaseControllerTest {
 
 		GetPostResponse mockResponse = new GetPostResponse(
 			mockUser.getName(),
-			mockUser.getUserImageUrl() != null,
-			mockUser.getUserImageUrl(),
+			false,
+			null,
 			mockUser.getEmail(),
 			mockPost.getId(),
 			mockPost.getUserId(),

--- a/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/profile/controller/ProfileControllerIntegrationTest.java
@@ -11,14 +11,20 @@ import org.springframework.test.web.servlet.ResultActions;
 import hanium.modic.backend.base.BaseIntegrationTest;
 import hanium.modic.backend.base.login.ContextHolderUtil;
 import hanium.modic.backend.base.login.WithCustomUser;
+import hanium.modic.backend.domain.image.domain.ImageExtension;
+import hanium.modic.backend.domain.image.domain.ImagePrefix;
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.entity.UserImageEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.repository.UserImageEntityRepository;
 
 public class ProfileControllerIntegrationTest extends BaseIntegrationTest {
 
 	@Autowired
 	private UserEntityRepository userEntityRepository;
+	@Autowired
+	private UserImageEntityRepository userImageRepository;
 
 	@Test
 	@DisplayName("TEST1: 내 프로필 조회 성공")
@@ -45,10 +51,20 @@ public class ProfileControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("TEST2: 타인 프로필 조회 성공")
 	@WithCustomUser(email = "viewer@test.com")
 	void getOtherProfileSuccess() throws Exception {
-		// given: 조회 대상 사용자 저장
-		UserEntity target =UserFactory.createMockUserWithoutId("Target");
-		target.updateUserImage("url");
+		// given:
+		// 1. 조회 대상 사용자 저장
+		UserEntity target = UserFactory.createMockUserWithoutId("Target");
 		target = userEntityRepository.save(target);
+		// 2. 조회 대상 사용자 프로필 이미지 저장
+		UserImageEntity image = UserImageEntity.builder()
+			.user(target)
+			.imagePath("profiles/" + target.getId() + "/image.png")
+			.fullImageName("image.png")
+			.imageName("image")
+			.extension(ImageExtension.PNG)
+			.imagePurpose(ImagePrefix.PROFILE)
+			.build();
+		userImageRepository.save(image);
 
 		// when: 타인의 프로필 조회 요청
 		ResultActions result = mockMvc.perform(get("/api/profiles")

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -137,7 +137,7 @@ class UserControllerTest extends BaseControllerTest {
 		Authentication authentication = new UsernamePasswordAuthenticationToken(mockUser, null, List.of());
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		UserInfoResponse mockResponse = UserInfoResponse.from(mockUser);
+		UserInfoResponse mockResponse = UserInfoResponse.of(mockUser, "URL");
 		given(userService.getUserInfo(any(UserEntity.class))).willReturn(mockResponse);
 
 		// when & then


### PR DESCRIPTION
 ## 🧩 작업 내용 요약                                                                                                                                                  
                                                                                                                                                                        
  - FollowService · ProfileService 등 사용자 목록 응답에서 정적 URL 대신 Signed URL 생성 로직으로 교체                                                                  
  - UserEntity 필드 로직 및 UserImageService를 Signed URL 발급에 맞춰 정비
  - Post/Review/Profile/User 관련 서비스·컨트롤러 테스트를 Signed URL 기반 응답으로 업데이트                                                                            
                                                                                                                                                                        
  ———                                                                                                                                                                   
                                                                                                                                                                        
  ## 🔍 관련 이슈                                                                                                                                                       
                                                                                                                                                                        
  - Resolves: #203                                                                                                                                                      
                                                                                                                                                                        
  ———                                                                                                                                                                   
                                                                                                                                                                        
  ## 🧠 변경 이유 및 주요 포인트                                                                                                                                        
                                                                                                                                                                        
  - 정적 경로 노출 시 권한 문제가 발생하던 사용자 이미지 조회 흐름을 Signed URL 기반으로 일원화                                                                                                                                                             
                                                                                                                                                                        
  ———                                                                                                                                                                   
                                                                                                                                                                        
  ## 🧪 테스트 및 검증                                                                                                                                                  
                                                                                                                                                                        
  - [ ] 단위 테스트 통과                                                                                                                                                
  - [ ] 통합 테스트 통과                                                                                                                                                
  - [ ] 로컬 서버 정상 구동 확인                                                                                                                                        
  - [ ] Swagger 또는 Postman 테스트 완료           

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 프로필 이미지 유무와(존재 시) URL이 댓글·팔로우·팔로잉·프로필·게시글 응답에 일관되게 반영됩니다.
  - 댓글 응답용 간결한 코멘트 DTO가 추가되어 댓글 목록이 더 표준화되었습니다.
- **버그 수정**
  - 이미지 존재 판별과 null 처리 개선으로 표시 오류 및 간헐적 문제 해결, 공개/비로그인 뷰에서도 상태가 정확히 반영됩니다.
- **리팩터링**
  - 이미지 조회 방식 통합으로 응답 생성 흐름이 일관화되었습니다.
- **테스트**
  - 단위·통합 테스트가 보강되어 이미지 관련 시나리오 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->