### PR TITLE
AI 유사도 검사 비동기 처리 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
+++ b/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
@@ -38,6 +38,16 @@ public class RabbitMqConfig {
 	public static final String AI_IMAGE_REQUEST_DLQ_ROUTING_KEY = "ai.image.request.dlq";
 	public static final String AI_IMAGE_REQUEST_RETRY_ROUTING_KEY = "ai.image.request.retry";
 
+	// Similarity Check Request
+	public static final String VOTE_SIMILARITY_REQUEST_QUEUE = "vote.similarity.request.queue";
+	public static final String VOTE_SIMILARITY_REQUEST_EXCHANGE = "vote.similarity.request.exchange";
+	public static final String VOTE_SIMILARITY_REQUEST_ROUTING_KEY = "vote.similarity.request";
+
+	// Similarity Check Response
+	public static final String VOTE_SIMILARITY_RESPONSE_QUEUE = "vote.similarity.response.queue";
+	public static final String VOTE_SIMILARITY_RESPONSE_EXCHANGE = "vote.similarity.response.exchange";
+	public static final String VOTE_SIMILARITY_RESPONSE_ROUTING_KEY = "vote.similarity.response";
+
 	private final RabbitMqProperties rabbitMqProperties;
 
 	@Bean
@@ -127,6 +137,42 @@ public class RabbitMqConfig {
 		return BindingBuilder.bind(aiImageRequestRetryExchange)
 			.to(aiImageRequestDlx)
 			.with(AI_IMAGE_REQUEST_RETRY_ROUTING_KEY);
+	}
+
+	// Request Queue, Exchange, Binding
+	@Bean
+	public Queue voteSimilarityRequestQueue() {
+		return new Queue(VOTE_SIMILARITY_REQUEST_QUEUE, true);
+	}
+
+	@Bean
+	public TopicExchange voteSimilarityRequestExchange() {
+		return new TopicExchange(VOTE_SIMILARITY_REQUEST_EXCHANGE, true, false);
+	}
+
+	@Bean
+	public Binding voteSimilarityRequestBinding(Queue voteSimilarityRequestQueue, TopicExchange voteSimilarityRequestExchange) {
+		return BindingBuilder.bind(voteSimilarityRequestQueue)
+			.to(voteSimilarityRequestExchange)
+			.with(VOTE_SIMILARITY_REQUEST_ROUTING_KEY);
+	}
+
+	// Response Queue, Exchange, Binding
+	@Bean
+	public Queue voteSimilarityResponseQueue() {
+		return new Queue(VOTE_SIMILARITY_RESPONSE_QUEUE, true);
+	}
+
+	@Bean
+	public TopicExchange voteSimilarityResponseExchange() {
+		return new TopicExchange(VOTE_SIMILARITY_RESPONSE_EXCHANGE, true, false);
+	}
+
+	@Bean
+	public Binding voteSimilarityResponseBinding(Queue voteSimilarityResponseQueue, TopicExchange voteSimilarityResponseExchange) {
+		return BindingBuilder.bind(voteSimilarityResponseQueue)
+			.to(voteSimilarityResponseExchange)
+			.with(VOTE_SIMILARITY_RESPONSE_ROUTING_KEY);
 	}
 
 	@Bean

--- a/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
@@ -2,6 +2,8 @@ package hanium.modic.backend.domain.post.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
@@ -38,6 +40,9 @@ public class AiDerivedPostService {
 	private final SimilarityVoteRepository similarityVoteRepository;
 	private final SimilarityVoteSummaryRepository voteSummaryRepository;
 
+	// AI 유사도 검사 요청 서비스
+	private final hanium.modic.backend.domain.vote.service.AiSimilarityRequestService aiSimilarityRequestService;
+
 	/**
 	 * AI 파생 포스트 생성 (투표 시스템 연동)
 	 * @param userId 사용자 ID
@@ -68,10 +73,14 @@ public class AiDerivedPostService {
 			throw new AppException(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION);
 		}
 
-		// 원본 이미지 ID
-		Long originalImageId = postEntityRepository.findById(createdAiImage.getPostId())
-			.orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION))
-			.getThumbnailImageId();
+		// 원본 포스트 및 원본 이미지 조회
+		PostEntity originalPost = postEntityRepository.findById(createdAiImage.getPostId())
+			.orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION));
+		Long originalImageId = originalPost.getThumbnailImageId();
+
+		// 원본 이미지 경로 조회
+		PostImageEntity originalImage = postImageEntityRepository.findById(originalImageId)
+			.orElseThrow(() -> new AppException(ErrorCode.IMAGE_NOT_FOUND_EXCEPTION));
 
 		// AI 파생 포스트 생성 - PENDING 상태로 생성 (투표 대기)
 		PostEntity aiDerivedPost = PostEntity.builder()
@@ -118,6 +127,18 @@ public class AiDerivedPostService {
 			.finalDecision(VoteDecision.PENDING) // 최종 결정 대기
 			.build();
 		voteSummaryRepository.save(voteSummary);
+
+		// AI 유사도 검사 요청 (트랜잭션 커밋 후 비동기 실행)
+		Long voteId = savedVote.getId();
+		String originalPath = originalImage.getImagePath();
+		String derivedPath = createdAiImage.getImagePath();
+
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				aiSimilarityRequestService.sendSimilarityCheckRequest(voteId, originalPath, derivedPath);
+			}
+		});
 
 		// 게시글 통계 초기화 (비동기)
 		asyncPostStatisticsService.initializeStatistics(savedPost.getId());

--- a/src/main/java/hanium/modic/backend/domain/vote/dto/SimilarityCheckRequestDto.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/dto/SimilarityCheckRequestDto.java
@@ -1,0 +1,11 @@
+package hanium.modic.backend.domain.vote.dto;
+
+/**
+ * AI 서버로 전송하는 유사도 검사 요청 DTO
+ */
+public record SimilarityCheckRequestDto(
+	Long voteId,                // 투표 ID (응답에 포함되어야 함)
+	String originalImagePath,   // 원본 이미지 경로 (S3 path)
+	String derivedImagePath     // 파생 이미지 경로 (S3 path)
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/vote/dto/SimilarityCheckResponseDto.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/dto/SimilarityCheckResponseDto.java
@@ -1,0 +1,12 @@
+package hanium.modic.backend.domain.vote.dto;
+
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+
+/**
+ * AI 서버로부터 받는 유사도 검사 응답 DTO
+ */
+public record SimilarityCheckResponseDto(
+	Long voteId,            // 투표 ID
+	VoteDecision decision   // AI 판단 결과 (APPROVE/DENY)
+) {
+}

--- a/src/main/java/hanium/modic/backend/domain/vote/listener/SimilarityCheckListener.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/listener/SimilarityCheckListener.java
@@ -1,0 +1,92 @@
+package hanium.modic.backend.domain.vote.listener;
+
+import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
+
+import java.util.Optional;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.common.property.property.VoteProperties;
+import hanium.modic.backend.domain.vote.dto.SimilarityCheckResponseDto;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+import hanium.modic.backend.domain.vote.enums.VoteStatus;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SimilarityCheckListener {
+
+	private final SimilarityVoteRepository similarityVoteRepository;
+	private final SimilarityVoteSummaryRepository voteSummaryRepository;
+	private final VoteProperties voteProperties;
+
+	/**
+	 * AI 유사도 검사 응답 처리
+	 * - AI 가중치만 추가하고, VoteEntity/PostEntity 상태는 변경하지 않음 (사람 투표 대기)
+	 * @param response AI 서버 응답 메시지
+	 */
+	@Transactional
+	@RabbitListener(queues = VOTE_SIMILARITY_RESPONSE_QUEUE)
+	public void handleSimilarityCheckResponse(SimilarityCheckResponseDto response) {
+		log.info("[AI 유사도 검사 응답 수신] voteId={}, decision={}", response.voteId(), response.decision());
+
+		// 1. SimilarityVoteEntity 조회
+		Optional<SimilarityVoteEntity> voteOpt = similarityVoteRepository.findById(response.voteId());
+		if (voteOpt.isEmpty()) {
+			log.error("[유사도 검사 실패] 투표를 찾을 수 없습니다. voteId={}", response.voteId());
+			return;
+		}
+		SimilarityVoteEntity vote = voteOpt.get();
+
+		// 2. SimilarityVoteSummaryEntity 조회
+		Optional<SimilarityVoteSummaryEntity> voteSummaryOpt = voteSummaryRepository.findByVoteId(response.voteId());
+		if (voteSummaryOpt.isEmpty()) {
+			log.error("[유사도 검사 실패] 투표 집계를 찾을 수 없습니다. voteId={}", response.voteId());
+			handleInvalidResponse(vote);
+			return;
+		}
+		SimilarityVoteSummaryEntity voteSummary = voteSummaryOpt.get();
+
+		// 3. AI 가중치 조회 (VoteProperties)
+		int aiVoteWeight = voteProperties.getAiVoteWeight();
+
+		// 4. 판단에 따라 가중치 추가
+		if (response.decision() == VoteDecision.APPROVE) {
+			voteSummary.addApproveWeight((long) aiVoteWeight);
+			voteSummary.setAiDecision(VoteDecision.APPROVE);
+			log.info("[승인 가중치 추가] voteId={}, weight={}", response.voteId(), aiVoteWeight);
+		} else if (response.decision() == VoteDecision.DENY) {
+			voteSummary.addDenyWeight((long) aiVoteWeight);
+			voteSummary.setAiDecision(VoteDecision.DENY);
+			log.info("[거부 가중치 추가] voteId={}, weight={}", response.voteId(), aiVoteWeight);
+		} else {
+			log.error("[유사도 검사 실패] 잘못된 판단 결과입니다. voteId={}, decision={}", response.voteId(), response.decision());
+			handleInvalidResponse(vote);
+			return;
+		}
+
+		// 5. SimilarityVoteSummaryEntity 저장
+		voteSummaryRepository.save(voteSummary);
+
+		log.info("[AI 유사도 검사 완료] voteId={}, aiDecision={}, approveWeight={}, denyWeight={}, totalWeight={}",
+			response.voteId(), voteSummary.getAiDecision(),
+			voteSummary.getApproveWeight(), voteSummary.getDenyWeight(), voteSummary.getTotalWeight());
+	}
+
+	/**
+	 * 잘못된 응답 처리 - VoteEntity를 CANCELLED 상태로 변경
+	 */
+	private void handleInvalidResponse(SimilarityVoteEntity vote) {
+		log.warn("[AI 판단 실패 처리] voteId={}", vote.getId());
+		vote.updateStatus(VoteStatus.CANCELLED);
+		similarityVoteRepository.save(vote);
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/vote/service/AiSimilarityRequestService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/AiSimilarityRequestService.java
@@ -1,0 +1,73 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
+
+import java.util.Optional;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.domain.vote.dto.SimilarityCheckRequestDto;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
+import hanium.modic.backend.domain.vote.enums.VoteStatus;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiSimilarityRequestService {
+
+	private final RabbitTemplate rabbitTemplate;
+	private final SimilarityVoteRepository similarityVoteRepository;
+
+	/**
+	 * AI 서버로 유사도 검사 요청 (비동기)
+	 * @param voteId 투표 ID
+	 * @param originalImagePath 원본 이미지 경로
+	 * @param derivedImagePath 파생 이미지 경로
+	 */
+	@Async
+	@Transactional
+	public void sendSimilarityCheckRequest(Long voteId, String originalImagePath, String derivedImagePath) {
+		log.info("[유사도 검사 요청] voteId={}, originalPath={}, derivedPath={}",
+			voteId, originalImagePath, derivedImagePath);
+
+		try {
+			// 1. 투표 엔티티 조회
+			Optional<SimilarityVoteEntity> voteOpt = similarityVoteRepository.findById(voteId);
+			if (voteOpt.isEmpty()) {
+				log.error("[유사도 검사 요청 실패] 투표를 찾을 수 없습니다. voteId={}", voteId);
+				return;
+			}
+			SimilarityVoteEntity vote = voteOpt.get();
+
+			// 2. 요청 DTO 생성
+			SimilarityCheckRequestDto requestDto = new SimilarityCheckRequestDto(
+				voteId,
+				originalImagePath,
+				derivedImagePath
+			);
+
+			// 3. RabbitMQ 메시지 발행
+			rabbitTemplate.convertAndSend(
+				VOTE_SIMILARITY_REQUEST_EXCHANGE,
+				VOTE_SIMILARITY_REQUEST_ROUTING_KEY,
+				requestDto
+			);
+
+			// 4. 투표 상태 → IN_PROGRESS
+			vote.updateStatus(VoteStatus.IN_PROGRESS);
+			similarityVoteRepository.save(vote);
+
+			log.info("[유사도 검사 요청 완료] voteId={}", voteId);
+
+		} catch (Exception e) {
+			log.error("[유사도 검사 요청 예외] voteId={}, error={}", voteId, e.getMessage(), e);
+			// 비동기 메서드이므로 예외를 던지지 않고 로깅만 수행
+		}
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/post/service/AiDerivedPostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/AiDerivedPostServiceTest.java
@@ -63,6 +63,9 @@ class AiDerivedPostServiceTest {
 	@Mock
 	private SimilarityVoteSummaryRepository voteSummaryRepository;
 
+	@Mock
+	private hanium.modic.backend.domain.vote.service.AiSimilarityRequestService aiSimilarityRequestService;
+
 	@InjectMocks
 	private AiDerivedPostService aiDerivedPostService;
 
@@ -72,33 +75,44 @@ class AiDerivedPostServiceTest {
 		// given
 		Long userId = 1L;
 		Long createdAiImageId = 100L;
-		Long originalImageId = 200L;
+		Long originalPostId = 1L;
 		String title = "AI Generated Post";
 		String description = "This is an AI derived post";
 		Long commercialPrice = 2000L;
 		Long nonCommercialPrice = 1000L;
 		Long ticketPrice = 300L;
-		Long postId = 1L;
+		Long newPostId = 2L;
 
 		UserEntity mockUser = UserFactory.createMockUser(userId);
 		AiChatImageEntity mockAiImage = createMockCreatedAiImageWithId(
-			createdAiImageId, userId, postId, "request-123");
-		PostEntity mockSavedPost = createMockPostWithId(postId, mockUser);
+			createdAiImageId, userId, originalPostId, "request-123");
+		PostEntity mockOriginalPost = createMockPostWithId(originalPostId, mockUser);
+		// The thumbnail image ID from mockOriginalPost will be 1L (from createMockPostWithId)
+		Long originalImageId = mockOriginalPost.getThumbnailImageId();
+		PostImageEntity mockOriginalImage = PostImageEntity.builder()
+			.imagePath("posts/original/image.jpg")
+			.fullImageName("original.jpg")
+			.imageName("original")
+			.extension(mockAiImage.getExtension())
+			.imagePurpose(ImagePrefix.POST)
+			.postEntity(mockOriginalPost)
+			.build();
+		PostEntity mockSavedPost = createMockPostWithId(newPostId, mockUser);
 
 		when(createdAiImageRepository.findById(createdAiImageId)).thenReturn(Optional.of(mockAiImage));
-		when(postEntityRepository.findById(anyLong())).thenReturn(Optional.of(mockSavedPost));
+		when(postEntityRepository.findById(originalPostId)).thenReturn(Optional.of(mockOriginalPost));
+		when(postImageEntityRepository.findById(originalImageId)).thenReturn(Optional.of(mockOriginalImage));
 		when(postEntityRepository.save(any(PostEntity.class))).thenReturn(mockSavedPost);
+		when(postImageEntityRepository.save(any(PostImageEntity.class))).thenReturn(mockOriginalImage);
+		when(voteSummaryRepository.save(any())).thenReturn(null);
 		doNothing().when(asyncPostStatisticsService).initializeStatistics(anyLong());
-		when(similarityVoteRepository.save(any(SimilarityVoteEntity.class))).thenAnswer(invocation -> {
-			SimilarityVoteEntity arg = invocation.getArgument(0);
-			return SimilarityVoteEntity.builder()
-				.originalImageId(arg.getOriginalImageId())
-				.derivedImageId(arg.getDerivedImageId())
-				.derivedPostId(1L)
-				.voteType(VoteType.SIMILARITY_CHECK)
-				.status(VoteStatus.PENDING)
-				.build();
-		});
+
+		// Create a mock vote entity with ID
+		SimilarityVoteEntity mockSavedVote = mock(SimilarityVoteEntity.class);
+		when(mockSavedVote.getId()).thenReturn(1L); // Only stub the ID which is needed
+
+		when(similarityVoteRepository.save(any(SimilarityVoteEntity.class))).thenReturn(mockSavedVote);
+		doNothing().when(aiSimilarityRequestService).sendSimilarityCheckRequest(anyLong(), anyString(), anyString());
 
 		// when
 		CreatePostResponse response = aiDerivedPostService.createAiDerivedPost(
@@ -129,6 +143,13 @@ class AiDerivedPostServiceTest {
 		assertThat(savedImage.getImageName()).isEqualTo(mockAiImage.getImageName());
 		assertThat(savedImage.getExtension()).isEqualTo(mockAiImage.getExtension());
 		assertThat(savedImage.getImagePurpose()).isEqualTo(ImagePrefix.POST);
+
+		// AI 유사도 검사 요청 검증 (이미지 경로 전달 확인)
+		verify(aiSimilarityRequestService).sendSimilarityCheckRequest(
+			anyLong(),
+			eq("posts/original/image.jpg"),
+			eq(mockAiImage.getImagePath())
+		);
 
 		verify(createdAiImageRepository, times(1)).findById(createdAiImageId);
 	}

--- a/src/test/java/hanium/modic/backend/domain/post/service/AiDerivedPostServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/post/service/AiDerivedPostServiceTest.java
@@ -8,13 +8,17 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
@@ -72,86 +76,99 @@ class AiDerivedPostServiceTest {
 	@Test
 	@DisplayName("AI 파생 포스트 생성 성공")
 	void createAiDerivedPost_Success() {
-		// given
-		Long userId = 1L;
-		Long createdAiImageId = 100L;
-		Long originalPostId = 1L;
-		String title = "AI Generated Post";
-		String description = "This is an AI derived post";
-		Long commercialPrice = 2000L;
-		Long nonCommercialPrice = 1000L;
-		Long ticketPrice = 300L;
-		Long newPostId = 2L;
+		try (MockedStatic<TransactionSynchronizationManager> mockedTxManager = mockStatic(
+			TransactionSynchronizationManager.class)) {
+			// given
+			Long userId = 1L;
+			Long createdAiImageId = 100L;
+			Long originalPostId = 1L;
+			String title = "AI Generated Post";
+			String description = "This is an AI derived post";
+			Long commercialPrice = 2000L;
+			Long nonCommercialPrice = 1000L;
+			Long ticketPrice = 300L;
+			Long newPostId = 2L;
 
-		UserEntity mockUser = UserFactory.createMockUser(userId);
-		AiChatImageEntity mockAiImage = createMockCreatedAiImageWithId(
-			createdAiImageId, userId, originalPostId, "request-123");
-		PostEntity mockOriginalPost = createMockPostWithId(originalPostId, mockUser);
-		// The thumbnail image ID from mockOriginalPost will be 1L (from createMockPostWithId)
-		Long originalImageId = mockOriginalPost.getThumbnailImageId();
-		PostImageEntity mockOriginalImage = PostImageEntity.builder()
-			.imagePath("posts/original/image.jpg")
-			.fullImageName("original.jpg")
-			.imageName("original")
-			.extension(mockAiImage.getExtension())
-			.imagePurpose(ImagePrefix.POST)
-			.postEntity(mockOriginalPost)
-			.build();
-		PostEntity mockSavedPost = createMockPostWithId(newPostId, mockUser);
+			UserEntity mockUser = UserFactory.createMockUser(userId);
+			AiChatImageEntity mockAiImage = createMockCreatedAiImageWithId(
+				createdAiImageId, userId, originalPostId, "request-123");
+			PostEntity mockOriginalPost = createMockPostWithId(originalPostId, mockUser);
+			// The thumbnail image ID from mockOriginalPost will be 1L (from createMockPostWithId)
+			Long originalImageId = mockOriginalPost.getThumbnailImageId();
+			PostImageEntity mockOriginalImage = PostImageEntity.builder()
+				.imagePath("posts/original/image.jpg")
+				.fullImageName("original.jpg")
+				.imageName("original")
+				.extension(mockAiImage.getExtension())
+				.imagePurpose(ImagePrefix.POST)
+				.postEntity(mockOriginalPost)
+				.build();
+			PostEntity mockSavedPost = createMockPostWithId(newPostId, mockUser);
 
-		when(createdAiImageRepository.findById(createdAiImageId)).thenReturn(Optional.of(mockAiImage));
-		when(postEntityRepository.findById(originalPostId)).thenReturn(Optional.of(mockOriginalPost));
-		when(postImageEntityRepository.findById(originalImageId)).thenReturn(Optional.of(mockOriginalImage));
-		when(postEntityRepository.save(any(PostEntity.class))).thenReturn(mockSavedPost);
-		when(postImageEntityRepository.save(any(PostImageEntity.class))).thenReturn(mockOriginalImage);
-		when(voteSummaryRepository.save(any())).thenReturn(null);
-		doNothing().when(asyncPostStatisticsService).initializeStatistics(anyLong());
+			when(createdAiImageRepository.findById(createdAiImageId)).thenReturn(Optional.of(mockAiImage));
+			when(postEntityRepository.findById(originalPostId)).thenReturn(Optional.of(mockOriginalPost));
+			when(postImageEntityRepository.findById(originalImageId)).thenReturn(Optional.of(mockOriginalImage));
+			when(postEntityRepository.save(any(PostEntity.class))).thenReturn(mockSavedPost);
+			when(postImageEntityRepository.save(any(PostImageEntity.class))).thenReturn(mockOriginalImage);
+			when(voteSummaryRepository.save(any())).thenReturn(null);
+			doNothing().when(asyncPostStatisticsService).initializeStatistics(anyLong());
 
-		// Create a mock vote entity with ID
-		SimilarityVoteEntity mockSavedVote = mock(SimilarityVoteEntity.class);
-		when(mockSavedVote.getId()).thenReturn(1L); // Only stub the ID which is needed
+			// Create a mock vote entity with ID
+			SimilarityVoteEntity mockSavedVote = mock(SimilarityVoteEntity.class);
+			when(mockSavedVote.getId()).thenReturn(1L); // Only stub the ID which is needed
 
-		when(similarityVoteRepository.save(any(SimilarityVoteEntity.class))).thenReturn(mockSavedVote);
-		doNothing().when(aiSimilarityRequestService).sendSimilarityCheckRequest(anyLong(), anyString(), anyString());
+			when(similarityVoteRepository.save(any(SimilarityVoteEntity.class))).thenReturn(mockSavedVote);
+			doNothing().when(aiSimilarityRequestService)
+				.sendSimilarityCheckRequest(anyLong(), anyString(), anyString());
 
-		// when
-		CreatePostResponse response = aiDerivedPostService.createAiDerivedPost(
-			userId, createdAiImageId, title, description, commercialPrice, nonCommercialPrice, ticketPrice);
+			// Mock TransactionSynchronizationManager to capture and immediately execute the callback
+			mockedTxManager.when(
+					() -> TransactionSynchronizationManager.registerSynchronization(any(TransactionSynchronization.class)))
+				.thenAnswer(invocation -> {
+					TransactionSynchronization sync = invocation.getArgument(0);
+					sync.afterCommit(); // Immediately execute the callback
+					return null;
+				});
 
-		// then
-		assertThat(response).isNotNull();
-		assertThat(response.postId()).isEqualTo(mockSavedPost.getId());
+			// when
+			CreatePostResponse response = aiDerivedPostService.createAiDerivedPost(
+				userId, createdAiImageId, title, description, commercialPrice, nonCommercialPrice, ticketPrice);
 
-		// PostEntity 저장 검증
-		ArgumentCaptor<PostEntity> postCaptor = ArgumentCaptor.forClass(PostEntity.class);
-		verify(postEntityRepository, times(1)).save(postCaptor.capture());
-		PostEntity savedPost = postCaptor.getValue();
-		assertThat(savedPost.getUserId()).isEqualTo(userId);
-		assertThat(savedPost.getTitle()).isEqualTo(title);
-		assertThat(savedPost.getDescription()).isEqualTo(description);
-		assertThat(savedPost.getCommercialPrice()).isEqualTo(commercialPrice);
-		assertThat(savedPost.getNonCommercialPrice()).isEqualTo(nonCommercialPrice);
-		assertThat(savedPost.getTicketPrice()).isEqualTo(ticketPrice);
-		assertThat(savedPost.getParentPostId()).isEqualTo(mockAiImage.getPostId()); // 부모 포스트 ID 검증
+			// then
+			assertThat(response).isNotNull();
+			assertThat(response.postId()).isEqualTo(mockSavedPost.getId());
 
-		// PostImageEntity 저장 검증
-		ArgumentCaptor<PostImageEntity> imageCaptor = ArgumentCaptor.forClass(PostImageEntity.class);
-		verify(postImageEntityRepository, times(1)).save(imageCaptor.capture());
-		PostImageEntity savedImage = imageCaptor.getValue();
-		assertThat(savedImage.getImagePath()).isEqualTo(mockAiImage.getImagePath()); // s3 이미지는 같은 것을 사용
-		assertThat(savedImage.getFullImageName()).isEqualTo(mockAiImage.getFullImageName());
-		assertThat(savedImage.getImageName()).isEqualTo(mockAiImage.getImageName());
-		assertThat(savedImage.getExtension()).isEqualTo(mockAiImage.getExtension());
-		assertThat(savedImage.getImagePurpose()).isEqualTo(ImagePrefix.POST);
+			// PostEntity 저장 검증
+			ArgumentCaptor<PostEntity> postCaptor = ArgumentCaptor.forClass(PostEntity.class);
+			verify(postEntityRepository, times(1)).save(postCaptor.capture());
+			PostEntity savedPost = postCaptor.getValue();
+			assertThat(savedPost.getUserId()).isEqualTo(userId);
+			assertThat(savedPost.getTitle()).isEqualTo(title);
+			assertThat(savedPost.getDescription()).isEqualTo(description);
+			assertThat(savedPost.getCommercialPrice()).isEqualTo(commercialPrice);
+			assertThat(savedPost.getNonCommercialPrice()).isEqualTo(nonCommercialPrice);
+			assertThat(savedPost.getTicketPrice()).isEqualTo(ticketPrice);
+			assertThat(savedPost.getParentPostId()).isEqualTo(mockAiImage.getPostId()); // 부모 포스트 ID 검증
 
-		// AI 유사도 검사 요청 검증 (이미지 경로 전달 확인)
-		verify(aiSimilarityRequestService).sendSimilarityCheckRequest(
-			anyLong(),
-			eq("posts/original/image.jpg"),
-			eq(mockAiImage.getImagePath())
-		);
+			// PostImageEntity 저장 검증
+			ArgumentCaptor<PostImageEntity> imageCaptor = ArgumentCaptor.forClass(PostImageEntity.class);
+			verify(postImageEntityRepository, times(1)).save(imageCaptor.capture());
+			PostImageEntity savedImage = imageCaptor.getValue();
+			assertThat(savedImage.getImagePath()).isEqualTo(mockAiImage.getImagePath()); // s3 이미지는 같은 것을 사용
+			assertThat(savedImage.getFullImageName()).isEqualTo(mockAiImage.getFullImageName());
+			assertThat(savedImage.getImageName()).isEqualTo(mockAiImage.getImageName());
+			assertThat(savedImage.getExtension()).isEqualTo(mockAiImage.getExtension());
+			assertThat(savedImage.getImagePurpose()).isEqualTo(ImagePrefix.POST);
 
-		verify(createdAiImageRepository, times(1)).findById(createdAiImageId);
+			// AI 유사도 검사 요청 검증 (이미지 경로 전달 확인)
+			verify(aiSimilarityRequestService).sendSimilarityCheckRequest(
+				anyLong(),
+				eq("posts/original/image.jpg"),
+				eq(mockAiImage.getImagePath())
+			);
+
+			verify(createdAiImageRepository, times(1)).findById(createdAiImageId);
+		}
 	}
 
 	@Test

--- a/src/test/java/hanium/modic/backend/domain/vote/listener/SimilarityCheckListenerTest.java
+++ b/src/test/java/hanium/modic/backend/domain/vote/listener/SimilarityCheckListenerTest.java
@@ -1,0 +1,209 @@
+package hanium.modic.backend.domain.vote.listener;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import hanium.modic.backend.common.property.property.VoteProperties;
+import hanium.modic.backend.domain.vote.dto.SimilarityCheckResponseDto;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteSummaryEntity;
+import hanium.modic.backend.domain.vote.enums.VoteDecision;
+import hanium.modic.backend.domain.vote.enums.VoteStatus;
+import hanium.modic.backend.domain.vote.enums.VoteType;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteSummaryRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SimilarityCheckListener 단위 테스트")
+class SimilarityCheckListenerTest {
+
+	@Mock
+	private SimilarityVoteRepository similarityVoteRepository;
+
+	@Mock
+	private SimilarityVoteSummaryRepository voteSummaryRepository;
+
+	@Mock
+	private VoteProperties voteProperties;
+
+	@InjectMocks
+	private SimilarityCheckListener similarityCheckListener;
+
+	@Test
+	@DisplayName("AI 승인 판단 시 - 승인 가중치 추가 및 aiDecision 업데이트")
+	void handleSimilarityCheckResponse_Approve_Success() {
+		// Given
+		Long voteId = 1L;
+		VoteDecision decision = VoteDecision.APPROVE;
+
+		SimilarityVoteEntity vote = SimilarityVoteEntity.builder()
+			.originalImageId(100L)
+			.derivedImageId(200L)
+			.derivedPostId(1L)
+			.voteType(VoteType.SIMILARITY_CHECK)
+			.status(VoteStatus.IN_PROGRESS)
+			.build();
+
+		SimilarityVoteSummaryEntity voteSummary = SimilarityVoteSummaryEntity.builder()
+			.voteId(voteId)
+			.approveWeight(0L)
+			.denyWeight(0L)
+			.totalWeight(0L)
+			.aiDecision(VoteDecision.PENDING)
+			.finalDecision(VoteDecision.PENDING)
+			.build();
+
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+		when(voteSummaryRepository.findByVoteId(voteId)).thenReturn(Optional.of(voteSummary));
+		when(voteProperties.getAiVoteWeight()).thenReturn(10);
+
+		SimilarityCheckResponseDto response = new SimilarityCheckResponseDto(voteId, decision);
+
+		// When
+		similarityCheckListener.handleSimilarityCheckResponse(response);
+
+		// Then
+		assertThat(voteSummary.getApproveWeight()).isEqualTo(10L);
+		assertThat(voteSummary.getDenyWeight()).isEqualTo(0L);
+		assertThat(voteSummary.getTotalWeight()).isEqualTo(10L);
+		assertThat(voteSummary.getAiDecision()).isEqualTo(VoteDecision.APPROVE);
+		verify(voteSummaryRepository).save(voteSummary);
+		verify(similarityVoteRepository, never()).save(any()); // VoteEntity는 상태 변경 없음
+	}
+
+	@Test
+	@DisplayName("AI 거부 판단 시 - 거부 가중치 추가 및 aiDecision 업데이트")
+	void handleSimilarityCheckResponse_Deny_Success() {
+		// Given
+		Long voteId = 1L;
+		VoteDecision decision = VoteDecision.DENY;
+
+		SimilarityVoteEntity vote = SimilarityVoteEntity.builder()
+			.originalImageId(100L)
+			.derivedImageId(200L)
+			.derivedPostId(1L)
+			.voteType(VoteType.SIMILARITY_CHECK)
+			.status(VoteStatus.IN_PROGRESS)
+			.build();
+
+		SimilarityVoteSummaryEntity voteSummary = SimilarityVoteSummaryEntity.builder()
+			.voteId(voteId)
+			.approveWeight(0L)
+			.denyWeight(0L)
+			.totalWeight(0L)
+			.aiDecision(VoteDecision.PENDING)
+			.finalDecision(VoteDecision.PENDING)
+			.build();
+
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+		when(voteSummaryRepository.findByVoteId(voteId)).thenReturn(Optional.of(voteSummary));
+		when(voteProperties.getAiVoteWeight()).thenReturn(10);
+
+		SimilarityCheckResponseDto response = new SimilarityCheckResponseDto(voteId, decision);
+
+		// When
+		similarityCheckListener.handleSimilarityCheckResponse(response);
+
+		// Then
+		assertThat(voteSummary.getApproveWeight()).isEqualTo(0L);
+		assertThat(voteSummary.getDenyWeight()).isEqualTo(10L);
+		assertThat(voteSummary.getTotalWeight()).isEqualTo(10L);
+		assertThat(voteSummary.getAiDecision()).isEqualTo(VoteDecision.DENY);
+		verify(voteSummaryRepository).save(voteSummary);
+		verify(similarityVoteRepository, never()).save(any()); // VoteEntity는 상태 변경 없음
+	}
+
+	@Test
+	@DisplayName("투표를 찾을 수 없을 때 - 저장하지 않고 종료")
+	void handleSimilarityCheckResponse_VoteNotFound_NoSave() {
+		// Given
+		Long voteId = 999L;
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.empty());
+
+		SimilarityCheckResponseDto response = new SimilarityCheckResponseDto(voteId, VoteDecision.APPROVE);
+
+		// When
+		similarityCheckListener.handleSimilarityCheckResponse(response);
+
+		// Then
+		verify(voteSummaryRepository, never()).save(any());
+		verify(similarityVoteRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("투표 집계를 찾을 수 없을 때 - VoteEntity CANCELLED로 변경")
+	void handleSimilarityCheckResponse_VoteSummaryNotFound_CancelsVote() {
+		// Given
+		Long voteId = 1L;
+
+		SimilarityVoteEntity vote = SimilarityVoteEntity.builder()
+			.originalImageId(100L)
+			.derivedImageId(200L)
+			.derivedPostId(1L)
+			.voteType(VoteType.SIMILARITY_CHECK)
+			.status(VoteStatus.IN_PROGRESS)
+			.build();
+
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+		when(voteSummaryRepository.findByVoteId(voteId)).thenReturn(Optional.empty());
+
+		SimilarityCheckResponseDto response = new SimilarityCheckResponseDto(voteId, VoteDecision.APPROVE);
+
+		// When
+		similarityCheckListener.handleSimilarityCheckResponse(response);
+
+		// Then
+		assertThat(vote.getStatus()).isEqualTo(VoteStatus.CANCELLED);
+		verify(similarityVoteRepository).save(vote);
+		verify(voteSummaryRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("잘못된 판단 결과일 때 - VoteEntity CANCELLED로 변경")
+	void handleSimilarityCheckResponse_InvalidDecision_CancelsVote() {
+		// Given
+		Long voteId = 1L;
+		VoteDecision decision = VoteDecision.PENDING; // Invalid for AI response
+
+		SimilarityVoteEntity vote = SimilarityVoteEntity.builder()
+			.originalImageId(100L)
+			.derivedImageId(200L)
+			.derivedPostId(1L)
+			.voteType(VoteType.SIMILARITY_CHECK)
+			.status(VoteStatus.IN_PROGRESS)
+			.build();
+
+		SimilarityVoteSummaryEntity voteSummary = SimilarityVoteSummaryEntity.builder()
+			.voteId(voteId)
+			.approveWeight(0L)
+			.denyWeight(0L)
+			.totalWeight(0L)
+			.aiDecision(VoteDecision.PENDING)
+			.finalDecision(VoteDecision.PENDING)
+			.build();
+
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+		when(voteSummaryRepository.findByVoteId(voteId)).thenReturn(Optional.of(voteSummary));
+
+		SimilarityCheckResponseDto response = new SimilarityCheckResponseDto(voteId, decision);
+
+		// When
+		similarityCheckListener.handleSimilarityCheckResponse(response);
+
+		// Then
+		assertThat(vote.getStatus()).isEqualTo(VoteStatus.CANCELLED);
+		assertThat(voteSummary.getAiDecision()).isEqualTo(VoteDecision.PENDING); // 변경 없음
+		verify(similarityVoteRepository).save(vote);
+		verify(voteSummaryRepository, never()).save(voteSummary);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/vote/service/AiSimilarityRequestServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/vote/service/AiSimilarityRequestServiceTest.java
@@ -1,0 +1,113 @@
+package hanium.modic.backend.domain.vote.service;
+
+import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import hanium.modic.backend.domain.vote.dto.SimilarityCheckRequestDto;
+import hanium.modic.backend.domain.vote.entity.SimilarityVoteEntity;
+import hanium.modic.backend.domain.vote.enums.VoteStatus;
+import hanium.modic.backend.domain.vote.enums.VoteType;
+import hanium.modic.backend.domain.vote.repository.SimilarityVoteRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AiSimilarityRequestService 단위 테스트")
+class AiSimilarityRequestServiceTest {
+
+	@Mock
+	private RabbitTemplate rabbitTemplate;
+
+	@Mock
+	private SimilarityVoteRepository similarityVoteRepository;
+
+	@InjectMocks
+	private AiSimilarityRequestService aiSimilarityRequestService;
+
+	@Test
+	@DisplayName("유사도 검사 요청 성공 - RabbitMQ 메시지 발행 및 VoteEntity 상태 IN_PROGRESS로 변경")
+	void sendSimilarityCheckRequest_Success() {
+		// Given
+		Long voteId = 1L;
+		String originalImagePath = "posts/original/image.jpg";
+		String derivedImagePath = "ai-response/derived/image.jpg";
+
+		SimilarityVoteEntity vote = SimilarityVoteEntity.builder()
+			.originalImageId(100L)
+			.derivedImageId(200L)
+			.derivedPostId(1L)
+			.voteType(VoteType.SIMILARITY_CHECK)
+			.status(VoteStatus.PENDING)
+			.build();
+
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.of(vote));
+
+		// When
+		aiSimilarityRequestService.sendSimilarityCheckRequest(voteId, originalImagePath, derivedImagePath);
+
+		// Then
+		verify(rabbitTemplate).convertAndSend(
+			eq(VOTE_SIMILARITY_REQUEST_EXCHANGE),
+			eq(VOTE_SIMILARITY_REQUEST_ROUTING_KEY),
+			argThat((Object dto) -> {
+				if (dto instanceof SimilarityCheckRequestDto req) {
+					return req.voteId().equals(voteId) &&
+						   req.originalImagePath().equals(originalImagePath) &&
+						   req.derivedImagePath().equals(derivedImagePath);
+				}
+				return false;
+			})
+		);
+
+		assertThat(vote.getStatus()).isEqualTo(VoteStatus.IN_PROGRESS);
+		verify(similarityVoteRepository).save(vote);
+	}
+
+	@Test
+	@DisplayName("투표를 찾을 수 없을 때 - 에러 로그 남기고 메시지 발행하지 않음")
+	void sendSimilarityCheckRequest_VoteNotFound_LogsErrorAndReturns() {
+		// Given
+		Long voteId = 999L;
+		String originalImagePath = "posts/original/image.jpg";
+		String derivedImagePath = "ai-response/derived/image.jpg";
+
+		when(similarityVoteRepository.findById(voteId)).thenReturn(Optional.empty());
+
+		// When
+		aiSimilarityRequestService.sendSimilarityCheckRequest(voteId, originalImagePath, derivedImagePath);
+
+		// Then
+		// 비동기 메서드이므로 예외를 던지지 않고 로깅만 수행
+		verify(rabbitTemplate, never()).convertAndSend(anyString(), anyString(), any(Object.class));
+		verify(similarityVoteRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("예외 발생 시 - 에러 로그 남기고 안전하게 종료")
+	void sendSimilarityCheckRequest_Exception_LogsErrorAndReturns() {
+		// Given
+		Long voteId = 1L;
+		String originalImagePath = "posts/original/image.jpg";
+		String derivedImagePath = "ai-response/derived/image.jpg";
+
+		when(similarityVoteRepository.findById(voteId)).thenThrow(new RuntimeException("Database error"));
+
+		// When
+		aiSimilarityRequestService.sendSimilarityCheckRequest(voteId, originalImagePath, derivedImagePath);
+
+		// Then
+		// 비동기 메서드이므로 예외를 던지지 않고 로깅만 수행
+		verify(rabbitTemplate, never()).convertAndSend(anyString(), anyString(), any(Object.class));
+		verify(similarityVoteRepository, never()).save(any());
+	}
+}

--- a/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/post/controller/AiDerivedPostControllerIntegrationTest.java
@@ -61,7 +61,7 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 			// given
 			UserEntity currentUser = ContextHolderUtil.getCurrentUser();
 
-			// PostEntity 생성 및 저장
+			// 먼저 임시 thumbnailImageId로 PostEntity 생성 및 저장
 			PostEntity postEntity = PostEntity.builder()
 				.userId(currentUser.getId())
 				.title("Original Post")
@@ -72,6 +72,21 @@ class AiDerivedPostControllerIntegrationTest extends BaseIntegrationTest {
 				.postStatus(PostStatus.ORIGINAL)
 				.thumbnailImageId(1L) // 임시 값
 				.build();
+			postEntity = postEntityRepository.save(postEntity);
+
+			// 원본 PostImageEntity 생성 및 저장 (서비스에서 원본 이미지 경로 조회용)
+			PostImageEntity originalPostImage = PostImageEntity.builder()
+				.imagePath("posts/original/image.jpg")
+				.fullImageName("original-image-full.jpg")
+				.imageName("original-image")
+				.extension(ImageExtension.JPG)
+				.imagePurpose(ImagePrefix.POST)
+				.postEntity(postEntity)
+				.build();
+			originalPostImage = postImageEntityRepository.save(originalPostImage);
+
+			// PostEntity의 thumbnailImageId를 실제 이미지 ID로 업데이트
+			postEntity.updateThumbnailImageId(originalPostImage.getId());
 			postEntity = postEntityRepository.save(postEntity);
 
 			// AiChatImageEntity 생성 및 저장


### PR DESCRIPTION
## 개요
AI 파생 포스트 생성 시 원본과 파생 이미지의 유사도를 AI 서버에 요청하여 자동으로 판단하는 기능을 RabbitMQ 기반 비동기로 구현했습니다.

## 주요 변경사항

### 1. DTO 추가
- `SimilarityCheckRequestDto`: AI 서버로 전송할 유사도 검사 요청
- `SimilarityCheckResponseDto`: AI 서버로부터 받을 유사도 검사 응답

### 2. RabbitMQ 설정
- 유사도 검사 요청/응답 큐, 익스체인지, 라우팅 키 추가
- 기존 AI 이미지 생성 패턴과 동일한 구조 적용

### 3. 비동기 처리 서비스
- `AiSimilarityRequestService`: RabbitMQ로 유사도 검사 요청 전송
- 투표 상태를 IN_PROGRESS로 업데이트
- 예외 발생 시 로깅 후 안전하게 종료

### 4. 응답 리스너
- `SimilarityCheckListener`: AI 서버 응답 수신 및 처리
- AI 판단 결과에 따라 가중치 추가 (APPROVE/DENY)
- 실패 시 투표를 CANCELLED 상태로 변경
- 투표 및 포스트 상태는 PENDING 유지 (사람 투표 대기)

### 5. 트랜잭션 동기화
- `TransactionSynchronization`을 사용하여 트랜잭션 커밋 후 비동기 실행
- DB 커밋 전 조회 시도로 인한 타이밍 이슈 해결

## 테스트
- `AiSimilarityRequestServiceTest`: 요청 전송 및 실패 처리 테스트
- `SimilarityCheckListenerTest`: 응답 처리 및 다양한 실패 시나리오 테스트
- `AiDerivedPostServiceTest`: 통합 테스트 업데이트
- 모든 단위 테스트 통과 (11/11)

Closes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI 유사도 검사 통합: 파생 게시물 생성 직후 유사도 검사 요청을 자동 전송하고, 결과에 따라 투표 요약에 AI 판단과 가중치를 반영합니다.
  - 투표 상태 가시성 향상: 검사 요청 시 투표 상태를 진행(IN_PROGRESS)으로 업데이트합니다.
  - 비정상 응답 처리: 응답 누락 또는 유효하지 않은 응답 발생 시 해당 투표를 취소하여 일관성 유지.

- **Tests**
  - 유사도 요청/응답 흐름에 대한 단위 및 통합 테스트 추가/확장(승인/거절/누락/예외 시나리오 포함).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->