### PR TITLE
유저 이름 검색 기능 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/user/repository/UserEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/user/repository/UserEntityRepository.java
@@ -2,7 +2,11 @@ package hanium.modic.backend.domain.user.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
@@ -12,4 +16,8 @@ public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
 	Optional<UserEntity> findByEmail(String email);
 
 	Optional<UserEntity> findByUniqueId(String uniqueId);
+
+	// Finds users whose names contain the provided keyword ignoring case.
+	@Query("SELECT u FROM UserEntity u WHERE LOWER(u.name) LIKE LOWER(CONCAT('%', :name, '%'))")
+	Page<UserEntity> findByNameContainingIgnoreCase(@Param("name") String name, Pageable pageable);
 }

--- a/src/main/java/hanium/modic/backend/domain/user/service/UserImageService.java
+++ b/src/main/java/hanium/modic/backend/domain/user/service/UserImageService.java
@@ -2,7 +2,10 @@ package hanium.modic.backend.domain.user.service;
 
 import static hanium.modic.backend.common.error.ErrorCode.*;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +50,19 @@ public class UserImageService extends ImageService {
 			.map(UserImageEntity::getImagePath)
 			.map(imageUtil::createImageGetUrl)
 			.orElseThrow(() -> new AppException(IMAGE_NOT_FOUND_EXCEPTION));
+	}
+
+	/** 여러 이미지 URL 조회, Map<Id, Url>로 응답
+	* userIds에 해당하는 이미지가 없으면 Map에 포함되지 않음
+	*/
+	@Transactional(readOnly = true)
+	public Map<Long, String> createImageGetUrlMap(final List<Long> userIds) {
+		// 1. 이미지 엔티티 조회
+		List<UserImageEntity> images = userImageRepository.findAllByUserIdIn(userIds);
+
+		// 2. Map<userId, imagePath> 형태로 변환
+		return images.stream()
+			.collect(Collectors.toMap(UserImageEntity::getUserId, UserImageEntity::getImagePath));
 	}
 
 	// 이미지 삭제

--- a/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
+++ b/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.domain.user.service;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -79,16 +80,17 @@ public class UserService {
 		// 1. 이름으로 유저 목록 조회
 		Page<UserEntity> users = userEntityRepository.findByNameContainingIgnoreCase(keyword, pageable);
 
-		// 2. 유저들 프로필 조회
-		userImageEntityRepository.findAllByUserIdIn(
+		// 2.한번에 이미지 조회
+		Map<Long, String> imageGetUrlMap = userImageService.createImageGetUrlMap(
 			users.map(UserEntity::getId).toList()
 		);
 
+		// 3. 각 유저의 이미지 URL 조회 및 응답 변환
 		return users.map(user -> {
-			final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
-			final boolean hasUserImage = userImageUrl.isPresent();
+			final boolean hasUserImage = imageGetUrlMap.containsKey(user.getId());
+			final String resolvedImageUrl = imageGetUrlMap.getOrDefault(user.getId(), null);
 
-			return SearchUsersResponse.of(user, hasUserImage, userImageUrl.orElse(null));
+			return SearchUsersResponse.of(user, hasUserImage, resolvedImageUrl);
 		});
 	}
 

--- a/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
+++ b/src/main/java/hanium/modic/backend/domain/user/service/UserService.java
@@ -2,6 +2,10 @@ package hanium.modic.backend.domain.user.service;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +16,9 @@ import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.entity.UserUpdateToken;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.repository.UserImageEntityRepository;
 import hanium.modic.backend.domain.user.repository.UserUpdateTokenRepository;
+import hanium.modic.backend.web.user.dto.response.SearchUsersResponse;
 import hanium.modic.backend.web.user.dto.response.UserCreateResponse;
 import hanium.modic.backend.web.user.dto.response.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +33,7 @@ public class UserService {
 	private final UserUpdateTokenRepository userUpdateTokenRepository;
 	private final AuthService authService;
 	private final UserImageService userImageService;
+	private final UserImageEntityRepository userImageEntityRepository;
 
 	// 회원가입
 	@Transactional
@@ -62,6 +69,27 @@ public class UserService {
 	public UserInfoResponse getUserInfo(UserEntity user) {
 		Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
 		return UserInfoResponse.of(user, userImageUrl.orElse(null));
+	}
+
+	// 이름으로 회원 목록 조회
+	@Transactional(readOnly = true)
+	public Page<SearchUsersResponse> searchUsersByName(final String keyword, final int page, final int size) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name"));
+
+		// 1. 이름으로 유저 목록 조회
+		Page<UserEntity> users = userEntityRepository.findByNameContainingIgnoreCase(keyword, pageable);
+
+		// 2. 유저들 프로필 조회
+		userImageEntityRepository.findAllByUserIdIn(
+			users.map(UserEntity::getId).toList()
+		);
+
+		return users.map(user -> {
+			final Optional<String> userImageUrl = userImageService.createImageGetUrlOptional(user.getId());
+			final boolean hasUserImage = userImageUrl.isPresent();
+
+			return SearchUsersResponse.of(user, hasUserImage, userImageUrl.orElse(null));
+		});
 	}
 
 	// 유저 이름 변경

--- a/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
+++ b/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
@@ -80,7 +80,6 @@ public class UserController {
 		responses = {
 			@ApiResponse(responseCode = "400", description = "입력값 검증 실패[C-001]"),
 			@ApiResponse(responseCode = "401", description = "인증 필요[A-001]"),
-			@ApiResponse(responseCode = "404", description = "요청한 사용자를 찾을 수 없습니다.[U-002]")
 		}
 	)
 	public ResponseEntity<AppResponse<PageResponse<SearchUsersResponse>>> searchUsersByName(
@@ -89,7 +88,7 @@ public class UserController {
 		@RequestParam(required = false, defaultValue = "10") @Min(value = 10, message = "페이지 크기는 10 이상이어야 합니다.") @Max(value = 20, message = "페이지 크기는 20 이하여야 합니다.") Integer size
 	) {
 		Page<SearchUsersResponse> result = userService.searchUsersByName(
-			keyword, page, size
+			keyword.strip(), page, size
 		);
 		return ResponseEntity.ok(AppResponse.ok(PageResponse.of(result)));
 	}

--- a/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
+++ b/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package hanium.modic.backend.web.user.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,10 +8,12 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
 import hanium.modic.backend.common.response.AppResponse;
+import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.service.UserCoinService;
 import hanium.modic.backend.domain.user.service.UserService;
@@ -22,11 +25,15 @@ import hanium.modic.backend.web.user.dto.request.UpdateUserPasswordRequest;
 import hanium.modic.backend.web.user.dto.request.UserCreateRequest;
 import hanium.modic.backend.web.user.dto.response.GetCoinBalanceResponse;
 import hanium.modic.backend.web.user.dto.response.GetUserUpdateTokenResponse;
+import hanium.modic.backend.web.user.dto.response.SearchUsersResponse;
 import hanium.modic.backend.web.user.dto.response.UserCreateResponse;
 import hanium.modic.backend.web.user.dto.response.UserInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -63,6 +70,28 @@ public class UserController {
 	)
 	public ResponseEntity<AppResponse<UserInfoResponse>> getUserInfo(@CurrentUser UserEntity user) {
 		return ResponseEntity.ok(AppResponse.ok(userService.getUserInfo(user)));
+	}
+
+	// Searches users by name keyword and returns paginated results.
+	@GetMapping("/search")
+	@Operation(
+		summary = "사용자 이름 검색 API",
+		description = "검색어를 기반으로 사용자 목록을 페이지 단위로 조회합니다. page는 0부터 시작합니다.",
+		responses = {
+			@ApiResponse(responseCode = "400", description = "입력값 검증 실패[C-001]"),
+			@ApiResponse(responseCode = "401", description = "인증 필요[A-001]"),
+			@ApiResponse(responseCode = "404", description = "요청한 사용자를 찾을 수 없습니다.[U-002]")
+		}
+	)
+	public ResponseEntity<AppResponse<PageResponse<SearchUsersResponse>>> searchUsersByName(
+		@RequestParam @NotBlank(message = "검색어는 필수입니다.") String keyword,
+		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다") Integer page,
+		@RequestParam(required = false, defaultValue = "10") @Min(value = 10, message = "페이지 크기는 10 이상이어야 합니다.") @Max(value = 20, message = "페이지 크기는 20 이하여야 합니다.") Integer size
+	) {
+		Page<SearchUsersResponse> result = userService.searchUsersByName(
+			keyword, page, size
+		);
+		return ResponseEntity.ok(AppResponse.ok(PageResponse.of(result)));
 	}
 
 	@PatchMapping("/name")

--- a/src/main/java/hanium/modic/backend/web/user/dto/response/SearchUsersResponse.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/response/SearchUsersResponse.java
@@ -1,0 +1,15 @@
+package hanium.modic.backend.web.user.dto.response;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+
+public record SearchUsersResponse(
+	Long id,
+	String name,
+	boolean hasUserImage,
+	String userImageUrl
+) {
+
+	public static SearchUsersResponse of(UserEntity user, boolean hasUserImage, String resolvedImageUrl) {
+		return new SearchUsersResponse(user.getId(), user.getName(), hasUserImage, resolvedImageUrl);
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/user/repository/UserEntityRepositoryTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/repository/UserEntityRepositoryTest.java
@@ -1,0 +1,57 @@
+package hanium.modic.backend.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.factory.UserFactory;
+
+@DataJpaTest
+class UserEntityRepositoryTest {
+
+	@Autowired
+	private UserEntityRepository userEntityRepository;
+
+	// Finds users whose names contain the given keyword ignoring case.
+	@Test
+	@DisplayName("이름이 포함된 회원을 페이지로 조회한다")
+	void findByNameContainingIgnoreCase_returnsMatchingUsers() {
+		UserEntity alice = userEntityRepository.save(UserFactory.createMockUserWithoutId("Alice"));
+		UserEntity albert = userEntityRepository.save(UserFactory.createMockUserWithoutId("Albert"));
+		userEntityRepository.save(UserFactory.createMockUserWithoutId("Bob"));
+
+		PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name"));
+
+		Page<UserEntity> result = userEntityRepository.findByNameContainingIgnoreCase("al", pageable);
+
+		List<String> names = result.getContent().stream()
+			.map(UserEntity::getName)
+			.toList();
+
+		assertThat(result.getTotalElements()).isEqualTo(2);
+		assertThat(names).containsExactly(albert.getName(), alice.getName());
+	}
+
+	// Returns an empty page when no users match the keyword.
+	@Test
+	@DisplayName("검색 결과가 없으면 빈 페이지를 반환한다")
+	void findByNameContainingIgnoreCase_returnsEmptyPageWhenNoMatch() {
+		userEntityRepository.save(UserFactory.createMockUserWithoutId("Charlie"));
+
+		PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name"));
+
+		Page<UserEntity> result = userEntityRepository.findByNameContainingIgnoreCase("zzz", pageable);
+
+		assertThat(result.getContent()).isEmpty();
+		assertThat(result.getTotalElements()).isZero();
+	}
+}

--- a/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -135,7 +136,6 @@ class UserServiceTest {
 		assertThat(response.userName()).isEqualTo(user.getName());
 	}
 
-	// Searches users and returns mapped page with image urls.
 	@Test
 	@DisplayName("사용자 이름 검색 시 페이지 결과 반환")
 	void searchUsersByName_success() {
@@ -151,7 +151,7 @@ class UserServiceTest {
 		);
 
 		when(userEntityRepository.findByNameContainingIgnoreCase(eq("user"), any(Pageable.class))).thenReturn(users);
-		when(userImageEntityRepository.findAllByUserIdIn(List.of(1L, 2L))).thenReturn(List.of());
+		when(userImageService.createImageGetUrlMap(List.of(1L, 2L))).thenReturn(Map.of());
 
 		Page<SearchUsersResponse> result = userService.searchUsersByName(keyword, page, size);
 
@@ -167,7 +167,6 @@ class UserServiceTest {
 		assertThat(pageable.getSort().getOrderFor("name").getDirection()).isEqualTo(Sort.Direction.ASC);
 	}
 
-	// Returns empty page when no users satisfy the keyword.
 	@Test
 	@DisplayName("사용자 이름 검색 시 결과가 없으면 빈 페이지 반환")
 	void searchUsersByName_emptyResult() {
@@ -188,29 +187,6 @@ class UserServiceTest {
 		assertThat(result.getContent()).isEmpty();
 		assertThat(result.getTotalElements()).isZero();
 		verify(userImageService, never()).createImageGetUrl(anyLong());
-	}
-
-	// Maps missing image urls to null when image service throws not-found.
-	@Test
-	@DisplayName("사용자 이미지가 없으면 null 로 반환")
-	void searchUsersByName_missingImage() {
-		final String keyword = "user";
-		final int page = 0;
-		final int size = 10;
-		UserEntity user = UserFactory.createMockUser(10L);
-		Page<UserEntity> users = new PageImpl<>(
-			List.of(user),
-			PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name")),
-			1
-		);
-
-		when(userEntityRepository.findByNameContainingIgnoreCase(eq("user"), any(Pageable.class))).thenReturn(users);
-		when(userImageEntityRepository.findAllByUserIdIn(List.of(10L))).thenReturn(List.of());
-
-		Page<SearchUsersResponse> result = userService.searchUsersByName(keyword, page, size);
-
-		assertThat(result.getContent()).hasSize(1);
-		assertThat(result.getContent().get(0).userImageUrl()).isNull();
 	}
 
 	@Test

--- a/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
@@ -4,12 +4,20 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import hanium.modic.backend.common.error.ErrorCode;
@@ -18,7 +26,9 @@ import hanium.modic.backend.domain.auth.service.AuthService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
+import hanium.modic.backend.domain.user.repository.UserImageEntityRepository;
 import hanium.modic.backend.domain.user.repository.UserUpdateTokenRepository;
+import hanium.modic.backend.web.user.dto.response.SearchUsersResponse;
 import hanium.modic.backend.web.user.dto.response.UserCreateResponse;
 import hanium.modic.backend.web.user.dto.response.UserInfoResponse;
 
@@ -42,6 +52,9 @@ class UserServiceTest {
 
 	@Mock
 	private UserImageService userImageService;
+
+	@Mock
+	private UserImageEntityRepository userImageEntityRepository;
 
 	@Test
 	@DisplayName("유저 회원가입 테스트")
@@ -120,6 +133,84 @@ class UserServiceTest {
 		assertThat(response.id()).isEqualTo(userId);
 		assertThat(response.userEmail()).isEqualTo(user.getEmail());
 		assertThat(response.userName()).isEqualTo(user.getName());
+	}
+
+	// Searches users and returns mapped page with image urls.
+	@Test
+	@DisplayName("사용자 이름 검색 시 페이지 결과 반환")
+	void searchUsersByName_success() {
+		final String keyword = "user";
+		final int page = 0;
+		final int size = 10;
+		UserEntity first = UserFactory.createMockUser(1L);
+		UserEntity second = UserFactory.createMockUser(2L);
+		Page<UserEntity> users = new PageImpl<>(
+			List.of(first, second),
+			PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name")),
+			2
+		);
+
+		when(userEntityRepository.findByNameContainingIgnoreCase(eq("user"), any(Pageable.class))).thenReturn(users);
+		when(userImageEntityRepository.findAllByUserIdIn(List.of(1L, 2L))).thenReturn(List.of());
+
+		Page<SearchUsersResponse> result = userService.searchUsersByName(keyword, page, size);
+
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().get(0).userImageUrl()).isEqualTo(null);
+		assertThat(result.getContent().get(1).userImageUrl()).isEqualTo(null);
+
+		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(userEntityRepository).findByNameContainingIgnoreCase(eq("user"), pageableCaptor.capture());
+		Pageable pageable = pageableCaptor.getValue();
+		assertThat(pageable.getPageNumber()).isEqualTo(page);
+		assertThat(pageable.getPageSize()).isEqualTo(size);
+		assertThat(pageable.getSort().getOrderFor("name").getDirection()).isEqualTo(Sort.Direction.ASC);
+	}
+
+	// Returns empty page when no users satisfy the keyword.
+	@Test
+	@DisplayName("사용자 이름 검색 시 결과가 없으면 빈 페이지 반환")
+	void searchUsersByName_emptyResult() {
+		final String keyword = "absent";
+		final int page = 0;
+		final int size = 10;
+		Page<UserEntity> emptyPage = new PageImpl<>(
+			List.of(),
+			PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name")),
+			0
+		);
+
+		when(userEntityRepository.findByNameContainingIgnoreCase(eq("absent"), any(Pageable.class)))
+			.thenReturn(emptyPage);
+
+		Page<SearchUsersResponse> result = userService.searchUsersByName(keyword, page, size);
+
+		assertThat(result.getContent()).isEmpty();
+		assertThat(result.getTotalElements()).isZero();
+		verify(userImageService, never()).createImageGetUrl(anyLong());
+	}
+
+	// Maps missing image urls to null when image service throws not-found.
+	@Test
+	@DisplayName("사용자 이미지가 없으면 null 로 반환")
+	void searchUsersByName_missingImage() {
+		final String keyword = "user";
+		final int page = 0;
+		final int size = 10;
+		UserEntity user = UserFactory.createMockUser(10L);
+		Page<UserEntity> users = new PageImpl<>(
+			List.of(user),
+			PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "name")),
+			1
+		);
+
+		when(userEntityRepository.findByNameContainingIgnoreCase(eq("user"), any(Pageable.class))).thenReturn(users);
+		when(userImageEntityRepository.findAllByUserIdIn(List.of(10L))).thenReturn(List.of());
+
+		Page<SearchUsersResponse> result = userService.searchUsersByName(keyword, page, size);
+
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).userImageUrl()).isNull();
 	}
 
 	@Test

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -35,6 +37,7 @@ import hanium.modic.backend.web.user.dto.request.UpdateUserPasswordRequest;
 import hanium.modic.backend.web.user.dto.request.UserCreateRequest;
 import hanium.modic.backend.web.user.dto.request.GetUserUpdateTokenRequest;
 import hanium.modic.backend.web.user.dto.request.UpdateUserEmailRequest;
+import hanium.modic.backend.web.user.dto.response.SearchUsersResponse;
 import hanium.modic.backend.web.user.dto.response.UserInfoResponse;
 
 @WebMvcTest(controllers = UserController.class)
@@ -147,6 +150,16 @@ class UserControllerTest extends BaseControllerTest {
 			.andExpect(jsonPath("$.data.userEmail").value(mockUser.getEmail()));
 
 		SecurityContextHolder.clearContext();
+	}
+
+	// Returns 400 when search keyword is missing.
+	@Test
+	@DisplayName("사용자 이름 검색 API는 검색어 없이 호출되면 400을 반환한다")
+	void searchUsersByName_validationFail() throws Exception {
+		mockMvc.perform(get("/api/users/search")
+				.param("page", "0")
+				.param("size", "20"))
+			.andExpect(status().isBadRequest());
 	}
 
 	@ParameterizedTest(name = "[{index}] {0}")


### PR DESCRIPTION
### 개요
close https://github.com/Modic-2025/modic_backend/issues/195
### 작업사항
- 유저 이름 검색 기능 구현
### 아쉬운 점
- 검색 기능의 비중이 높지 않아, 단순 LIKE 쿼리를 통해 해결햇지만, 추후 상황에 따라 Elastic Search 도입 고려


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 이름 키워드로 사용자 검색 기능 추가(대소문자 무시, 부분 일치).
  - 페이지네이션 지원(페이지/크기 기본값 및 범위 검증 포함) 및 이름 오름차순 정렬.
  - 검색 결과에 사용자 이미지 존재 여부와 이미지 URL 포함.

- **Tests**
  - 저장소 레벨에서 키워드 검색 및 정렬 검증 테스트 추가.
  - 서비스 레벨에서 페이지네이션, 빈 결과 및 이미지 처리 검증 테스트 추가.
  - 컨트롤러 레벨에서 검색 파라미터 유효성 검증(키워드 누락 시 400) 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->