### PR TITLE
AI 이미지 생성 응답 큐 DLQ 및 재시도 메커니즘 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
+++ b/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
@@ -38,6 +38,14 @@ public class RabbitMqConfig {
 	public static final String AI_IMAGE_REQUEST_DLQ_ROUTING_KEY = "ai.image.request.dlq";
 	public static final String AI_IMAGE_REQUEST_RETRY_ROUTING_KEY = "ai.image.request.retry";
 
+	// DLQ (Dead Letter Queue) 및 재시도 관련 상수 - AI Image Created
+	public static final String AI_IMAGE_CREATED_DLX = "ai.image.created.dlx";
+	public static final String AI_IMAGE_CREATED_DLQ = "ai.image.created.dlq";
+	public static final String AI_IMAGE_CREATED_RETRY_EXCHANGE = "ai.image.created.retry.exchange";
+	public static final String AI_IMAGE_CREATED_RETRY_QUEUE = "ai.image.created.retry.queue";
+	public static final String AI_IMAGE_CREATED_DLQ_ROUTING_KEY = "ai.image.created.dlq";
+	public static final String AI_IMAGE_CREATED_RETRY_ROUTING_KEY = "ai.image.created.retry";
+
 	// Similarity Check Request
 	public static final String VOTE_SIMILARITY_REQUEST_QUEUE = "vote.similarity.request.queue";
 	public static final String VOTE_SIMILARITY_REQUEST_EXCHANGE = "vote.similarity.request.exchange";
@@ -72,7 +80,10 @@ public class RabbitMqConfig {
 
 	@Bean
 	public Queue aiImageCreatedQueue() {
-		return new Queue(AI_IMAGE_CREATED_QUEUE, true);
+		Map<String, Object> args = new HashMap<>();
+		args.put("x-dead-letter-exchange", AI_IMAGE_CREATED_DLX);
+		args.put("x-dead-letter-routing-key", AI_IMAGE_CREATED_RETRY_ROUTING_KEY);
+		return new Queue(AI_IMAGE_CREATED_QUEUE, true, false, false, args);
 	}
 
 	@Bean
@@ -85,6 +96,60 @@ public class RabbitMqConfig {
 		return BindingBuilder.bind(aiImageCreatedQueue)
 			.to(aiImageCreatedExchange)
 			.with(AI_IMAGE_CREATED_ROUTING_KEY);
+	}
+
+	// DLX (Dead Letter Exchange) - AI Image Created
+	@Bean
+	public TopicExchange aiImageCreatedDlx() {
+		return new TopicExchange(AI_IMAGE_CREATED_DLX, true, false);
+	}
+
+	// 최종 실패 메시지 저장소
+	@Bean
+	public Queue aiImageCreatedDlq() {
+		return new Queue(AI_IMAGE_CREATED_DLQ, true);
+	}
+
+	// DLX에서 최종 DLQ로의 바인딩
+	@Bean
+	public Binding aiImageCreatedDlqBinding(Queue aiImageCreatedDlq, TopicExchange aiImageCreatedDlx) {
+		return BindingBuilder.bind(aiImageCreatedDlq)
+			.to(aiImageCreatedDlx)
+			.with(AI_IMAGE_CREATED_DLQ_ROUTING_KEY);
+	}
+
+	// 재시도용 Exchange
+	@Bean
+	public TopicExchange aiImageCreatedRetryExchange() {
+		return new TopicExchange(AI_IMAGE_CREATED_RETRY_EXCHANGE, true, false);
+	}
+
+	// 재시도 대기 Queue (TTL 60초 설정, 만료 시 원래 exchange로 재전송)
+	@Bean
+	public Queue aiImageCreatedRetryQueue() {
+		Map<String, Object> args = new HashMap<>();
+		args.put("x-message-ttl", 60000); // 60초
+		args.put("x-dead-letter-exchange", AI_IMAGE_CREATED_EXCHANGE);
+		args.put("x-dead-letter-routing-key", AI_IMAGE_CREATED_ROUTING_KEY);
+		return new Queue(AI_IMAGE_CREATED_RETRY_QUEUE, true, false, false, args);
+	}
+
+	// 재시도 Exchange와 Queue 바인딩
+	@Bean
+	public Binding aiImageCreatedRetryBinding(Queue aiImageCreatedRetryQueue,
+		TopicExchange aiImageCreatedRetryExchange) {
+		return BindingBuilder.bind(aiImageCreatedRetryQueue)
+			.to(aiImageCreatedRetryExchange)
+			.with(AI_IMAGE_CREATED_RETRY_ROUTING_KEY);
+	}
+
+	// DLX에서 재시도 Exchange로의 바인딩
+	@Bean
+	public Binding aiImageCreatedDlxToRetryBinding(TopicExchange aiImageCreatedRetryExchange,
+		TopicExchange aiImageCreatedDlx) {
+		return BindingBuilder.bind(aiImageCreatedRetryExchange)
+			.to(aiImageCreatedDlx)
+			.with(AI_IMAGE_CREATED_RETRY_ROUTING_KEY);
 	}
 
 	// DLX (Dead Letter Exchange) - 실패한 메시지를 받아서 재시도 또는 최종 처리로 라우팅

--- a/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
+++ b/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
@@ -9,6 +9,7 @@ import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -261,6 +262,21 @@ public class RabbitMqConfig {
 			}
 		}
 		return connectionFactory;
+	}
+
+	@Bean
+	public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+		CachingConnectionFactory connectionFactory) {
+		SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+		factory.setConnectionFactory(connectionFactory);
+		factory.setMessageConverter(jackson2JsonMessageConverter());
+
+		// 리스너에서 예외 발생 시 메시지를 다시 큐로 반환하지 않음
+		// DLQ가 설정된 큐는 x-dead-letter-exchange를 통해 DLX로 라우팅되고
+		// DLQ에서 실패해도 무한 루프가 발생하지 않음
+		factory.setDefaultRequeueRejected(false);
+
+		return factory;
 	}
 
 	@Bean

--- a/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
+++ b/src/main/java/hanium/modic/backend/common/amqp/config/RabbitMqConfig.java
@@ -251,10 +251,14 @@ public class RabbitMqConfig {
 
 		connectionFactory.setRequestedHeartBeat(120); // 2분
 
-		try {
-			connectionFactory.getRabbitConnectionFactory().useSslProtocol("TLSv1.2");
-		} catch (Exception e) {
-			throw new RuntimeException("RabbitMQ SSL 설정 실패", e);
+		// AWS AmazonMQ는 포트 5671에서 자동으로 SSL을 사용
+		// 포트 5671일 경우에만 SSL 프로토콜 활성화
+		if (rabbitMqProperties.getPort() == 5671) {
+			try {
+				connectionFactory.getRabbitConnectionFactory().useSslProtocol();
+			} catch (Exception e) {
+				throw new RuntimeException("RabbitMQ SSL 설정 실패", e);
+			}
 		}
 		return connectionFactory;
 	}

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/dto/ChatMessageResponse.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/dto/ChatMessageResponse.java
@@ -35,4 +35,17 @@ public record ChatMessageResponse(
 	public static ChatMessageResponse from(AiChatMessageEntity entity) {
 		return from(entity, null);
 	}
+
+	public static ChatMessageResponse createErrorResponse(AiChatMessageEntity entity, String errorMessage) {
+		return new ChatMessageResponse(
+			entity.getId(),
+			entity.getMessageOrder(),
+			SenderType.AI,
+			errorMessage,
+			entity.getRequestId(),
+			null,
+			entity.getCreateAt(),
+			AiImageStatus.RESPONSE_FAILED
+		);
+	}
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/enums/AiImageStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/enums/AiImageStatus.java
@@ -4,5 +4,6 @@ public enum AiImageStatus {
 	REQUEST, // 요청 상태 및 요청 완료 상태
 	REQUEST_PENDING, // AI 요청 대기 상태
 	REQUEST_FAILED, // AI 요청 실패 상태
-	RESPONSE // 응답을 의미
+	RESPONSE, // 응답을 의미
+	RESPONSE_FAILED // 응답 처리 실패 상태
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedDlqListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedDlqListener.java
@@ -1,0 +1,71 @@
+package hanium.modic.backend.domain.ai.aiServer.listener;
+
+import static hanium.modic.backend.common.amqp.config.RabbitMqConfig.*;
+
+import java.util.Optional;
+
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import hanium.modic.backend.domain.ai.aiChat.dto.ChatMessageResponse;
+import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
+import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageRepository;
+import hanium.modic.backend.domain.ai.aiServer.dto.AiImageResponseMessageDto;
+import hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
+import hanium.modic.backend.domain.ai.aiServer.service.AiResponseSseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiImageCreatedDlqListener {
+
+	private final AiChatMessageRepository aiChatMessageRepository;
+	private final AiResponseSseService aiResponseSseService;
+
+	/**
+	 * AI 이미지 생성 응답 처리 최종 실패 메시지 처리
+	 * - 메시지 상태를 RESPONSE_FAILED로 변경
+	 * - SSE 연결이 있으면 클라이언트에 실패 알림
+	 * @param messageDto AI 이미지 응답 메시지
+	 * @param message RabbitMQ 메시지 메타데이터
+	 */
+	@Transactional
+	@RabbitListener(queues = AI_IMAGE_CREATED_DLQ)
+	public void handleFinalFailedMessage(AiImageResponseMessageDto messageDto, Message message) {
+		log.error("[최종 실패] AI 이미지 생성 응답 처리 최종 실패: requestId={}", messageDto.requestId());
+
+		// 1. 요청 메시지 조회
+		Optional<AiChatMessageEntity> chatMessageOpt = aiChatMessageRepository
+			.findByRequestIdAndSenderType(messageDto.requestId(), SenderType.USER);
+
+		if (chatMessageOpt.isEmpty()) {
+			log.error("[데이터 오류] requestId={}에 해당하는 채팅 메시지를 찾을 수 없습니다", messageDto.requestId());
+			return;
+		}
+
+		AiChatMessageEntity requestChatMessage = chatMessageOpt.get();
+
+		// 2. 메시지 상태를 RESPONSE_FAILED로 변경
+		requestChatMessage.updateStatus(AiImageStatus.RESPONSE_FAILED);
+		aiChatMessageRepository.save(requestChatMessage);
+		log.info("[상태 업데이트] requestId={} 메시지 상태를 RESPONSE_FAILED로 변경", messageDto.requestId());
+
+		// 3. SSE 연결이 있으면 클라이언트에 실패 알림
+		try {
+			ChatMessageResponse errorResponse = ChatMessageResponse.createErrorResponse(
+				requestChatMessage,
+				"이미지 생성 응답 처리에 실패했습니다. 잠시 후 다시 시도해주세요."
+			);
+			aiResponseSseService.sendToClient(messageDto.requestId(), errorResponse);
+			log.info("[SSE 알림] requestId={} 클라이언트에 실패 알림 전송", messageDto.requestId());
+		} catch (Exception e) {
+			log.warn("[SSE 알림 실패] requestId={} SSE 연결이 없거나 전송 실패: {}",
+				messageDto.requestId(), e.getMessage());
+		}
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedDlqListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedDlqListener.java
@@ -9,13 +9,13 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import hanium.modic.backend.domain.ai.aiChat.dto.ChatMessageResponse;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageRepository;
 import hanium.modic.backend.domain.ai.aiServer.dto.AiImageResponseMessageDto;
 import hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 import hanium.modic.backend.domain.ai.aiServer.service.AiResponseSseService;
+import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/hanium/modic/backend/web/ai/aiChat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/hanium/modic/backend/web/ai/aiChat/dto/response/ChatMessageResponse.java
@@ -35,4 +35,17 @@ public record ChatMessageResponse(
 	public static ChatMessageResponse from(AiChatMessageEntity entity) {
 		return from(entity, null);
 	}
+
+	public static ChatMessageResponse createErrorResponse(AiChatMessageEntity entity, String errorMessage) {
+		return new ChatMessageResponse(
+			entity.getId(),
+			entity.getMessageOrder(),
+			SenderType.AI,
+			errorMessage,
+			entity.getRequestId(),
+			null,
+			entity.getCreateAt(),
+			AiImageStatus.RESPONSE_FAILED
+		);
+	}
 }

--- a/src/test/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedDlqListenerTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedDlqListenerTest.java
@@ -1,0 +1,209 @@
+package hanium.modic.backend.domain.ai.aiServer.listener;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+
+import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
+import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageRepository;
+import hanium.modic.backend.domain.ai.aiServer.dto.AiImageResponseMessageDto;
+import hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
+import hanium.modic.backend.domain.ai.aiServer.service.AiResponseSseService;
+import hanium.modic.backend.domain.image.domain.ImageExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AiImageCreatedDlqListener 단위 테스트")
+class AiImageCreatedDlqListenerTest {
+
+	@Mock
+	private AiChatMessageRepository aiChatMessageRepository;
+
+	@Mock
+	private AiResponseSseService aiResponseSseService;
+
+	@InjectMocks
+	private AiImageCreatedDlqListener aiImageCreatedDlqListener;
+
+	@Test
+	@DisplayName("DLQ 메시지 처리 성공 - 메시지 상태를 RESPONSE_FAILED로 변경")
+	void handleFinalFailedMessage_Success() {
+		// Given
+		String requestId = "test-request-id-123";
+
+		AiImageResponseMessageDto messageDto = new AiImageResponseMessageDto(
+			true,
+			requestId,
+			true,
+			null,
+			"/images/test.png",
+			"test_20250112.png",
+			"test",
+			ImageExtension.PNG,
+			"Test image",
+			"Chat summary",
+			false
+		);
+
+		AiChatMessageEntity requestChatMessage = AiChatMessageEntity.builder()
+			.userId(1L)
+			.postId(100L)
+			.aiChatRoomId(10L)
+			.messageOrder(1L)
+			.senderType(SenderType.USER)
+			.textContent("Generate an image")
+			.requestId(requestId)
+			.status(AiImageStatus.REQUEST_PENDING)
+			.build();
+
+		Message message = new Message(new byte[0], new MessageProperties());
+
+		when(aiChatMessageRepository.findByRequestIdAndSenderType(requestId, SenderType.USER))
+			.thenReturn(Optional.of(requestChatMessage));
+
+		// When
+		aiImageCreatedDlqListener.handleFinalFailedMessage(messageDto, message);
+
+		// Then
+		assertThat(requestChatMessage.getStatus()).isEqualTo(AiImageStatus.RESPONSE_FAILED);
+		verify(aiChatMessageRepository).save(requestChatMessage);
+		verify(aiResponseSseService).sendToClient(eq(requestId), any());
+	}
+
+	@Test
+	@DisplayName("메시지를 찾을 수 없을 때 - 저장하지 않고 종료")
+	void handleFinalFailedMessage_MessageNotFound_NoSave() {
+		// Given
+		String requestId = "not-found-request-id";
+
+		AiImageResponseMessageDto messageDto = new AiImageResponseMessageDto(
+			false,
+			requestId,
+			false,
+			"Error occurred",
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+
+		Message message = new Message(new byte[0], new MessageProperties());
+
+		when(aiChatMessageRepository.findByRequestIdAndSenderType(requestId, SenderType.USER))
+			.thenReturn(Optional.empty());
+
+		// When
+		aiImageCreatedDlqListener.handleFinalFailedMessage(messageDto, message);
+
+		// Then
+		verify(aiChatMessageRepository, never()).save(any());
+		verify(aiResponseSseService, never()).sendToClient(anyString(), any());
+	}
+
+	@Test
+	@DisplayName("SSE 전송 실패 시 - 예외를 삼키고 정상 종료")
+	void handleFinalFailedMessage_SseFailure_ContinuesExecution() {
+		// Given
+		String requestId = "test-request-id-456";
+
+		AiImageResponseMessageDto messageDto = new AiImageResponseMessageDto(
+			true,
+			requestId,
+			true,
+			null,
+			"/images/test2.png",
+			"test2_20250112.png",
+			"test2",
+			ImageExtension.PNG,
+			"Test image 2",
+			"Chat summary 2",
+			false
+		);
+
+		AiChatMessageEntity requestChatMessage = AiChatMessageEntity.builder()
+			.userId(2L)
+			.postId(200L)
+			.aiChatRoomId(20L)
+			.messageOrder(1L)
+			.senderType(SenderType.USER)
+			.textContent("Generate another image")
+			.requestId(requestId)
+			.status(AiImageStatus.REQUEST_PENDING)
+			.build();
+
+		Message message = new Message(new byte[0], new MessageProperties());
+
+		when(aiChatMessageRepository.findByRequestIdAndSenderType(requestId, SenderType.USER))
+			.thenReturn(Optional.of(requestChatMessage));
+
+		doThrow(new RuntimeException("SSE connection not found"))
+			.when(aiResponseSseService).sendToClient(anyString(), any());
+
+		// When & Then - 예외가 발생해도 메서드는 정상 종료되어야 함
+		assertThatCode(() -> aiImageCreatedDlqListener.handleFinalFailedMessage(messageDto, message))
+			.doesNotThrowAnyException();
+
+		// 메시지 상태는 변경되어야 함
+		assertThat(requestChatMessage.getStatus()).isEqualTo(AiImageStatus.RESPONSE_FAILED);
+		verify(aiChatMessageRepository).save(requestChatMessage);
+	}
+
+	@Test
+	@DisplayName("이미지 생성 실패 메시지 처리 - isImageGenerated=false")
+	void handleFinalFailedMessage_ImageNotGenerated() {
+		// Given
+		String requestId = "test-request-id-789";
+
+		AiImageResponseMessageDto messageDto = new AiImageResponseMessageDto(
+			false,
+			requestId,
+			false,
+			"AI server failed to generate image",
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+
+		AiChatMessageEntity requestChatMessage = AiChatMessageEntity.builder()
+			.userId(3L)
+			.postId(300L)
+			.aiChatRoomId(30L)
+			.messageOrder(1L)
+			.senderType(SenderType.USER)
+			.textContent("Generate image request")
+			.requestId(requestId)
+			.status(AiImageStatus.REQUEST_PENDING)
+			.build();
+
+		Message message = new Message(new byte[0], new MessageProperties());
+
+		when(aiChatMessageRepository.findByRequestIdAndSenderType(requestId, SenderType.USER))
+			.thenReturn(Optional.of(requestChatMessage));
+
+		// When
+		aiImageCreatedDlqListener.handleFinalFailedMessage(messageDto, message);
+
+		// Then
+		assertThat(requestChatMessage.getStatus()).isEqualTo(AiImageStatus.RESPONSE_FAILED);
+		verify(aiChatMessageRepository).save(requestChatMessage);
+		verify(aiResponseSseService).sendToClient(eq(requestId), any());
+	}
+}


### PR DESCRIPTION
## 요약
AI 이미지 생성 응답 큐(`AI_IMAGE_CREATED_QUEUE`)에서 예외 발생 시 무한 루프 문제를 해결하기 위해 DLQ 및 재시도 메커니즘을 추가했습니다.

## 변경사항

### 1. RabbitMQ DLQ 설정 추가
- `AI_IMAGE_CREATED_QUEUE`에 Dead Letter Exchange 설정 추가
- 재시도 큐(`AI_IMAGE_CREATED_RETRY_QUEUE`) 구성 (TTL 60초)
- 최종 실패 큐(`AI_IMAGE_CREATED_DLQ`) 구성

### 2. DLQ 리스너 구현
- `AiImageCreatedDlqListener`: 최종 실패 메시지 처리
  - 메시지 상태를 `RESPONSE_FAILED`로 변경
  - SSE 연결이 있으면 클라이언트에 실패 알림 전송

### 3. 무한 재시도 방지
- `SimpleRabbitListenerContainerFactory` 설정 추가
- `setDefaultRequeueRejected(false)`로 예외 발생 시 메시지 재큐잉 방지

### 4. 도메인 모델 확장
- `AiImageStatus` enum에 `RESPONSE_FAILED` 상태 추가
- `ChatMessageResponse`에 `createErrorResponse()` 메서드 추가

### 5. 단위 테스트
- `AiImageCreatedDlqListenerTest`: 4개 테스트 케이스 작성

## 데이터베이스 변경사항

**반드시 배포 전에 실행 필요:**

```sql
ALTER TABLE ai_chat_messages 
MODIFY COLUMN status ENUM(
    'REQUEST',
    'REQUEST_PENDING', 
    'REQUEST_FAILED',
    'RESPONSE',
    'RESPONSE_FAILED'
) NOT NULL;
```

## 메시지 플로우

### 정상 처리
```
AI_IMAGE_CREATED_QUEUE → AiImageCreatedListener → DB 저장 → SSE 응답
```

### 실패 처리 (재시도)
```
AI_IMAGE_CREATED_QUEUE (예외 발생)
    ↓
AI_IMAGE_CREATED_DLX
    ↓
AI_IMAGE_CREATED_RETRY_QUEUE (60초 대기)
    ↓
AI_IMAGE_CREATED_QUEUE (재시도)
```

### 최종 실패 처리
```
AI_IMAGE_CREATED_QUEUE (재시도 실패)
    ↓
AI_IMAGE_CREATED_DLX
    ↓
AI_IMAGE_CREATED_DLQ
    ↓
AiImageCreatedDlqListener (상태 업데이트 및 알림)
```

## 테스트 계획

- [x] 단위 테스트 통과 확인
- [x] 전체 테스트 통과 확인
- [ ] DB 스키마 변경 적용
- [ ] RabbitMQ 기존 큐 삭제 후 재생성
- [ ] 정상 메시지 처리 확인
- [ ] 예외 발생 시 DLQ 이동 확인
- [ ] 재시도 메커니즘 동작 확인
- [ ] DLQ 리스너 처리 확인

## 주의사항

1. **배포 전 필수 작업**
   - DB 스키마 변경 적용 (위 SQL 실행)
   - RabbitMQ에서 기존 `ai.image.created.queue` 삭제

2. **모니터링 포인트**
   - DLQ 메시지 수 모니터링
   - 재시도 큐 메시지 체류 시간 확인
   - 최종 실패 로그 확인

Closes #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - AI 이미지 생성 실패가 최종 확정될 경우, 사용자가 오류 알림과 함께 RESPONSE_FAILED 상태를 확인할 수 있습니다.
- 개선
  - AI 이미지 생성 이벤트에 재시도/지연 처리와 DLQ 연계를 추가하여 처리 안정성과 복원력을 강화했습니다.
  - 메시지 리스너 동작을 조정해 무한 재큐를 방지하고 실패 시 올바르게 사후 처리되도록 했습니다.
- 테스트
  - 최종 실패 처리 흐름(SSE 알림, 상태 업데이트, 예외 처리 등)에 대한 단위 테스트를 추가했습니다.
- 기타
  - 포트에 따라 SSL을 선택적으로 활성화하여 연결 보안을 유연하게 구성했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->