### PR TITLE
[FEATURE] 투표 API에 대한 응답으로 현 투표현황 리턴

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
+++ b/src/main/java/hanium/modic/backend/domain/vote/service/VotingService.java
@@ -26,6 +26,7 @@ import hanium.modic.backend.domain.post.enums.PostStatus;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
 import hanium.modic.backend.web.vote.dto.response.VoteParticipationResponse;
 import hanium.modic.backend.web.vote.dto.response.GetVoteStreakResponse;
+import hanium.modic.backend.web.vote.dto.response.VoteSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,6 +49,7 @@ public class VotingService {
 	private final VoteRewardService voteRewardService;
 	private final VoteCompletionRewardService voteCompletionRewardService;
 	private final UserVoteStreakService userVoteStreakService;
+	private final VoteQueryService voteQueryService;
 
 	/**
 	 * 사용자의 투표 연속 정답 정보를 조회합니다.
@@ -114,12 +116,19 @@ public class VotingService {
 			// 9. 리워드 처리 (투표 참여 직후)
 			VoteRewardResult reward = voteRewardService.processVoteReward(voteId, userId, decision);
 
-			// 10. 응답 생성
+			// 10. 투표 현항 조회
+			VoteSummaryResponse voteResults = voteQueryService.getVoteResults(voteId);
+			float approveRate = Math.round((voteResults.approveWeight() * 10000f / voteResults.totalWeight())) / 100f;
+			float denyRate = Math.round((voteResults.denyWeight() * 10000f / voteResults.totalWeight())) / 100f;
+
+			// 11. 응답 생성
 			return VoteParticipationResponse.of(
 				voteId,
 				reward.isCorrectAnswer(),
 				reward.currentStreak(),
-				reward.receivedTicket()
+				reward.receivedTicket(),
+				approveRate,
+				denyRate
 			);
 		} catch (LockException e) {
 			log.error("투표 참여 락 획득 실패: voteId={}, userId={}", voteId, userId, e);

--- a/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteParticipationResponse.java
+++ b/src/main/java/hanium/modic/backend/web/vote/dto/response/VoteParticipationResponse.java
@@ -1,10 +1,22 @@
 package hanium.modic.backend.web.vote.dto.response;
 
-public record VoteParticipationResponse(Long voteId, boolean isCorrectAnswer, int currentStreak,
-										boolean receivedTicket) {
-
-	public static VoteParticipationResponse of(Long voteId, boolean isCorrectAnswer, int currentStreak,
-		boolean receivedTicket) {
-		return new VoteParticipationResponse(voteId, isCorrectAnswer, currentStreak, receivedTicket);
+public record VoteParticipationResponse(
+	Long voteId,
+	boolean isCorrectAnswer,
+	int currentStreak,
+	boolean receivedTicket,
+	float approveRate,
+	float denyRate
+) {
+	public static VoteParticipationResponse of(
+		Long voteId,
+		boolean isCorrectAnswer,
+		int currentStreak,
+		boolean receivedTicket,
+		float approveRate,
+		float denyRate
+	) {
+		return new VoteParticipationResponse(voteId, isCorrectAnswer, currentStreak, receivedTicket, approveRate,
+			denyRate);
 	}
 }


### PR DESCRIPTION
## 개요
- close #211

## 작업사항
 - 투표 API에 대한 응답으로 투표 현황 리턴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 투표 참여 후 결과에 찬성률과 반대률이 함께 표시됩니다. 사용자는 자신의 선택 결과와 연속 정답 수, 티켓 수령 여부와 함께 실시간 비율을 확인할 수 있습니다.
- 개선
  - 투표 참여 응답 구조가 확장되어 결과 지표(찬성률/반대률)를 포함합니다. 기존 기능에는 영향 없이 추가 정보가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->