### PR TITLE
[FIX] : findAllDescendantsByPostId 쿼리 오류 수정

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/post/repository/PostEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/post/repository/PostEntityRepository.java
@@ -47,7 +47,7 @@ public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 	@Query(value = """
 		WITH RECURSIVE post_tree AS (
 			SELECT id, user_id, title, description, commercial_price, non_commercial_price,
-			       ticket_price, is_ai_derived_post, parent_post_id, post_status,
+			       ticket_price, parent_post_id, post_status, thumbnail_image_id,
 			       create_at, update_at
 			FROM post
 			WHERE id = :postId
@@ -55,7 +55,7 @@ public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 			UNION ALL
 		
 			SELECT p.id, p.user_id, p.title, p.description, p.commercial_price, p.non_commercial_price,
-			       p.ticket_price, p.is_ai_derived_post, p.parent_post_id, p.post_status,
+			       p.ticket_price, p.parent_post_id, p.post_status, p.thumbnail_image_id,
 			       p.create_at, p.update_at
 			FROM post p
 			INNER JOIN post_tree pt ON p.parent_post_id = pt.id


### PR DESCRIPTION
## 개요
- close #215

## 작업사항
- findAllDescendantsByPostId 메서드의 쿼리에서 is_ai_derived_post 오타나서 수정했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 게시글 계층(자식/후손) 조회 시 썸네일 정보가 누락되거나 잘못 표시되던 문제를 수정했습니다.
  * 후손 게시글을 포함해 불러오는 목록/상세 화면에서 썸네일이 안정적으로 표시됩니다.
  * 불필요한 표기 혼동을 줄이고, 기존의 가격/상태 정보 표시는 변함없이 유지됩니다.
  * 관련 화면의 데이터 정합성을 개선하여 일관된 표시와 조회 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->