### PR TITLE
Swagger 에러 내용 자동화

### DIFF
--- a/src/main/java/hanium/modic/backend/common/swagger/ApiErrorMapping.java
+++ b/src/main/java/hanium/modic/backend/common/swagger/ApiErrorMapping.java
@@ -1,0 +1,15 @@
+package hanium.modic.backend.common.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import hanium.modic.backend.common.error.ErrorCode;
+
+// ErrorCode의 내용을 Swagger API Response로 매핑하기 위한 어노테이션
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorMapping {
+	ErrorCode[] value();
+}

--- a/src/main/java/hanium/modic/backend/common/swagger/ApiErrorMappingCustomizer.java
+++ b/src/main/java/hanium/modic/backend/common/swagger/ApiErrorMappingCustomizer.java
@@ -1,0 +1,59 @@
+package hanium.modic.backend.common.swagger;
+
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import hanium.modic.backend.common.error.ErrorCode;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+@Configuration
+public class ApiErrorMappingCustomizer {
+
+	private static final String ERROR_EXAMPLE_JSON = """
+		{
+		  "isSuccess": false,
+		  "status": "%s",
+		  "code": "%s",
+		  "message": "%s",
+		  "reasons": {}
+		}
+		""";
+
+	@Bean
+	public OperationCustomizer applyApiErrorMapping() {
+		return (Operation operation, HandlerMethod handlerMethod) -> {
+			// ApiErrorMapping 애노테이션이 있는지 확인
+			ApiErrorMapping mapping = handlerMethod.getMethodAnnotation(ApiErrorMapping.class);
+
+			// 애노테이션이 있으면 해당 에러 코드를 OpenAPI 응답에 추가
+			if (mapping != null) {
+				ApiResponses responses = operation.getResponses();
+
+				// operation에 ApiResponse 추가
+				for (ErrorCode code : mapping.value()) {
+					ApiResponse apiResponse = new ApiResponse()
+						.description(code.getMessage())
+						.content(new Content().addMediaType(
+							"application/json",
+							new MediaType()
+								.schema(new Schema<>().$ref("#/components/schemas/ErrorResponse"))
+								.example(String.format(ERROR_EXAMPLE_JSON,code.getStatus().value(), code.getCode(), code.getMessage()))
+						));
+
+					responses.addApiResponse(
+						String.valueOf(code.getStatus().value()), // HTTP 상태 코드
+						apiResponse // ApiResponse 객체
+					);
+				}
+			}
+			return operation;
+		};
+	}
+}

--- a/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
+++ b/src/main/java/hanium/modic/backend/web/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package hanium.modic.backend.web.user.controller;
 
+import static hanium.modic.backend.common.error.ErrorCode.*;
+
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
+import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.response.AppResponse;
 import hanium.modic.backend.common.response.PageResponse;
+import hanium.modic.backend.common.swagger.ApiErrorMapping;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.service.UserCoinService;
 import hanium.modic.backend.domain.user.service.UserService;
@@ -47,12 +51,9 @@ public class UserController {
 	@PostMapping
 	@Operation(
 		summary = "회원가입 API",
-		description = "이메일, 비밀번호, 이름을 입력하여 회원가입을 진행합니다.",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-			@ApiResponse(responseCode = "409", description = "이미 사용중인 이메일입니다.[U-001]"),
-		}
+		description = "이메일, 비밀번호, 이름을 입력하여 회원가입을 진행합니다."
 	)
+	@ApiErrorMapping({USER_INPUT_EXCEPTION, USER_EMAIL_DUPLICATED_EXCEPTION})
 	public ResponseEntity<AppResponse<UserCreateResponse>> createUser(@RequestBody @Valid UserCreateRequest request) {
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(AppResponse.created(userService.createUser(
@@ -76,12 +77,9 @@ public class UserController {
 	@GetMapping("/search")
 	@Operation(
 		summary = "사용자 이름 검색 API",
-		description = "검색어를 기반으로 사용자 목록을 페이지 단위로 조회합니다. page는 0부터 시작합니다.",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "입력값 검증 실패[C-001]"),
-			@ApiResponse(responseCode = "401", description = "인증 필요[A-001]"),
-		}
+		description = "검색어를 기반으로 사용자 목록을 페이지 단위로 조회합니다. page는 0부터 시작합니다."
 	)
+	@ApiErrorMapping({USER_INPUT_EXCEPTION})
 	public ResponseEntity<AppResponse<PageResponse<SearchUsersResponse>>> searchUsersByName(
 		@RequestParam @NotBlank(message = "검색어는 필수입니다.") String keyword,
 		@RequestParam(required = false, defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다") Integer page,
@@ -96,11 +94,9 @@ public class UserController {
 	@PatchMapping("/name")
 	@Operation(
 		summary = "유저 이름 변경 API",
-		description = "로그인한 유저의 이름을 변경합니다.",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-		}
+		description = "로그인한 유저의 이름을 변경합니다."
 	)
+	@ApiErrorMapping({USER_INPUT_EXCEPTION})
 	public ResponseEntity<AppResponse<Void>> updateUserName(
 		@CurrentUser UserEntity user,
 		@RequestBody @Valid UpdateUserNameRequest request
@@ -113,13 +109,9 @@ public class UserController {
 	@PatchMapping("/email")
 	@Operation(
 		summary = "유저 이메일 변경 API",
-		description = "로그인한 유저의 이메일을 변경합니다. (토큰 필요)",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-			@ApiResponse(responseCode = "409", description = "이미 사용중인 이메일입니다.[U-001]"),
-			@ApiResponse(responseCode = "400", description = "토큰이 유효하지 않습니다.[U-008]")
-		}
+		description = "로그인한 유저의 이메일을 변경합니다. (토큰 필요)"
 	)
+	@ApiErrorMapping({USER_INPUT_EXCEPTION, USER_EMAIL_DUPLICATED_EXCEPTION, USER_UPDATE_TOKEN_INVALID_EXCEPTION})
 	public ResponseEntity<AppResponse<Void>> updateUserEmail(
 		@CurrentUser UserEntity user,
 		@RequestBody @Valid UpdateUserEmailRequest request
@@ -131,12 +123,9 @@ public class UserController {
 	@PatchMapping("/password")
 	@Operation(
 		summary = "유저 비밀번호 변경 API",
-		description = "로그인한 유저의 비밀번호를 변경합니다.",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-			@ApiResponse(responseCode = "400", description = "토큰이 유효하지 않습니다.[U-008]")
-		}
+		description = "로그인한 유저의 비밀번호를 변경합니다."
 	)
+	@ApiErrorMapping({USER_INPUT_EXCEPTION, USER_UPDATE_TOKEN_INVALID_EXCEPTION})
 	public ResponseEntity<AppResponse<Void>> updateUserPassword(
 		@CurrentUser UserEntity user,
 		@RequestBody @Valid UpdateUserPasswordRequest request
@@ -162,13 +151,13 @@ public class UserController {
 	@PostMapping("/coins/transfer")
 	@Operation(
 		summary = "코인 송금 API",
-		description = "유저가 다른 유저에게 코인을 송금합니다.",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "코인이 부족합니다.[U-004]"),
-			@ApiResponse(responseCode = "400", description = "자신에게 코인을 송금할 수 없습니다.[U-005]"),
-			@ApiResponse(responseCode = "500", description = "코인 송금에 실패하였습니다.[U-006]")
-		}
+		description = "유저가 다른 유저에게 코인을 송금합니다."
 	)
+	@ApiErrorMapping({
+		USER_COIN_NOT_ENOUGH_EXCEPTION,
+		USER_COIN_TRANSFER_SAME_USER_EXCEPTION,
+		USER_COIN_TRANSFER_FAIL_EXCEPTION
+	})
 	public ResponseEntity<AppResponse<Void>> transferCoins(
 		@CurrentUser UserEntity user,
 		@RequestBody @Valid TransferCoinsRequest request


### PR DESCRIPTION
# 문제

<img width="1057" height="291" alt="image" src="https://github.com/user-attachments/assets/153d43ba-46ea-4748-a7bf-a187fec1d56c" />

현재 위와 같이 직접 상태코드, 에러 내용, 에러 코드를 명시해줘야한다.

개발할 때마다 직접 명시해야 해서 오타가 많이나고,

에러 내용이 변경되면 직접 사용 위치 찾아가 일일이 변경해야 했다.

# 해결 과정

우선 Controller API 내부에서 발생할 수 있는 Exception들을 자동으로 감지해주는 기능이 없나 확인해봤다.

모든 API에서 터질 수 있는 예외 자동화는 가능하나, API 마다 자동화 기능은 존재하지 않았다.

그래서 Swagger 내용이라도 줄일 수 있는 방법을 찾아보는 중

https://jaeseo0519.tistory.com/406?utm_source=chatgpt.com

위 블로그 글에서 OperationCustomizer를 통해 Swagger를 변형시키는 방법을 찾아냈다.

이를 기반으로 

<img width="1058" height="167" alt="image" src="https://github.com/user-attachments/assets/0a165cbc-b14f-430d-b5b6-b9f1123daf3e" />


해당 ErrorCode를 커스텀 애노테이션으로 받고, OperationCustomizer를 통해 내용을 업데이트 하면 되겠다고 판단했다.

<img width="998" height="241" alt="image" src="https://github.com/user-attachments/assets/f782300c-82d4-482a-ad1c-e1c7c1a15c8b" />


우선 @ApiResponse를 대체할 Errorcode를 받는 Custom애노테이션을 만들었다.

<img width="1105" height="916" alt="image" src="https://github.com/user-attachments/assets/26e53c52-416b-4783-9237-fac7b91d72b3" />

그리고 OperationCustomizer를 통해 Errorcode의 내용을 넣어줬다.

# 해결

<img width="1855" height="271" alt="image" src="https://github.com/user-attachments/assets/74b81433-e59c-4e02-aac2-dd1cdd2f0817" />

이제 Controller에 에러 메세지, 상태코드 등을 명시할 필요 없이 ErrorCode만 제공하게 했다.

이로 인해, 기존에 ErrorCode가 변경될 시 모든 Controller를 찾아해매며 수정할 필요가 없어졌다.

<img width="1074" height="392" alt="image" src="https://github.com/user-attachments/assets/2eea2d3d-1090-4aa0-b30f-b46ee6ad9831" />


Swagger에서도 예쁘게 ErrorResponse 내용이 포함되어 찍혔다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 검색 엔드포인트에 페이지 크기 조정 기능이 추가되었습니다. 한 번에 표시할 검색 결과 항목 수를 10-20개 범위 내에서 선택할 수 있습니다.

* **Documentation**
  * API 에러 응답 문서화 메커니즘이 개선되어 더 일관되고 명확한 오류 정보 제공이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->