### PR TITLE
refactor: 채팅 정렬 순서 변경

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,14 +19,14 @@ import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 public interface AiChatMessageRepository extends JpaRepository<AiChatMessageEntity, Long> {
 
 	/**
-	 * 특정 사용자-포스트의 메시지 목록 조회 (페이지네이션, 최신순)
+	 * 특정 사용자-포스트의 메시지 목록 조회 (페이지네이션, 오래된 순)
 	 */
 	@Query("SELECT cm FROM AiChatMessageEntity cm " +
 		"WHERE cm.userId = :userId AND cm.postId = :postId " +
-		"ORDER BY cm.messageOrder DESC")
-	Page<AiChatMessageEntity> findByUserIdAndPostIdOrderByMessageOrderDesc(
+		"ORDER BY cm.messageOrder ASC")
+	Page<AiChatMessageEntity> findByUserIdAndPostIdOrderByMessageOrderAsc(
 		@Param("userId") Long userId,
-		@Param("postId") Long postId, 
+		@Param("postId") Long postId,
 		Pageable pageable
 	);
 
@@ -67,4 +66,9 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessageEnti
 
 
 	Optional<AiChatMessageEntity> findByRequestIdAndSenderType(String requestId, SenderType senderType);
+
+	/**
+	 * 특정 사용자-포스트의 메시지 개수 조회
+	 */
+	long countByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -120,15 +120,29 @@ public class AiChatMessageService {
 
 	// 채팅 메시지 페이징 조회
 	@Transactional(readOnly = true)
-	public PageResponse<ChatMessageResponse> getMessages(Long userId, Long postId, int page, int size) {
+	public PageResponse<ChatMessageResponse> getMessages(
+		final Long userId,
+		final Long postId,
+		int page, // page는 -1인 경우 마지막 페이지 조회로 변경됨
+		final int size
+	) {
 		// 채팅방 접근 권한 검증
 		aiChatRoomService.validateChatRoomAccess(userId, postId);
 
-		Pageable pageable = PageRequest.of(page, size);
+		// page가 -1인 경우 마지막 페이지로 변환
+		if (page == -1) {
+			// 마지막 페이지 조회를 위한 총 메시지 개수 계산
+			long totalMessages = aiChatMessageRepository.countByUserIdAndPostId(userId, postId);
+			page = (int) ((totalMessages - 1) / size); // 0-based index
+			if (page < 0) {
+				page = 0; // 메시지가 없는 경우 첫 페이지로 설정
+			}
+		}
 
 		// Page 조회
+		Pageable pageable = PageRequest.of(page, size);
 		Page<AiChatMessageEntity> messagePage = aiChatMessageRepository
-			.findByUserIdAndPostIdOrderByMessageOrderDesc(userId, postId, pageable);
+			.findByUserIdAndPostIdOrderByMessageOrderAsc(userId, postId, pageable);
 
 		// 엔티티 → DTO 변환
 		Page<ChatMessageResponse> responsePage = messagePage.map(msg -> {

--- a/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
@@ -1,5 +1,7 @@
 package hanium.modic.backend.web.ai.aiChat.controller;
 
+import static hanium.modic.backend.common.error.ErrorCode.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
+import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.response.AppResponse;
 import hanium.modic.backend.common.response.PageResponse;
+import hanium.modic.backend.common.swagger.ApiErrorMapping;
 import hanium.modic.backend.domain.ai.aiChat.dto.ChatContextResetResponse;
 import hanium.modic.backend.web.ai.aiChat.dto.request.ChatMessageRequest;
 import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
@@ -97,6 +101,7 @@ public class AiChatController {
 		summary = "채팅 메시지 목록 조회",
 		description = """
 			채팅 메시지 목록을 페이지네이션으로 조회합니다.
+			page를 -1로 조회하면, 가장 마지막 페이지를 조회합니다.
 			senderType을 통해 유저요청(USER)과 AI응답(AI)을 구분할 수 있습니다.
 			
 			status를 통해 GPT 응답 상태를 구분할 수 있습니다.
@@ -105,17 +110,17 @@ public class AiChatController {
 			- REQUEST_FAILED, // AI 요청 실패 상태 -> SSE에 연결해도 답장을 받을 수 없습니다.
 			- RESPONSE // AI의 응답을 의미
 			
-			""",
-		responses = {
-			@ApiResponse(responseCode = "404", description = "AI 이미지 생성권을 구매한 이력이 없습니다.[AI-004]"),
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]")
-		}
+			"""
 	)
+	@ApiErrorMapping({
+		AI_IMAGE_PERMISSION_NOT_FOUND,
+		USER_INPUT_EXCEPTION
+	})
 	@GetMapping("/messages")
 	public ResponseEntity<AppResponse<PageResponse<ChatMessageResponse>>> getChatMessages(
 		@Parameter(description = "포스트 ID") @PathVariable @Positive(message = "포스트 ID는 양수여야 합니다.") Long postId,
 		@Parameter(description = "페이지 번호 (0부터 시작)")
-		@RequestParam(defaultValue = "0") @Min(0) int page,
+		@RequestParam(defaultValue = "0") @Min(-1) int page,
 		@Parameter(description = "페이지 크기 (최대 50)")
 		@RequestParam(defaultValue = "20") @Min(1) @Max(50) int size,
 		@CurrentUser UserEntity user


### PR DESCRIPTION
## 개요
- close #219 

## 작업사항
- 채팅 조회 순 오래된 순으로 변경
- page - 1로 조회시 최신 메세지 조회하도록 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마지막 페이지 조회: page = -1로 설정하여 메시지의 마지막 페이지를 직접 조회 가능

* **버그 수정**
  * 메시지 정렬 순서를 최신순에서 오래된순으로 변경하여 올바른 메시지 흐름 제공
  * 오류 응답 처리 개선으로 사용자 입력 오류 및 권한 오류에 대한 명확한 피드백 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->