### PR TITLE
FEAT: MessageOrderId  동시성 문제 해결

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -91,6 +91,7 @@ public enum ErrorCode {
 	// AI Chat
 	AI_CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "AC-001", "AI 채팅방을 찾을 수 없습니다."),
 	EMPTY_CHAT_MESSAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "AC-002", "채팅 메시지랑 이미지가 모두 비어있습니다."),
+	AI_CHAT_MESSAGE_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "AC-003", "AI 채팅 메시지 순서 정보를 찾을 수 없습니다."),
 
 	// Vote
 	VOTE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "V-001", "해당 투표를 찾을 수 없습니다."),

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/entity/AiChatMessageOrderEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/entity/AiChatMessageOrderEntity.java
@@ -1,0 +1,46 @@
+package hanium.modic.backend.domain.ai.aiChat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ai_chat_message_order",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AiChatMessageOrderEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "post_id", nullable = false)
+	private Long postId;
+
+	@Column(name = "last_order", nullable = false)
+	private Long lastOrder;
+
+	public AiChatMessageOrderEntity(Long userId, Long postId, Long lastOrder) {
+		this.userId = userId;
+		this.postId = postId;
+		this.lastOrder = lastOrder;
+	}
+
+	/** 순번 증가 */
+	public void increment() {
+		this.lastOrder = this.lastOrder + 1;
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageOrderRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageOrderRepository.java
@@ -1,0 +1,28 @@
+package hanium.modic.backend.domain.ai.aiChat.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageOrderEntity;
+import jakarta.persistence.LockModeType;
+
+public interface AiChatMessageOrderRepository extends JpaRepository<AiChatMessageOrderEntity, Long> {
+
+	/** (userId, postId) 조합으로 레코드를 조회하고 FOR UPDATE로 락을 건다 */
+
+	/** (userId, postId) 조합으로 레코드를 조회하고 FOR UPDATE로 락을 건다 */
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+        SELECT c FROM AiChatMessageOrderEntity c
+        WHERE c.userId = :userId AND c.postId = :postId
+    """)
+	Optional<AiChatMessageOrderEntity> findForUpdate(
+		@Param("userId") Long userId,
+		@Param("postId") Long postId
+	);
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageRepository.java
@@ -54,17 +54,6 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessageEnti
 		@Param("contextResetAt") LocalDateTime contextResetAt,
 		Pageable pageable);
 
-	/**
-	 * 특정 사용자-포스트의 다음 메시지 순서 조회
-	 */
-	@Query("SELECT COALESCE(MAX(cm.messageOrder), 0) + 1 " +
-		"FROM AiChatMessageEntity cm " +
-		"WHERE cm.userId = :userId AND cm.postId = :postId")
-	Long findNextMessageOrder(
-		@Param("userId") Long userId,
-		@Param("postId") Long postId);
-
-
 	Optional<AiChatMessageEntity> findByRequestIdAndSenderType(String requestId, SenderType senderType);
 
 	/**

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageOrderService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageOrderService.java
@@ -1,13 +1,14 @@
 package hanium.modic.backend.domain.ai.aiChat.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
+import hanium.modic.backend.common.error.ErrorCode;
+import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageOrderEntity;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageOrderRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +22,17 @@ public class AiChatMessageOrderService {
 	@Transactional
 	public Long nextMessageOrder(Long userId, Long postId) {
 		AiChatMessageOrderEntity seq = aiChatMessageOrderRepository.findForUpdate(userId, postId)
-			.orElseGet(() -> aiChatMessageOrderRepository.save(
-				new AiChatMessageOrderEntity(userId, postId, 0L)
-			));
+			.orElseGet(() -> {
+				try {
+					return aiChatMessageOrderRepository.save(
+						new AiChatMessageOrderEntity(userId, postId, 0L)
+					);
+				} catch (DataIntegrityViolationException e) {
+					// 다른 트랜잭션이 이미 생성한 경우, 다시 조회
+					return aiChatMessageOrderRepository.findForUpdate(userId, postId)
+						.orElseThrow(() -> new AppException(ErrorCode.AI_CHAT_MESSAGE_ORDER_NOT_FOUND));
+				}
+			});
 		seq.increment();
 		return seq.getLastOrder();
 	}

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageOrderService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageOrderService.java
@@ -1,0 +1,30 @@
+package hanium.modic.backend.domain.ai.aiChat.service;
+
+
+import java.util.Optional;
+
+import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageOrderEntity;
+import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageOrderRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiChatMessageOrderService {
+
+	private final AiChatMessageOrderRepository aiChatMessageOrderRepository;
+
+	/**
+	 * (userId, postId) 기준으로 다음 messageOrder 값을 원자적으로 가져옵니다.
+	 */
+	@Transactional
+	public Long nextMessageOrder(Long userId, Long postId) {
+		AiChatMessageOrderEntity seq = aiChatMessageOrderRepository.findForUpdate(userId, postId)
+			.orElseGet(() -> aiChatMessageOrderRepository.save(
+				new AiChatMessageOrderEntity(userId, postId, 0L)
+			));
+		seq.increment();
+		return seq.getLastOrder();
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -34,14 +34,23 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AiChatMessageService {
 
+	// aiChatMessage 관련
 	private final AiChatMessageRepository aiChatMessageRepository;
+	private final AiChatMessageOrderService aiChatMessageOrderService;
+
+	// aiChatRoom 관련
 	private final AiChatRoomService aiChatRoomService;
+	private final AiChatRoomRepository aiChatRoomRepository;
+
+	// aiServer 관련
 	private final AiServerService aiServerService;
+
+	// aiChatImage 관련
 	private final AiChatImageRepository aiChatImageRepository;
 	private final AiChatImageService aiChatImageService;
 
 	private final KeyGenerator keyGenerator;
-	private final AiChatRoomRepository aiChatRoomRepository;
+
 
 	// 사용자의 메시지,이미지 저장 후 AI 요청
 	@Transactional
@@ -56,7 +65,7 @@ public class AiChatMessageService {
 		validateAiChatImageExistence(request.aiChatImageId());
 
 		// 다음 메시지 순서 조회
-		Long messageOrder = aiChatMessageRepository.findNextMessageOrder(userId, postId);
+		Long messageOrder = aiChatMessageOrderService.nextMessageOrder(userId, postId);
 
 		// 요청 ID 생성
 		String requestId = keyGenerator.generateKey();

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
@@ -8,6 +8,7 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import hanium.modic.backend.domain.ai.aiChat.service.AiChatMessageOrderService;
 import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatRoomEntity;
@@ -34,6 +35,7 @@ public class AiImageCreatedListener {
 	private final AiChatMessageRepository aiChatMessageRepository;
 	private final AiChatRoomRepository aiChatRoomRepository;
 	private final AiResponseSseService aiResponseSseService;
+	private final AiChatMessageOrderService aiChatMessageOrderService;
 
 	// MQ에서 이미지 생성 완료 메시지 수신
 	// 요청 메시지 변경 및 응답 메시지 저장&SSE 응답
@@ -91,8 +93,10 @@ public class AiImageCreatedListener {
 		aiChatImageRepository.save(aiChatImage);
 
 		// 2. 다음 메시지 순서 조회
-		Long messageOrder = aiChatMessageRepository.findNextMessageOrder(requestChatMessage.getUserId(),
-			requestChatMessage.getPostId());
+		Long messageOrder = aiChatMessageOrderService.nextMessageOrder(
+			requestChatMessage.getUserId(),
+			requestChatMessage.getPostId()
+		);
 
 		// 3.응답 메시지 저장
 		AiChatMessageEntity responseChatMessage = AiChatMessageEntity.builder()
@@ -125,8 +129,10 @@ public class AiImageCreatedListener {
 	private void handleFailedImageGeneration(AiImageResponseMessageDto message,
 		AiChatMessageEntity requestChatMessage) {
 		// 1.다음 메시지 순서 조회
-		Long messageOrder = aiChatMessageRepository.findNextMessageOrder(requestChatMessage.getUserId(),
-			requestChatMessage.getPostId());
+		Long messageOrder = aiChatMessageOrderService.nextMessageOrder(
+			requestChatMessage.getUserId(),
+			requestChatMessage.getPostId()
+		);
 
 		// 2.응답 메시지 저장
 		AiChatMessageEntity responseChatMessage = AiChatMessageEntity.builder()

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import hanium.modic.backend.common.amqp.service.MessageQueueService;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.domain.ai.aiChat.service.AiChatMessageOrderService;
 import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatRoomEntity;
@@ -50,6 +51,7 @@ public class AiServerService {
 	private final ObjectMapper objectMapper;
 	private final AiResponseSseService aiResponseSseService;
 	private final AiChatService aiChatService;
+	private final AiChatMessageOrderService aiChatMessageOrderService;
 
 	// AiAgent를 통해 해당 메시지 채팅응답용인지, 이미지 생성용인지 구분 후 처리
 	// 빠른 응답을 위해 비동기 처리, 응답은 SSE를 통해 클라이언트에 전달
@@ -130,7 +132,7 @@ public class AiServerService {
 
 		// 2.채팅 저장
 		// 다음 메시지 순서 조회
-		Long messageOrder = aiChatMessageRepository.findNextMessageOrder(userId, postId);
+		Long messageOrder = aiChatMessageOrderService.nextMessageOrder(userId, postId);
 
 		// 메시지 저장
 		AiChatMessageEntity message = AiChatMessageEntity.builder()


### PR DESCRIPTION
# 문제

현재 유저 채팅이 오면

<img width="1365" height="758" alt="image" src="https://github.com/user-attachments/assets/6fd091cb-8464-44f1-9172-66e914bac9eb" />

위와 같이 메세지 순서를 조회하고, 메세지를 저장한다.

<img width="1423" height="560" alt="image" src="https://github.com/user-attachments/assets/0128f785-45d6-46ad-8ae1-7333d768045f" />


메세지 순서는 DB의 최대 값으로 처리한다.

<img width="1387" height="733" alt="image" src="https://github.com/user-attachments/assets/b0901593-085a-457f-af79-7cc84a70ef02" />


하지만, 요청 메세지와 응답 메세지가 동시에 처리되면서 messageOrder 종종 중복되는 문제가 발생했다.

# 해결과정

동시성 문제이므로, messageOrderId 조회와 저장을 원자적으로 처리하면 되었다.

- 비관적락을 사용해서 원자성을 가져간다.
    - DB 성능저하가 발생한다.
    - 다만 채팅은 조회가 많은 API라 성능 저하를 줄이고 싶었다.
- 시퀀스 테이블을 별도로 가져가고 select for udpate로 원자성을 가져간다.
    - 테이블에는 락이 안걸리므로 성능을 보장할 수 있다.
    - 별도의 테이블 관리가 필요해지고, 별도의 데이터 저장소가 필요하다.

처음에는 락을 생각했으나, 테이블 sequence 전략과 유사하게 가져가면 되겠다고 생각했다.

sequenceTable을 만들고, selectForUpdate 문을 사용해 원자적으로 가져가면 조회 성능과 원자성을 모두 보장할 수 있었다.



# 해결

<img width="1377" height="759" alt="image" src="https://github.com/user-attachments/assets/52ca7de7-24e9-4576-9d3f-5199e8794cb6" />


정상적으로 저장되었다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * AI 채팅 메시지 순서 계산을 전담하는 로직을 도입해 동시성 처리와 순서 보장 안정성을 개선했습니다.
  * 이미지 생성 실패·성공 시 메시지 순서 부여가 일관되게 적용됩니다.
* **버그 수정**
  * 동시 삽입 충돌 시 재시도 처리로 메시지 순서 누락 가능성을 줄였습니다.
* **문구/오류**
  * 메시지 순서 관련 오류 발생 시 명확한 안내가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->