### PR TITLE
fix: Swagger에서 ErrorResponse를 스캔하지 못해 발생하는 에러 해결

### DIFF
--- a/src/main/java/hanium/modic/backend/common/swagger/ApiErrorMappingCustomizer.java
+++ b/src/main/java/hanium/modic/backend/common/swagger/ApiErrorMappingCustomizer.java
@@ -19,10 +19,10 @@ public class ApiErrorMappingCustomizer {
 	private static final String ERROR_EXAMPLE_JSON = """
 		{
 		  "isSuccess": false,
-		  "status": "%s",
+		  "status": "%d",
 		  "code": "%s",
 		  "message": "%s",
-		  "reasons": {}
+		  "reason": {}
 		}
 		""";
 

--- a/src/main/java/hanium/modic/backend/common/swagger/conf/SwaggerConfig.java
+++ b/src/main/java/hanium/modic/backend/common/swagger/conf/SwaggerConfig.java
@@ -11,6 +11,11 @@ import hanium.modic.backend.common.property.property.SwaggerProperties;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
@@ -25,23 +30,37 @@ public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI openAPI() {
-
+		// Bearer Auth 설정
 		SecurityScheme securityScheme = new SecurityScheme()
-			.type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
-			.in(SecurityScheme.In.HEADER).name("Authorization");
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.name("Authorization");
+
 		SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+		// ErrorResponse 스키마 강제 등록
+		Components components = new Components()
+			.addSecuritySchemes("bearerAuth", securityScheme)
+			.addSchemas("ErrorResponse", new Schema<>()
+				.addProperty("isSuccess", new BooleanSchema().example(false))
+				.addProperty("status", new IntegerSchema().example(400))
+				.addProperty("code", new StringSchema().example("INVALID_REQUEST"))
+				.addProperty("message", new StringSchema().example("잘못된 요청입니다."))
+				.addProperty("reason", new ArraySchema().items(new StringSchema().example("필드 검증 실패"))));
 
 		return new OpenAPI()
 			.servers(List.of(new Server().url(swaggerProperties.getUrl()).description("백엔드 서버")))
-			.components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+			.components(components)
 			.security(Arrays.asList(securityRequirement))
 			.info(apiInfo());
 	}
 
 	private Info apiInfo() {
 		return new Info()
-			.title("Modic api 명세서")
-			.description("Modic	 api 명세서입니다.")
+			.title("Modic API 명세서")
+			.description("Modic 서비스의 REST API 명세서입니다.")
 			.version("1.0.0");
 	}
 }


### PR DESCRIPTION
-swaggerConfig에서 강제로 등록했다.

## 개요
- close #233 

## 작업사항
<img width="2320" height="375" alt="image" src="https://github.com/user-attachments/assets/9d993143-b3a3-42bd-bdd3-039e4995624c" />
Swagger에서 ErrorResponse를 스캔하지 못해 에러가 발생했다. 강제로 등록하여 해결하였다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 문서의 제목과 설명이 개선되었습니다.
  * 오류 응답 형식이 표준화되었습니다.

* **개선사항**
  * Bearer 인증 설정이 명확하게 재구성되었습니다.
  * 통일된 오류 응답 스키마가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->