### PR TITLE
Feature: 원작자로부터 파생된 이미지가 아니면 2차 창작물 등록 불가하도록 추가

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -90,6 +90,7 @@ public enum ErrorCode {
 	AI_IMAGE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "AI-010", "생성된 AI 이미지를 찾을 수 없습니다."),
 	AI_IMAGE_ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "AI-011", "AI 이미지에 대한 권한이 없습니다."),
 	AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI-012", "AI 서버와의 통신 중 에러가 발생하였습니다."),
+	CANT_REGISTER_AI_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "AI-013", "원작자 이미지와 무관한 이미지는 파생 포스트로 등록할 수 없습니다."),
 
 	// AI Chat
 	AI_CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "AC-001", "AI 채팅방을 찾을 수 없습니다."),

--- a/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
+++ b/src/main/java/hanium/modic/backend/domain/post/service/AiDerivedPostService.java
@@ -70,24 +70,29 @@ public class AiDerivedPostService {
 		AiChatImageEntity createdAiImage = AiChatImageRepository.findById(createdAiImageId)
 			.orElseThrow(() -> new AppException(ErrorCode.AI_IMAGE_NOT_FOUND_EXCEPTION));
 
-		// 2. 소유자 검증(내가 생성한 이미지가 아니면 거부)
+		// 2. 생성된 AI 이미지가 원작자로부터 파생되지 않은 이미지 거부
+		if (!createdAiImage.getFromOriginImage()) {
+			throw new AppException(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION);
+		}
+
+		// 3. 소유자 검증(내가 생성한 이미지가 아니면 거부)
 		if (!createdAiImage.getUserId().equals(userId)) {
 			throw new AppException(ErrorCode.AI_IMAGE_ACCESS_DENIED_EXCEPTION);
 		}
 
-		// 3. 이미 해당 이미지로 파생 포스트가 생성되었는지 확인
+		// 4. 이미 해당 이미지로 파생 포스트가 생성되었는지 확인
 		validateDuplicateDerivedPost(createdAiImage.getPostId(), createdAiImageId);
 
-		// 4. 원본 포스트 조회
+		// 5. 원본 포스트 조회
 		PostEntity originalPost = postEntityRepository.findById(createdAiImage.getPostId())
 			.orElseThrow(() -> new AppException(ErrorCode.POST_NOT_FOUND_EXCEPTION));
 		Long originalImageId = originalPost.getThumbnailImageId();
 
-		// 5. 원본 이미지 조회
+		// 6. 원본 이미지 조회
 		PostImageEntity originalImage = postImageEntityRepository.findById(originalImageId)
 			.orElseThrow(() -> new AppException(ErrorCode.IMAGE_NOT_FOUND_EXCEPTION));
 
-		// AI 파생 포스트 생성 - PENDING 상태로 생성 (투표 대기)
+		// 7. AI 파생 포스트 생성 - PENDING 상태로 생성 (투표 대기)
 		PostEntity aiDerivedPost = PostEntity.builder()
 			.userId(userId)
 			.title(title)
@@ -101,7 +106,7 @@ public class AiDerivedPostService {
 			.build();
 		PostEntity savedPost = postEntityRepository.save(aiDerivedPost);
 
-		// 파생 포스트 이미지 저장
+		// 8. 파생 포스트 이미지 저장
 		PostImageEntity postImage = PostImageEntity.builder()
 			.imagePath(createdAiImage.getImagePath()) // 기존 AI 이미지 경로 사용, AI 이미지 Entity 삭제되어도 S3는 삭제 x
 			.fullImageName(createdAiImage.getFullImageName())
@@ -112,7 +117,7 @@ public class AiDerivedPostService {
 			.build();
 		postImageEntityRepository.save(postImage);
 
-		// 투표 시스템 연동: SimilarityVoteEntity 생성 (PENDING 상태)
+		// 9. 투표 시스템 연동: SimilarityVoteEntity 생성 (PENDING 상태)
 		SimilarityVoteEntity similarityVote = SimilarityVoteEntity.builder()
 			.originalImageId(originalImageId)
 			.derivedImageId(createdAiImageId)
@@ -122,7 +127,7 @@ public class AiDerivedPostService {
 			.build();
 		SimilarityVoteEntity savedVote = similarityVoteRepository.save(similarityVote);
 
-		// 투표 집계 초기화: SimilarityVoteSummaryEntity 생성 (기본값 0)
+		// 10. 투표 집계 초기화: SimilarityVoteSummaryEntity 생성 (기본값 0)
 		SimilarityVoteSummaryEntity voteSummary = SimilarityVoteSummaryEntity.builder()
 			.voteId(savedVote.getId())
 			.approveWeight(0L)
@@ -133,7 +138,7 @@ public class AiDerivedPostService {
 			.build();
 		voteSummaryRepository.save(voteSummary);
 
-		// AI 유사도 검사 요청 (트랜잭션 커밋 후 비동기 실행)
+		// 11. AI 유사도 검사 요청 (트랜잭션 커밋 후 비동기 실행)
 		Long voteId = savedVote.getId();
 		String originalPath = originalImage.getImagePath();
 		String derivedPath = createdAiImage.getImagePath();

--- a/src/main/java/hanium/modic/backend/web/post/controller/AiDerivedPostController.java
+++ b/src/main/java/hanium/modic/backend/web/post/controller/AiDerivedPostController.java
@@ -35,7 +35,8 @@ public class AiDerivedPostController {
 		USER_INPUT_EXCEPTION,
 		AI_IMAGE_NOT_FOUND_EXCEPTION,
 		AI_IMAGE_ACCESS_DENIED_EXCEPTION,
-		DUPLICATE_DERIVED_POST_EXCEPTION
+		DUPLICATE_DERIVED_POST_EXCEPTION,
+		CANT_REGISTER_AI_IMAGE_EXCEPTION
 	})
 	public ResponseEntity<AppResponse<CreatePostResponse>> createAiDerivedPost(
 		@CurrentUser UserEntity currentUser,

--- a/src/test/java/hanium/modic/backend/domain/ai/entityfactory/AiFactory.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/entityfactory/AiFactory.java
@@ -18,6 +18,8 @@ public class AiFactory {
 			.imageName("ai-image")
 			.extension(ImageExtension.PNG)
 			.imagePurpose(ImagePrefix.AI_RESPONSE)
+			.fromOriginImage(true)
+			.description("test")
 			.build();
 	}
 


### PR DESCRIPTION
## 개요
- close #240 

## 작업사항
- 원작자로부터 파생된 이미지가 아니면 2차 창작물 등록 불가하도록 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 파생 포스트 등록 시 원본 이미지와의 관련성을 검증하는 기능 추가
  * 원작자 이미지와 무관한 이미지는 파생 포스트로 등록할 수 없도록 개선

* **Chores**
  * API 에러 처리 확대로 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->