### PR TITLE
[FIX] 이미지 없는 채팅 응답시 NullpointException 뜨는 오류 수정

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -77,7 +77,7 @@ public class AiChatMessageService {
 			.messageOrder(messageOrder)
 			.senderType(SenderType.USER)
 			.textContent(request.textContent())
-			.aiChatImageId(request.aiChatImageId())
+			.aiChatImageId(request.aiChatImageId()) // null 가능
 			.status(AiImageStatus.REQUEST_PENDING)
 			.requestId(requestId)
 			.build();
@@ -96,7 +96,12 @@ public class AiChatMessageService {
 		// Ai 요청
 		aiServerService.processAiRequest(userId, message, aiChatImages);
 
-		return ChatMessageResponse.of(message, aiChatImageService.createImageGetUrl(request.aiChatImageId()));
+		// 이미지 유무에 따른 응답 생성
+		if (request.aiChatImageId() == null) {
+			return ChatMessageResponse.from(message);
+		} else {
+			return ChatMessageResponse.of(message, aiChatImageService.createImageGetUrl(request.aiChatImageId()));
+		}
 	}
 
 	// 요청 메세지가 비어있는지 검증


### PR DESCRIPTION
## 개요
- close #244 

## 작업사항
- 이미지 없는 채팅 응답시 NullpointException 뜨는 오류 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * AI 채팅 메시지 응답에서 이미지 처리 로직을 개선하여 이미지가 없을 때 불필요한 이미지 URL 생성을 방지하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->