### PR TITLE
[FEAT] 유저 정보 조회 응답 형식 통일

### DIFF
--- a/src/main/java/hanium/modic/backend/web/user/dto/response/SearchUsersResponse.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/response/SearchUsersResponse.java
@@ -3,8 +3,8 @@ package hanium.modic.backend.web.user.dto.response;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 
 public record SearchUsersResponse(
-	Long id,
-	String name,
+	Long userId,
+	String userName,
 	boolean hasUserImage,
 	String userImageUrl
 ) {

--- a/src/main/java/hanium/modic/backend/web/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/hanium/modic/backend/web/user/dto/response/UserInfoResponse.java
@@ -8,7 +8,7 @@ import hanium.modic.backend.domain.user.entity.UserEntity;
 
 @JsonInclude(NON_NULL)
 public record UserInfoResponse(
-	Long id,
+	Long userId,
 	String userEmail,
 	String userName,
 	boolean hasUserImage,

--- a/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/user/service/UserServiceTest.java
@@ -131,7 +131,7 @@ class UserServiceTest {
 		UserInfoResponse response = userService.getUserInfo(user);
 
 		// then
-		assertThat(response.id()).isEqualTo(userId);
+		assertThat(response.userId()).isEqualTo(userId);
 		assertThat(response.userEmail()).isEqualTo(user.getEmail());
 		assertThat(response.userName()).isEqualTo(user.getName());
 	}

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerIntegrationTest.java
@@ -88,7 +88,7 @@ public class UserControllerIntegrationTest extends BaseIntegrationTest {
 				.header("Authorization", "Bearer " + token.accessToken())
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpectAll(jsonPath("$.data.id").value(user.getId()),
+			.andExpectAll(jsonPath("$.data.userId").value(user.getId()),
 				jsonPath("$.data.userEmail").value(user.getEmail()),
 				jsonPath("$.data.userName").value(user.getName()));
 	}

--- a/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
+++ b/src/test/java/hanium/modic/backend/web/user/controller/UserControllerTest.java
@@ -149,7 +149,7 @@ class UserControllerTest extends BaseControllerTest {
 		// when & then
 		mockMvc.perform(get("/api/users/me"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.id").value(mockUser.getId()))
+			.andExpect(jsonPath("$.data.userId").value(mockUser.getId()))
 			.andExpect(jsonPath("$.data.userEmail").value(mockUser.getEmail()));
 
 		SecurityContextHolder.clearContext();


### PR DESCRIPTION
## 개요
- close #256 

## 작업사항
- 내 정보 조회 API 응답 형식 통일
- 유저 검색 API 응답 형식 통일

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 변경 사항**
  * 사용자 검색 및 조회 API의 응답 필드명이 명확하게 변경되었습니다.
  * 사용자 ID 필드: `id` → `userId`
  * 사용자명 필드: `name` → `userName`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->