### PR TITLE
[FEAT] : 채팅 요청 취소 기능 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -98,6 +98,8 @@ public enum ErrorCode {
 	AI_CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "AC-001", "AI 채팅방을 찾을 수 없습니다."),
 	EMPTY_CHAT_MESSAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "AC-002", "채팅 메시지랑 이미지가 모두 비어있습니다."),
 	AI_CHAT_MESSAGE_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "AC-003", "AI 채팅 메시지 순서 정보를 찾을 수 없습니다."),
+	AI_CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "AC-004", "AI 채팅 메시지를 찾을 수 없습니다."),
+	AI_CHAT_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "AC-005", "요청이 아닌 메시지는 취소할 수 없습니다."),
 
 	// Vote
 	VOTE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "V-001", "해당 투표를 찾을 수 없습니다."),

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/entity/AiChatMessageEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/entity/AiChatMessageEntity.java
@@ -1,9 +1,8 @@
 package hanium.modic.backend.domain.ai.aiChat.entity;
 
 import hanium.modic.backend.common.entity.BaseEntity;
-import hanium.modic.backend.domain.ai.aiServer.entity.AiChatImageEntity;
-import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 import hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus;
+import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/repository/AiChatMessageRepository.java
@@ -60,4 +60,6 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessageEnti
 	 * 특정 사용자-포스트의 메시지 개수 조회
 	 */
 	long countByUserIdAndPostId(Long userId, Long postId);
+
+	Optional<AiChatMessageEntity> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -1,5 +1,8 @@
 package hanium.modic.backend.domain.ai.aiChat.service;
 
+import static hanium.modic.backend.common.error.ErrorCode.*;
+import static hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus.*;
+
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -17,7 +20,6 @@ import hanium.modic.backend.domain.ai.aiChat.entity.AiChatRoomEntity;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageRepository;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatRoomRepository;
 import hanium.modic.backend.domain.ai.aiServer.entity.AiChatImageEntity;
-import hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus;
 import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 import hanium.modic.backend.domain.ai.aiServer.repository.AiChatImageRepository;
 import hanium.modic.backend.domain.ai.aiServer.service.AiServerService;
@@ -78,7 +80,7 @@ public class AiChatMessageService {
 			.senderType(SenderType.USER)
 			.textContent(request.textContent())
 			.aiChatImageId(request.aiChatImageId()) // null 가능
-			.status(AiImageStatus.REQUEST_PENDING)
+			.status(REQUEST_PENDING)
 			.requestId(requestId)
 			.build();
 		aiChatMessageRepository.save(message);
@@ -97,11 +99,29 @@ public class AiChatMessageService {
 		aiServerService.processAiRequest(userId, message, aiChatImages);
 
 		// 이미지 유무에 따른 응답 생성
-		if (request.aiChatImageId() == null) {
-			return ChatMessageResponse.from(message);
-		} else {
-			return ChatMessageResponse.of(message, aiChatImageService.createImageGetUrl(request.aiChatImageId()));
+		return createChatMessageResponseByAiChatImageId(message);
+	}
+
+	// AI 채팅 요청 취소
+	@Transactional
+	public ChatMessageResponse cancelAiRequest(Long userId, Long messageId) {
+		// 유저ID와 메시지ID로 메시지 조회(유저 ID가 권한체크 역할을 함, userId는 토큰에서 가져옴)
+		AiChatMessageEntity aiChatMessage = aiChatMessageRepository.findByIdAndUserId(messageId, userId)
+			.orElseThrow(() -> new AppException(AI_CHAT_MESSAGE_NOT_FOUND));
+
+		// 요청이 아닌 것은 취소 불가
+		if (!(aiChatMessage.getStatus() == REQUEST_PENDING)) {
+			throw new AppException(AI_CHAT_CANNOT_CANCEL);
 		}
+
+		// MQ에 있는 메세지는 삭제 불가능(리스너에서 후처리)
+
+		// 요청메세지 상태를 취소됨으로 변경
+		aiChatMessage.updateStatus(REQUEST_CANCELLED);
+		aiChatMessageRepository.save(aiChatMessage);
+
+		// 변경된 메시지 응답(이미지 유무에 따른 응답 생성)
+		return createChatMessageResponseByAiChatImageId(aiChatMessage);
 	}
 
 	// 요청 메세지가 비어있는지 검증
@@ -170,5 +190,15 @@ public class AiChatMessageService {
 
 		// PageResponse로 감싸서 반환
 		return PageResponse.of(responsePage);
+	}
+
+	// 채팅 Image 존재 여부에 따라 ChatMessageResponse 생성
+	private ChatMessageResponse createChatMessageResponseByAiChatImageId(AiChatMessageEntity message) {
+		if (message.getAiChatImageId() == null) {
+			return ChatMessageResponse.from(message);
+		} else {
+			String imageUrl = aiChatImageService.createImageGetUrl(message.getAiChatImageId());
+			return ChatMessageResponse.of(message, imageUrl);
+		}
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/enums/AiImageStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/enums/AiImageStatus.java
@@ -4,6 +4,7 @@ public enum AiImageStatus {
 	REQUEST, // 요청 상태 및 요청 완료 상태
 	REQUEST_PENDING, // AI 요청 대기 상태
 	REQUEST_FAILED, // AI 요청 실패 상태
+	REQUEST_CANCELLED, // AI 요청 취소 상태
 	RESPONSE, // 응답을 의미
 	RESPONSE_FAILED // 응답 처리 실패 상태
 }

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/listener/AiImageCreatedListener.java
@@ -53,7 +53,13 @@ public class AiImageCreatedListener {
 		}
 		AiChatMessageEntity requestChatMessage = chatMessageOpt.get();
 
-		// 2. 채팅 룸 조회 및 요약 업데이트
+		// 2.요청 메세지가 취소된 경우 처리 중단
+		if (requestChatMessage.getStatus() == AiImageStatus.REQUEST_CANCELLED) {
+			log.info("[AI 이미지 처리 중단] 요청이 취소되었습니다. requestId: {}", message.requestId());
+			return;
+		}
+
+		// 3. 채팅 룸 조회 및 요약 업데이트
 		Optional<AiChatRoomEntity> aiChatRoomOpt = aiChatRoomRepository.findById(requestChatMessage.getAiChatRoomId());
 		if (aiChatRoomOpt.isEmpty()) {
 			log.error("[AI 이미지 처리 실패] AI 채팅방을 찾을 수 없습니다. aiChatImageId: {}", requestChatMessage.getAiChatImageId());
@@ -63,7 +69,7 @@ public class AiImageCreatedListener {
 		aiChatRoom.updateChatSummary(message.chatSummary());
 		aiChatRoomRepository.save(aiChatRoom);
 
-		// 3.응답 이미지가 있는지 확인 후 이에 따라 SSE 응답
+		// 4.응답 이미지가 있는지 확인 후 이에 따라 SSE 응답
 		if (message.isImageGenerated()) {
 			handleSuccessImageGeneration(message, requestChatMessage, aiChatRoom);
 		} else {

--- a/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
@@ -101,10 +101,7 @@ public class AiChatController {
 	@PostMapping("/messages/{messageId}/cancel")
 	@Operation(
 		summary = "AI 응답 취소",
-		description = "진행 중인 AI 응답을 취소합니다. 이미 완료된 응답은 취소할 수 없습니다.",
-		responses = {
-			@ApiResponse(responseCode = "409", description = "이미 완료된 응답은 취소할 수 없습니다.[AI-013]")
-		}
+		description = "진행 중인 AI 응답을 취소합니다. 이미 완료된 응답은 취소할 수 없습니다."
 	)
 	@ApiErrorMapping({
 		AI_CHAT_MESSAGE_NOT_FOUND,

--- a/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
@@ -14,18 +14,17 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import hanium.modic.backend.common.annotation.user.CurrentUser;
-import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.response.AppResponse;
 import hanium.modic.backend.common.response.PageResponse;
 import hanium.modic.backend.common.swagger.ApiErrorMapping;
 import hanium.modic.backend.domain.ai.aiChat.dto.ChatContextResetResponse;
-import hanium.modic.backend.web.ai.aiChat.dto.request.ChatMessageRequest;
-import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
-import hanium.modic.backend.web.ai.aiChat.dto.response.GetChatRoomResponse;
 import hanium.modic.backend.domain.ai.aiChat.service.AiChatMessageService;
 import hanium.modic.backend.domain.ai.aiChat.service.AiChatRoomService;
 import hanium.modic.backend.domain.ai.aiServer.service.AiResponseSseService;
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.web.ai.aiChat.dto.request.ChatMessageRequest;
+import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
+import hanium.modic.backend.web.ai.aiChat.dto.response.GetChatRoomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -52,18 +51,18 @@ public class AiChatController {
 
 	private static final long SSE_TIMEOUT = 5 * 60 * 1000L; // 5 minutes
 
+	@GetMapping("/room")
 	@Operation(
 		summary = "채팅방 정보 조회",
 		description = """
 			특정 포스트에 대한 사용자의 채팅방 정보를 조회합니다.
 			AI 이미지 생성권이 있어야 합니다.(생성권을 다 소모하더라도 조회는 가능합니다.)
-			""",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-			@ApiResponse(responseCode = "404", description = "AI 이미지 생성권을 구매한 이력이 없습니다.[AI-004]")
-		}
+			"""
 	)
-	@GetMapping("/room")
+	@ApiErrorMapping({
+		AI_IMAGE_PERMISSION_NOT_FOUND,
+		USER_INPUT_EXCEPTION
+	})
 	public ResponseEntity<AppResponse<GetChatRoomResponse>> getChatRoom(
 		@Parameter(description = "포스트 ID") @PathVariable @Positive(message = "포스트 ID는 양수여야 합니다.") Long postId,
 		@CurrentUser UserEntity user
@@ -72,6 +71,7 @@ public class AiChatController {
 		return ResponseEntity.ok(AppResponse.ok(response));
 	}
 
+	@PostMapping("/messages")
 	@Operation(
 		summary = "채팅 메시지 전송",
 		description = """
@@ -88,7 +88,6 @@ public class AiChatController {
 			@ApiResponse(responseCode = "400", description = "이미지를 훔칠 수 없습니다.[I-006]")
 		}
 	)
-	@PostMapping("/messages")
 	public ResponseEntity<AppResponse<ChatMessageResponse>> sendUserMessage(
 		@Parameter(description = "ai chat room ID") @PathVariable @Positive(message = "포스트 ID는 양수여야 합니다.") Long postId,
 		@Valid @RequestBody ChatMessageRequest request,
@@ -99,6 +98,28 @@ public class AiChatController {
 		return ResponseEntity.ok(AppResponse.ok(response));
 	}
 
+	@PostMapping("/messages/{messageId}/cancel")
+	@Operation(
+		summary = "AI 응답 취소",
+		description = "진행 중인 AI 응답을 취소합니다. 이미 완료된 응답은 취소할 수 없습니다.",
+		responses = {
+			@ApiResponse(responseCode = "409", description = "이미 완료된 응답은 취소할 수 없습니다.[AI-013]")
+		}
+	)
+	@ApiErrorMapping({
+		AI_CHAT_MESSAGE_NOT_FOUND,
+		AI_CHAT_CANNOT_CANCEL
+	})
+	public ResponseEntity<AppResponse<ChatMessageResponse>> cancelAiResponse(
+		@CurrentUser UserEntity user,
+		@Parameter(description = "메시지 ID") @PathVariable @Positive(message = "메시지 ID는 양수여야 합니다.") Long messageId
+	) {
+		ChatMessageResponse response = aiChatMessageService.cancelAiRequest(user.getId(), messageId);
+
+		return ResponseEntity.ok(AppResponse.ok(response));
+	}
+
+	@GetMapping("/messages")
 	@Operation(
 		summary = "채팅 메시지 목록 조회",
 		description = """
@@ -110,6 +131,7 @@ public class AiChatController {
 			- REQUEST, // 요청 상태 및 요청 완료 상태
 			- REQUEST_PENDING, // AI 요청 대기 상태 -> SSE에 연결하면 응답을 실시간으로 받을 수 있습니다.
 			- REQUEST_FAILED, // AI 요청 실패 상태 -> SSE에 연결해도 답장을 받을 수 없습니다.
+			- REQUEST_CANCELLED, // AI 요청 취소 상태 -> SSE에 연결해도 답장을 받을 수 없습니다.
 			- RESPONSE // AI의 응답을 의미
 			
 			"""
@@ -118,7 +140,6 @@ public class AiChatController {
 		AI_IMAGE_PERMISSION_NOT_FOUND,
 		USER_INPUT_EXCEPTION
 	})
-	@GetMapping("/messages")
 	public ResponseEntity<AppResponse<PageResponse<ChatMessageResponse>>> getChatMessages(
 		@Parameter(description = "포스트 ID") @PathVariable @Positive(message = "포스트 ID는 양수여야 합니다.") Long postId,
 		@Parameter(description = "페이지 번호 (0부터 시작)")
@@ -133,15 +154,15 @@ public class AiChatController {
 		return ResponseEntity.ok(AppResponse.ok(responses));
 	}
 
+	@PostMapping("/context/reset")
 	@Operation(
 		summary = "채팅 컨텍스트 초기화",
-		description = "채팅 컨텍스트를 초기화합니다. 기존 채팅 내역은 유지되지만 AI가 참조하지 않습니다.",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-			@ApiResponse(responseCode = "404", description = "AI 이미지 생성권을 구매한 이력이 없습니다.[AI-004]")
-		}
+		description = "채팅 컨텍스트를 초기화합니다. 기존 채팅 내역은 유지되지만 AI가 참조하지 않습니다."
 	)
-	@PostMapping("/context/reset")
+	@ApiErrorMapping({
+		AI_IMAGE_PERMISSION_NOT_FOUND,
+		USER_INPUT_EXCEPTION
+	})
 	public ResponseEntity<AppResponse<ChatContextResetResponse>> resetContext(
 		@Parameter(description = "포스트 ID") @PathVariable @Positive(message = "포스트 ID는 양수여야 합니다.") Long postId,
 		@CurrentUser UserEntity user) {
@@ -171,12 +192,12 @@ public class AiChatController {
 			  "status": "RESPONSE" // 응답이므로 RESPONSE
 			}
 			
-			""",
-		responses = {
-			@ApiResponse(responseCode = "400", description = "사용자 입력 오류[C-001]"),
-			@ApiResponse(responseCode = "403", description = "유저 권한 오류[C-002]")
-		}
+			"""
 	)
+	@ApiErrorMapping({
+		USER_INPUT_EXCEPTION,
+		USER_ROLE_EXCEPTION
+	})
 	public SseEmitter subscribe(
 		@PathVariable @NotBlank(message = "요청 ID는 필수입니다.") String requestId,
 		@CurrentUser UserEntity userEntity


### PR DESCRIPTION
## 개요
- close #258 

## 작업사항
### 채팅 요청 취소 API 구현
- 요청 메세지 상태가 RequestPending이면, RequestCancelled로 변경
- MQ 내용은 삭제 x
- 리스너에서 후처리하도록 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 요청 취소: 진행 중인 AI 응답(이미지 포함)을 사용자가 취소할 수 있습니다.
  * 실시간 상태 구독(SSE): AI 이미지 생성 진행을 실시간으로 받아볼 수 있습니다.
  * 채팅 메시지 조회 및 전송 엔드포인트 개선: 대화 전송·조회 흐름이 강화되었습니다.
  * 채팅 컨텍스트 초기화: 대화 기록을 초기화하여 새 대화를 시작할 수 있습니다.

* **버그 수정 / 개선**
  * 취소된 이미지 요청은 더 이상 처리되지 않으며 관련 상태 표시가 개선되었습니다.
  * 관련 오류 응답이 사용자에게 더 명확하게 전달됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->