### PR TITLE
[FIX] 비동기로 인해, ChatMessage가 두 번 저장하려하면서 락 장애 발생하는 오류 수정

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -3,8 +3,6 @@ package hanium.modic.backend.domain.ai.aiChat.service;
 import static hanium.modic.backend.common.error.ErrorCode.*;
 import static hanium.modic.backend.domain.ai.aiServer.enums.AiImageStatus.*;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +17,6 @@ import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatRoomEntity;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageRepository;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatRoomRepository;
-import hanium.modic.backend.domain.ai.aiServer.entity.AiChatImageEntity;
 import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 import hanium.modic.backend.domain.ai.aiServer.repository.AiChatImageRepository;
 import hanium.modic.backend.domain.ai.aiServer.service.AiServerService;
@@ -58,6 +55,8 @@ public class AiChatMessageService {
 	public ChatMessageResponse sendUserMessage(Long userId, Long postId, ChatMessageRequest request) {
 		// 메시지랑 이미지 둘 다 비어있으면 에러
 		validateRequestMessageNotEmpty(request);
+		// 이미지가 다른 사람의 이미지면 에러
+		validateAiChatImageOwnership(userId, request.aiChatImageId());
 
 		// 채팅방 조회
 		AiChatRoomEntity aiChatRoom = aiChatRoomRepository.findByUserIdAndPostId(userId, postId)
@@ -85,18 +84,8 @@ public class AiChatMessageService {
 			.build();
 		aiChatMessageRepository.save(message);
 
-		// 이미지 조회
-		List<AiChatImageEntity> aiChatImages = List.of();
-		if (request.aiChatImageId() != null) {
-			aiChatImages = aiChatImageRepository.findById(request.aiChatImageId())
-				.map(List::of)
-				.orElse(List.of());
-			// 이미지들이 자신의 것인지 확인
-			validateAiChatImagesOwnership(userId, aiChatImages);
-		}
-
 		// Ai 요청
-		aiServerService.processAiRequest(userId, message, aiChatImages);
+		aiServerService.processAiRequest(userId, message.getId(), request.aiChatImageId());
 
 		// 이미지 유무에 따른 응답 생성
 		return createChatMessageResponseByAiChatImageId(message);
@@ -135,11 +124,13 @@ public class AiChatMessageService {
 	}
 
 	// 이미지들이 자신의 것인지 확인
-	private void validateAiChatImagesOwnership(Long userId, List<AiChatImageEntity> aiChatImages) {
-		for (AiChatImageEntity image : aiChatImages) {
-			if (!image.getUserId().equals(userId)) {
-				throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
-			}
+	private void validateAiChatImageOwnership(Long userId, Long aiChatImageId) {
+		if (aiChatImageId == null) {
+			return; // 이미지 ID가 null인 경우 소유권 검증 불필요
+		}
+		boolean hasUserImage = aiChatImageRepository.existsByIdAndUserId(aiChatImageId, userId);
+		if (!hasUserImage) {
+			throw new AppException(ErrorCode.IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION);
 		}
 	}
 

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
@@ -67,9 +67,21 @@ public class AiServerService {
 	@Async("llmTaskExecutor")
 	public void processAiRequest(
 		final Long nowUserId,
-		AiChatMessageEntity chatMessage,
-		List<AiChatImageEntity> aiChatImages // 없으면 빈 리스트
+		final Long messageId,
+		final Long aiChatImageId // 없으면 null, null이 아니면 해당 이미지는 반드시 존재해야 함
 	) {
+		// 비동기 통신이라 chatMessage를 외부에서 받아오지 않고 여기서 다시 조회
+		AiChatMessageEntity chatMessage = aiChatMessageRepository.findById(messageId)
+			.orElseThrow(() -> new AppException(ErrorCode.AI_CHAT_MESSAGE_NOT_FOUND));
+
+		// 이미지가 있으면 해당 이미지 조회
+		List<AiChatImageEntity> aiChatImages = List.of();
+		if (aiChatImageId != null) {
+			aiChatImages = aiChatImageRepository.findById(aiChatImageId)
+				.map(List::of)
+				.orElse(List.of());
+		}
+
 		final Long postId = chatMessage.getPostId();
 
 		// 해당 Post에 대한 AI 이미지 생성 권한 검증


### PR DESCRIPTION
## 개요
- close #262 

## 작업사항
<img width="2741" height="1133" alt="image" src="https://github.com/user-attachments/assets/7361cfb9-83b2-4f3e-9f61-fb9b9996d2d6" />
비동기 메서드 외부에서 데이터를 저장하고, 비동기 내부에서 값을 변경하려고했다.
하지만 비동기 메서드여서 단순 update메서드로 변경감지가 이뤄지지 않았고, 이에 save를 추가했을 때 새로운데이터로 인식해 두 번 저장하려다 장애가 발생했다.

이를 비동기 메서드에 엔티티를 직접적으로 넘기지 않고, 다시 조회하게끔하여 해결했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * AI 채팅 이미지 처리 로직을 최적화하여 성능을 개선했습니다.
  * 이미지 소유권 검증 프로세스를 단순화하여 처리 속도를 향상시켰습니다.

* **버그 수정**
  * AI 이미지 처리 시 소유권 검증의 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->