### PR TITLE
[FIX] 비동기로 인해 기존 내역이 커밋되기 전, 메세지를 조회하여 NotFound 뜨는 에러 해결

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -57,6 +57,8 @@ public class AiChatMessageService {
 		validateRequestMessageNotEmpty(request);
 		// 이미지가 다른 사람의 이미지면 에러
 		validateAiChatImageOwnership(userId, request.aiChatImageId());
+		// 이미지 생성권 없으면 에러
+		validateRemainingGenerationsEnough(userId, postId);
 
 		// 채팅방 조회
 		AiChatRoomEntity aiChatRoom = aiChatRoomRepository.findByUserIdAndPostId(userId, postId)
@@ -139,6 +141,15 @@ public class AiChatMessageService {
 		if (aiChatImageId != null) {
 			aiChatImageRepository.findById(aiChatImageId)
 				.orElseThrow(() -> new AppException(ErrorCode.IMAGE_NOT_FOUND_EXCEPTION));
+		}
+	}
+
+	// 이미지 생성권 없으면 에러
+	private void validateRemainingGenerationsEnough(Long userId, Long postId) {
+		AiChatRoomEntity aip = aiChatRoomRepository.findByUserIdAndPostId(userId, postId)
+			.orElseThrow(() -> new AppException(AI_IMAGE_PERMISSION_NOT_FOUND));
+		if (!aip.hasRemainingGenerations()) {
+			throw new AppException(REMAINING_GENERATIONS_NOT_ENOUGH_EXCEPTION);
 		}
 	}
 

--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiChatMessageService.java
@@ -51,7 +51,7 @@ public class AiChatMessageService {
 	private final KeyGenerator keyGenerator;
 
 	// 사용자의 메시지,이미지 저장 후 AI 요청
-	@Transactional
+	// @Transactional 붙이면 장애남(AiChatMessage가 커밋되기 전에 processAiRequest가 실행되어 MQ에서 메시지를 못찾음)
 	public ChatMessageResponse sendUserMessage(Long userId, Long postId, ChatMessageRequest request) {
 		// 메시지랑 이미지 둘 다 비어있으면 에러
 		validateRequestMessageNotEmpty(request);

--- a/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiServer/service/AiServerService.java
@@ -15,13 +15,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import hanium.modic.backend.common.amqp.service.MessageQueueService;
 import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
-import hanium.modic.backend.domain.ai.aiChat.service.AiChatImageService;
-import hanium.modic.backend.domain.ai.aiChat.service.AiChatMessageOrderService;
-import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatMessageEntity;
 import hanium.modic.backend.domain.ai.aiChat.entity.AiChatRoomEntity;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatMessageRepository;
 import hanium.modic.backend.domain.ai.aiChat.repository.AiChatRoomRepository;
+import hanium.modic.backend.domain.ai.aiChat.service.AiChatImageService;
+import hanium.modic.backend.domain.ai.aiChat.service.AiChatMessageOrderService;
 import hanium.modic.backend.domain.ai.aiChat.service.AiChatRoomService;
 import hanium.modic.backend.domain.ai.aiChat.service.AiImagePermissionService;
 import hanium.modic.backend.domain.ai.aiServer.dto.AiImageRequestMessageDto;
@@ -33,6 +32,7 @@ import hanium.modic.backend.domain.ai.aiServer.enums.SenderType;
 import hanium.modic.backend.domain.ai.aiServer.repository.AiChatImageRepository;
 import hanium.modic.backend.domain.post.entity.PostImageEntity;
 import hanium.modic.backend.domain.post.repository.PostImageEntityRepository;
+import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -82,15 +82,11 @@ public class AiServerService {
 				.orElse(List.of());
 		}
 
-		final Long postId = chatMessage.getPostId();
-
-		// 해당 Post에 대한 AI 이미지 생성 권한 검증
-		validateAiRequestPermission(nowUserId, postId);
-
 		// AI 요청 처리
 		try {
 			// AiAgent를 통해 해당 메시지 채팅응답용인지, 이미지 생성용인지 구분
-			RequestCategory requestCategory = classifyRequestCategory(chatMessage.getTextContent(), chatMessage.hasImage());
+			RequestCategory requestCategory = classifyRequestCategory(chatMessage.getTextContent(),
+				chatMessage.hasImage());
 			log.info("Classified request category: {}", requestCategory);
 
 			if (requestCategory == RequestCategory.CHAT_GENERATION) {
@@ -111,20 +107,20 @@ public class AiServerService {
 	// AiAgent를 통해 해당 메시지 채팅응답용인지, 이미지 생성용인지 구분 후 처리
 	private RequestCategory classifyRequestCategory(String message, boolean hasImage) {
 		String systemPrompt = """
-        You are a classifier.
-        The user can provide both text and/or an image.
-        
-        Decide the intent:
-        - "IMAGE_GENERATION":
-            * If the user only provides an image without text.
-            * If the text is asking to generate, modify, or create a new image.
-            * If the user provides both image and text, but the text still indicates a new image should be generated.
-        - "CHAT_GENERATION":
-            * If the user only wants a conversational response.
-            * If the user provides both image and text, but the text indicates normal chat about the image, not a request for new generation.
-
-        Only return one of the two exact words.
-        """;
+			You are a classifier.
+			The user can provide both text and/or an image.
+			
+			Decide the intent:
+			- "IMAGE_GENERATION":
+			    * If the user only provides an image without text.
+			    * If the text is asking to generate, modify, or create a new image.
+			    * If the user provides both image and text, but the text still indicates a new image should be generated.
+			- "CHAT_GENERATION":
+			    * If the user only wants a conversational response.
+			    * If the user provides both image and text, but the text indicates normal chat about the image, not a request for new generation.
+			
+			Only return one of the two exact words.
+			""";
 
 		// 메시지가 null 또는 빈 문자열일 수 있으니 기본값 처리
 		String safeMessage = (message == null) ? "" : message;
@@ -254,16 +250,9 @@ public class AiServerService {
 		// 5. MQ에 요청
 		messageQueueService.sendImageGenerationRequest(aiImageRequestMessageDto);
 
-		// 6. 사용권소모, MQ과정까지 실패하면 사용권 소모하면 안됨.
+		// 6. 사용권소모, MQ과정까지 실패하면 DLQ 리스너에서 복구
 		aiImagePermissionService.consumeRemainingGenerations(nowUserId, postId);
 
-	}
-
-	// 해당 Post에 대한 AI 이미지 생성 권한 검증
-	private void validateAiRequestPermission(Long userId, Long postId) {
-		if (!aiChatRoomRepository.existsByUserIdAndPostId(userId, postId)) {
-			throw new AppException(ErrorCode.AI_IMAGE_PERMISSION_NOT_FOUND);
-		}
 	}
 
 	// AiChatMessageEntity 리스트를 ChatMessage 리스트로 변환

--- a/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
+++ b/src/main/java/hanium/modic/backend/web/ai/aiChat/controller/AiChatController.java
@@ -27,7 +27,6 @@ import hanium.modic.backend.web.ai.aiChat.dto.response.ChatMessageResponse;
 import hanium.modic.backend.web.ai.aiChat.dto.response.GetChatRoomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -79,15 +78,16 @@ public class AiChatController {
 			이미지가 없으면 imageId에 null을 입력합니다.
 			
 			이미지는 사전에 업로드되어 있어야 하며, 업로드된 이미지 ID를 함께 전송해야 합니다.
-			""",
-		responses = {
-			@ApiResponse(responseCode = "404", description = "AI 채팅방을 찾을 수 없습니다.[AC-001]"),
-			@ApiResponse(responseCode = "404", description = "해당 이미지를 찾을 수 없습니다.[I-002]"),
-			@ApiResponse(responseCode = "400", description = "AI 이미지 생성권이 부족합니다.[AI-007]"),
-			@ApiResponse(responseCode = "500", description = "AI 서버와의 통신 중 에러가 발생하였습니다.[AI-012]"),
-			@ApiResponse(responseCode = "400", description = "이미지를 훔칠 수 없습니다.[I-006]")
-		}
+			"""
 	)
+	@ApiErrorMapping({
+		AI_CHAT_ROOM_NOT_FOUND,
+		IMAGE_NOT_FOUND_EXCEPTION,
+		REMAINING_GENERATIONS_NOT_ENOUGH_EXCEPTION,
+		USER_INPUT_EXCEPTION,
+		AI_SERVER_ERROR,
+		IMAGE_CAN_NOT_BE_STOLEN_EXCEPTION
+	})
 	public ResponseEntity<AppResponse<ChatMessageResponse>> sendUserMessage(
 		@Parameter(description = "ai chat room ID") @PathVariable @Positive(message = "포스트 ID는 양수여야 합니다.") Long postId,
 		@Valid @RequestBody ChatMessageRequest request,


### PR DESCRIPTION
## 개요
- close #262 

## 작업사항
- 비동기로 인해 기존 내역이 커밋되기 전, 메세지를 조회하여 NotFound 뜨는 에러 해결
- 이미지 생성권이 없는 유저는 채팅 또한 못보내도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * AI 이미지 생성 요청 시 사용 가능한 생성 횟수에 대한 사전 검증 로직 추가
  * API 오류 처리 및 문서화 방식 개선

* **버그 수정**
  * 메시지 전송 시 권한 검증 절차 강화로 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->