### PR TITLE
[FEAT] : 거래 장부를 위한 CoinTransaction 및 CoinTransactionEntity 엔티티 구현 

### DIFF
--- a/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
+++ b/src/main/java/hanium/modic/backend/common/error/ErrorCode.java
@@ -114,6 +114,7 @@ public enum ErrorCode {
 	COIN_NOT_ENOUGH_EXCEPTION(HttpStatus.BAD_REQUEST, "ACC-002", "코인이 부족합니다."),
 	COIN_TRANSFER_SAME_USER_EXCEPTION(HttpStatus.BAD_REQUEST, "ACC-003", "자신에게 코인을 송금할 수 업습니다."),
 	COIN_TRANSFER_FAIL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "ACC-004", "코인 송금에 실패하였습니다."),
+	EFFECTIVE_AT_CANT_NOT_BE_NULL(HttpStatus.BAD_REQUEST, "ACC-005", "유효 시간이 null일 수 없습니다.")
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/Account.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/Account.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,6 +31,10 @@ public class Account {
 
 	@Column(name = "coin", nullable = false)
 	private Long coin = 0L;
+
+	@Version
+	@Column(name = "version", nullable = false)
+	private Long version = 0L;
 
 	/**
 	 * 사용자 아이디로 계좌 생성

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransaction.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransaction.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 /**
  * Transaction 거래의 단위 거래(debit, credit)
  */
-@Table(name = "coin_transcation")
+@Table(name = "coin_transactions")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransaction.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransaction.java
@@ -1,0 +1,50 @@
+package hanium.modic.backend.domain.transaction.entity;
+
+import static jakarta.persistence.EnumType.*;
+
+import java.time.LocalDateTime;
+
+import hanium.modic.backend.common.entity.BaseEntity;
+import hanium.modic.backend.domain.transaction.enums.TransactionStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transaction 거래의 단위 거래(debit, credit)
+ */
+@Table(name = "coin_transcation")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoinTransaction extends BaseEntity {
+
+	@Id
+	@Column(name = "id", updatable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "status", nullable = false, updatable = false)
+	@Enumerated(STRING)
+	private TransactionStatus status;
+
+	@Column(name = "effective_at", nullable = true)
+	private LocalDateTime effectiveAt; // 거래가 실제로 반영된 시간
+
+	@Builder
+	private CoinTransaction(
+		TransactionStatus status,
+		LocalDateTime effectiveAt
+	) {
+		this.status = status;
+		this.effectiveAt = effectiveAt;
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
@@ -1,0 +1,127 @@
+package hanium.modic.backend.domain.transaction.entity;
+
+import static jakarta.persistence.EnumType.*;
+
+import java.time.LocalDateTime;
+
+import hanium.modic.backend.common.entity.BaseEntity;
+import hanium.modic.backend.domain.transaction.enums.TransactionDirection;
+import hanium.modic.backend.domain.transaction.enums.TransactionStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transaction 거래의 단위 거래(debit, credit)
+ */
+@Table(name = "coin_transcation_entity")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoinTransactionEntity extends BaseEntity {
+
+	@Id
+	@Column(name = "id", updatable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "account_id", nullable = false, updatable = false)
+	private Long accountId;
+
+	@Column(name = "account_version", nullable = false, updatable = false)
+	private Long accountVersion;
+
+	@Column(name = "coin_transaction_id", nullable = false, updatable = false)
+	private Long coinTransactionId;
+
+	@Column(name = "status", nullable = false, updatable = false)
+	@Enumerated(STRING)
+	private TransactionStatus status;
+
+	@Column(name = "direction", nullable = false, updatable = false)
+	@Enumerated(STRING)
+	private TransactionDirection direction;
+
+	@Column(name = "amount", nullable = false, updatable = false)
+	private Long amount;
+
+	@Column(name = "discarded_at", nullable = true)
+	private LocalDateTime discardedAt; // 취소되지 않았으면 null
+
+	@Column(name = "effective_at", nullable = true)
+	private LocalDateTime effectiveAt; // 거래가 실제로 반영된 시간
+
+	private CoinTransactionEntity(
+		Long accountId,
+		Long accountVersion,
+		Long coinTransactionId,
+		TransactionStatus status,
+		TransactionDirection direction,
+		Long amount,
+		LocalDateTime discardedAt,
+		LocalDateTime effectiveAt
+	) {
+		this.accountId = accountId;
+		this.accountVersion = accountVersion;
+		this.coinTransactionId = coinTransactionId;
+		this.status = status;
+		this.direction = direction;
+		this.amount = amount;
+		this.discardedAt = discardedAt;
+		this.effectiveAt = effectiveAt;
+	}
+
+	public static CoinTransactionEntity createPendingTransaction(
+		Long accountId,
+		Long accountVersion,
+		Long coinTransactionId,
+		TransactionDirection direction,
+		Long amount
+	) {
+		return new CoinTransactionEntity(
+			accountId,
+			accountVersion,
+			coinTransactionId,
+			TransactionStatus.PENDING,
+			direction,
+			amount,
+			null,
+			null
+		);
+	}
+
+	// 거래가 실제로 반영된 시간도 함께 설정
+	// Posted를 생성 시에는 기존 Pending 거래의 discardedAt 설정해야 함
+	public static CoinTransactionEntity createPostedTransaction(
+		Long accountId,
+		Long accountVersion,
+		Long coinTransactionId,
+		TransactionDirection direction,
+		Long amount,
+		LocalDateTime effectiveAt
+	) {
+		return new CoinTransactionEntity(
+			accountId,
+			accountVersion,
+			coinTransactionId,
+			TransactionStatus.POSTED,
+			direction,
+			amount,
+			null,
+			effectiveAt
+		);
+	}
+
+	// 거래 취소하기
+	public void discardTransaction(LocalDateTime discardedAt) {
+		this.status = TransactionStatus.ARCHIVED;
+		this.discardedAt = discardedAt;
+	}
+}

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 /**
  * Transaction 거래의 단위 거래(debit, credit)
  */
-@Table(name = "coin_transcation_entity")
+@Table(name = "coin_tranaction_entities")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -120,8 +120,8 @@ public class CoinTransactionEntity extends BaseEntity {
 	}
 
 	// 거래 취소하기
+	// 별도로 취소 상태의 CoinTransactionEntity 생성해야 함
 	public void discardTransaction(LocalDateTime discardedAt) {
-		this.status = TransactionStatus.ARCHIVED;
 		this.discardedAt = discardedAt;
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
@@ -1,10 +1,12 @@
 package hanium.modic.backend.domain.transaction.entity;
 
+import static hanium.modic.backend.common.error.ErrorCode.*;
 import static jakarta.persistence.EnumType.*;
 
 import java.time.LocalDateTime;
 
 import hanium.modic.backend.common.entity.BaseEntity;
+import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.transaction.enums.TransactionDirection;
 import hanium.modic.backend.domain.transaction.enums.TransactionStatus;
 import jakarta.persistence.Column;
@@ -107,6 +109,11 @@ public class CoinTransactionEntity extends BaseEntity {
 		Long amount,
 		LocalDateTime effectiveAt
 	) {
+		// effectiveAt null 체크
+		if (effectiveAt == null) {
+			throw new AppException(EFFECTIVE_AT_CANT_NOT_BE_NULL);
+		}
+
 		return new CoinTransactionEntity(
 			accountId,
 			accountVersion,
@@ -122,6 +129,15 @@ public class CoinTransactionEntity extends BaseEntity {
 	// 거래 취소하기
 	// 별도로 취소 상태의 CoinTransactionEntity 생성해야 함
 	public void discardTransaction(LocalDateTime discardedAt) {
+		// 이미 취소된 거래는 다시 취소할 수 없음
+		if (this.discardedAt != null) {
+			throw new AppException(COIN_TRANSFER_FAIL_EXCEPTION);
+		}
+		// discardedAt은 null일 수 없음
+		if (discardedAt == null) {
+			throw new AppException(EFFECTIVE_AT_CANT_NOT_BE_NULL);
+		}
+
 		this.discardedAt = discardedAt;
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/transaction/enums/TransactionDirection.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/enums/TransactionDirection.java
@@ -1,0 +1,6 @@
+package hanium.modic.backend.domain.transaction.enums;
+
+public enum TransactionDirection {
+	DEBIT, // 출금
+	CREDIT // 입금
+}

--- a/src/main/java/hanium/modic/backend/domain/transaction/enums/TransactionStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/enums/TransactionStatus.java
@@ -3,5 +3,5 @@ package hanium.modic.backend.domain.transaction.enums;
 public enum TransactionStatus {
 	PENDING, // 대기중
 	POSTED, // 성공
-	ARCHIVED // 실패
+	ARCHIVED // 취소 및 보관
 }

--- a/src/main/java/hanium/modic/backend/domain/transaction/enums/TransactionStatus.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/enums/TransactionStatus.java
@@ -1,0 +1,7 @@
+package hanium.modic.backend.domain.transaction.enums;
+
+public enum TransactionStatus {
+	PENDING, // 대기중
+	POSTED, // 성공
+	ARCHIVED // 실패
+}


### PR DESCRIPTION
## 개요
- close #268 

## 작업사항

# Account 엔티티 구현
- id
- coin
- version (추가)

version은 CoinTransactionEntity 목록 조회와 Account의 coin 잔액 조회의 동시성 문제를 해결하고자 도입하였다.

## 동시성 발생 예시

### 1) t 시점
클라이언트가 Annie 계좌 잔고를 읽음

→ 예: 잔고=1000

### 2) t+1 시점
Ledger에 거래가 새로 기록됨:

- **transaction_1**
- effective_at = t-1 (이 거래는 실제로 t-1에 발생한 거래임, 실제 거래 성사 시간의 불일치로 인해 실제 거래 발생 시간을 기록)
- amount = -100

즉, t 시점 잔고는 사실 900이었어야 함
하지만 Ledger는 나중에 알게 됨.

### 3) t+2 시점
클라이언트가 이렇게 요청함: t 시점 이전의 모든 거래를 주세요.

이 경우 잔고는 1000원이지만, Entity(거래 장부) 상 900 시점의 최신 데이터 존재.

## 해결 방안
version 필드를 추가하여, 실제 유저가 조회할 때는 
```
  WHERE account_id = 'account_a'
  AND effective_at <= 'timestamp_a'
  AND (discarded_at IS NULL OR discarded_at >= 'timestamp_a')
```
위와 같이
특정 시점에 Account를 읽었을 때, version이 10이라면

Entry에서 account_id에 해당하며, 상태가 posted이고, effective_at이 이 시점 이하이고, accout_version이 10이하인 것들에 대해 조회한다.
(이 일관성을 위해 Account 변경과 Transaction이 posted되는 것은 둘이 atomicity하게 일어나도록 한다. 이로 인해 해당 version에 해당하는 Entry들이 반드시 존재한다.)

이로 인해 항상 코인 잔액과, 거래 기록은 일관성있게 조회된다.


</br>
</br>
</br>
</br>




# CoinTransactionEntity(단위 거래 장부)  엔티티 구현

- id
- account_id
- account_version
- status
    - pending, posted, archived 중 하나
    - pending : 초기상태
        - 트랜잭션이 처음 상생되었을 때, 예금과 출금에 대해 pending 상태를 부여한다.
    - posted : 확정된 상태
    - archived: 포스팅되기 전에 취소된 상태
- direction
    - credit or debit 중 하나
- amount
- discarded_at
    - discarded_at은 기본적으로 null이나, 버려졌으면 실제 명시되며, 해당 Transaction에서 discared되지 않은 모든 Entry들은 모두 Transaction과 같은 상태로 움직여야 한다.
- effective_at
    - 실제 거래가 된 시점

### version에 대하여
Account와 CoinTranstionEntity 조회 일관성을 위해 account_version을 명시했다.

### status에 대하여
status는 pending, posted, archived 상태로 구분했다. (당장은 내부적으로만 거래가 발생하며 필요없지만, 추후 PG 사를 도입하여 외부 API를 통해 결제가 이뤄지므로 추가했다. pending은 PG사에 요청한 상황, posted는 PG사 결제가 끝난 상황)

### direction에 대하여
복식부기를 위하여, debit과 credit으로 구분하였다.
추후 매일 자정에 Entity를 조회하며 복식부기상 장부가 일치하는지 체크할 예정이다.

### discared_at에 대하여
CoinTransactionEntity 같은 경우, discarded_at과 effective_at 제외 수정이 불가하게 해야 한다.(장부는 변경이 있으면 안되기에)
거래가 pending에서 posted로 변경되면 discarded_at 필드를 채우고 posted 에 맞는 Entity를 새로 생성한다.
추후 장부 조회 시 discarded_at이 null이 아닌 장부는 조회에서 제외시킨다.

### effective_at에 대하여
PG사를 통해 결제하면, 실제 장부 기록 시점과 거래 시점이 다르다. 거래 시점에 맞게 조회시키고자 추가했다.



</br>
</br>
</br>
</br>




# Transaction  엔티티 구현
- id
- status
    - pending, posted, archived 중 하나
- entries
    - 트랜잭션 안에 속한 entries 목록
- effective_at
    - 실제 거래가 된 시점



</br>
</br>
</br>
</br>



## 유의사항
- 애플리케이션 계층에서는 updatable을 false로 설정하면 변경을 막았지만, DB 계층에서는 쿼리로 수정이 가능하다. 이를 어떻게 막을 지 고민해야 한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 거래 상태 추적 및 방향 지정을 포함한 향상된 거래 관리 시스템 추가
  * 거래 생명주기 관리를 위한 보류 및 완료 상태 구분
  * 계정에 낙관적 잠금 지원 추가

* **버그 수정**
  * 유효 시간 검증 추가로 거래 데이터 무결성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->