### PR TITLE
[FEAT] 복식부기를 고려한 코인 장부 저장 기능 구현

### DIFF
--- a/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiImagePermissionService.java
+++ b/src/main/java/hanium/modic/backend/domain/ai/aiChat/service/AiImagePermissionService.java
@@ -47,8 +47,8 @@ public class AiImagePermissionService {
 		// 2) 권한 업서트 + 증가 (원자적)
 		aiChatRoomRepository.upsertAndIncrease(userId, postId, AI_IMAGE_PERMISSION_COUNT);
 
-		// 3) 코인 후차감, 코인 거래는 별도의 트랜잭션으로 동작하여 후처리, 예외는 전파
-		accountService.consumeCoin(userId, post.getNonCommercialPrice());
+		// 3) 코인을 원작자에게 전송, 코인 거래는 별도의 트랜잭션으로 동작하여 후처리, 예외는 전파
+		accountService.transferCoin(userId, post.getUserId(), post.getNonCommercialPrice());
 
 		// 4) 알림
 		UserEntity user = userEntityRepository.findById(userId)

--- a/src/main/java/hanium/modic/backend/domain/profile/service/ProfileService.java
+++ b/src/main/java/hanium/modic/backend/domain/profile/service/ProfileService.java
@@ -11,6 +11,7 @@ import hanium.modic.backend.common.error.ErrorCode;
 import hanium.modic.backend.common.error.exception.AppException;
 import hanium.modic.backend.domain.follow.repository.FollowEntityRepository;
 import hanium.modic.backend.domain.post.repository.PostEntityRepository;
+import hanium.modic.backend.domain.transaction.entity.Account;
 import hanium.modic.backend.domain.transaction.repository.AccountRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.entity.UserImageEntity;
@@ -48,7 +49,7 @@ public class ProfileService {
 			.map(UserImageEntity::getId);
 		final boolean hasUserImage = userImageUrl.isPresent();
 		final long coinAmount = accountRepository.findById(user.getId())
-			.map(account -> account.getCoin())
+			.map(Account::getPostedBalance)
 			.orElseThrow(() -> new AppException(ACCOUNT_NOT_FOUND_EXCEPTION));
 
 		return new GetMyProfileResponse(

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/Account.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/Account.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,12 +28,12 @@ public class Account {
 	@Column(name = "user_id", nullable = false, unique = true)
 	private Long userId;
 
-	@Column(name = "coin", nullable = false)
-	private Long coin = 0L;
+	// Ledger가 관리하는 version
+	@Column(name = "ledger_version", nullable = false)
+	private Long ledgerVersion = 0L;
 
-	@Version
-	@Column(name = "version", nullable = false)
-	private Long version = 0L;
+	@Column(name = "posted_balance", nullable = false)
+	private Long postedBalance = 0L;
 
 	/**
 	 * 사용자 아이디로 계좌 생성
@@ -45,10 +44,13 @@ public class Account {
 		this.userId = userId;
 	}
 
-	public void addCoin(Long coin) {
-		if (this.coin + coin < 0) {
+	// 잔액 업데이트
+	public void updateBalance(Long newBalance) {
+		if (newBalance < 0) {
 			throw new AppException(COIN_NOT_ENOUGH_EXCEPTION);
 		}
-		this.coin += coin;
+
+		this.postedBalance = newBalance;
+		this.ledgerVersion++; // Balance 변경 시마다 version 증가
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/entity/CoinTransactionEntity.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 /**
  * Transaction 거래의 단위 거래(debit, credit)
  */
-@Table(name = "coin_tranaction_entities")
+@Table(name = "coin_transaction_entities")
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/hanium/modic/backend/domain/transaction/repository/AccountRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/repository/AccountRepository.java
@@ -1,8 +1,12 @@
 package hanium.modic.backend.domain.transaction.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import hanium.modic.backend.domain.transaction.entity.Account;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
+
+	Optional<Account> findByUserId(Long userId);
 }

--- a/src/main/java/hanium/modic/backend/domain/transaction/repository/CoinTransactionEntityRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/repository/CoinTransactionEntityRepository.java
@@ -1,0 +1,8 @@
+package hanium.modic.backend.domain.transaction.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import hanium.modic.backend.domain.transaction.entity.CoinTransactionEntity;
+
+public interface CoinTransactionEntityRepository extends JpaRepository<CoinTransactionEntity, Long> {
+}

--- a/src/main/java/hanium/modic/backend/domain/transaction/repository/CoinTransactionRepository.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/repository/CoinTransactionRepository.java
@@ -1,0 +1,8 @@
+package hanium.modic.backend.domain.transaction.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import hanium.modic.backend.domain.transaction.entity.CoinTransaction;
+
+public interface CoinTransactionRepository extends JpaRepository<CoinTransaction, Long> {
+}

--- a/src/main/java/hanium/modic/backend/domain/transaction/service/AccountService.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/service/AccountService.java
@@ -2,18 +2,15 @@ package hanium.modic.backend.domain.transaction.service;
 
 import static hanium.modic.backend.common.error.ErrorCode.*;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import hanium.modic.backend.common.error.exception.AppException;
-import hanium.modic.backend.common.error.exception.LockException;
 import hanium.modic.backend.domain.notification.dto.NotificationPayload;
 import hanium.modic.backend.domain.notification.enums.NotificationType;
 import hanium.modic.backend.domain.notification.service.NotificationService;
 import hanium.modic.backend.domain.transaction.entity.Account;
 import hanium.modic.backend.domain.transaction.repository.AccountRepository;
-import hanium.modic.backend.infra.redis.distributedLock.LockManager;
 import hanium.modic.backend.domain.user.entity.UserEntity;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.transaction.dto.response.GetCoinBalanceResponse;
@@ -23,11 +20,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AccountService {
 
+	// 계좌, 거래 관련
 	private final AccountRepository accountRepository;
+	private final LedgerService ledgerService;
 
-	private final LockManager lockManager;
-
+	// 알림 관련
 	private final NotificationService notificationService;
+
+	// 유저 관련
 	private final UserEntityRepository userEntityRepository;
 
 	// 코인 잔액 조회
@@ -35,23 +35,12 @@ public class AccountService {
 		Account account = accountRepository.findById(userId)
 			.orElseThrow(() -> new AppException(ACCOUNT_NOT_FOUND_EXCEPTION));
 
-		return new GetCoinBalanceResponse(account.getCoin());
-	}
-
-	// 코인 충전
-	public void chargeCoin(final long userId, final long coin) {
-		try {
-			lockManager.accountLock(userId, () -> {
-				addCoin(userId, coin);
-			});
-		} catch (LockException e) {
-			// Todo: 추후 결제 포함될 시, 결제 취소 로직 필요
-			throw new AppException(COIN_TRANSFER_FAIL_EXCEPTION);
-		}
+		return new GetCoinBalanceResponse(account.getPostedBalance());
 	}
 
 	// 코인 양도
-	public void transferCoin(final long fromUserId, final long toUserId, long coin) throws AppException {
+	@Transactional
+	public void transferCoin(final long fromUserId, final long toUserId, long coin) {
 		// 자기 자신에게 양도 불가
 		if (fromUserId == toUserId) {
 			throw new AppException(COIN_TRANSFER_SAME_USER_EXCEPTION);
@@ -60,20 +49,9 @@ public class AccountService {
 		// 받는 사람 존재 확인
 		UserEntity toUser = userEntityRepository.findById(toUserId)
 			.orElseThrow(() -> new AppException(USER_NOT_FOUND_EXCEPTION));
-		accountRepository.findById(toUserId)
-			.orElseThrow(() -> new AppException(ACCOUNT_NOT_FOUND_EXCEPTION));
 
-		// 락 걸고 양도 처리
-		try {
-			lockManager.multipleUserLock(List.of(fromUserId, toUserId), () -> {
-				// 출금
-				addCoin(fromUserId, -coin);
-				// 입금
-				addCoin(toUserId, coin);
-			});
-		} catch (LockException e) {
-			throw new AppException(COIN_TRANSFER_FAIL_EXCEPTION);
-		}
+		// 양도 처리
+		ledgerService.transfer(fromUserId, toUserId, coin);
 
 		// 알림
 		notificationService.createNotification(
@@ -83,25 +61,5 @@ public class AccountService {
 				.amount(coin)
 				.build()
 		);
-	}
-
-	// 코인 소비
-	public void consumeCoin(final long userId, long coin) throws AppException {
-		try {
-			lockManager.accountLock(userId, () -> {
-				addCoin(userId, -coin);
-			});
-		} catch (LockException e) {
-			throw new AppException(COIN_TRANSFER_FAIL_EXCEPTION);
-		}
-	}
-
-	// 코인 추가, 트랜잭션은 lockManager에 의해 관리됨
-	private void addCoin(final long userId, final long coin) {
-		Account account = accountRepository.findById(userId)
-			.orElseThrow(() -> new AppException(ACCOUNT_NOT_FOUND_EXCEPTION));
-
-		account.addCoin(coin);
-		accountRepository.save(account);
 	}
 }

--- a/src/main/java/hanium/modic/backend/domain/transaction/service/LedgerService.java
+++ b/src/main/java/hanium/modic/backend/domain/transaction/service/LedgerService.java
@@ -1,0 +1,80 @@
+package hanium.modic.backend.domain.transaction.service;
+
+import static hanium.modic.backend.common.error.ErrorCode.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import hanium.modic.backend.common.error.exception.AppException;
+import hanium.modic.backend.common.error.exception.LockException;
+import hanium.modic.backend.domain.transaction.entity.Account;
+import hanium.modic.backend.domain.transaction.entity.CoinTransaction;
+import hanium.modic.backend.domain.transaction.entity.CoinTransactionEntity;
+import hanium.modic.backend.domain.transaction.enums.TransactionDirection;
+import hanium.modic.backend.domain.transaction.enums.TransactionStatus;
+import hanium.modic.backend.domain.transaction.repository.AccountRepository;
+import hanium.modic.backend.domain.transaction.repository.CoinTransactionEntityRepository;
+import hanium.modic.backend.domain.transaction.repository.CoinTransactionRepository;
+import hanium.modic.backend.infra.redis.distributedLock.LockManager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LedgerService {
+
+	// 계좌, 거래 관련
+	private final AccountRepository accountRepository;
+	private final CoinTransactionRepository coinTransactionRepository;
+	private final CoinTransactionEntityRepository entryRepository;
+
+	// 기타
+	private final LockManager lockManager;
+
+	// 코인 전송(게좌 변경, 트랜잭션, 엔티티 저장) 후 알림 처리
+	public void transfer(final long fromUserId, final long toUserId, final long amount) {
+		// 락 걸고 양도 처리
+		try {
+			lockManager.multipleAccountLock(List.of(fromUserId, toUserId), () -> {
+				// 1) 계좌 읽기
+				Account fromAccount = accountRepository.findByUserId(fromUserId)
+					.orElseThrow(() -> new AppException(ACCOUNT_NOT_FOUND_EXCEPTION));
+				Account toAccount = accountRepository.findByUserId(toUserId)
+					.orElseThrow(() -> new AppException(ACCOUNT_NOT_FOUND_EXCEPTION));
+
+				// 2) posted_balance 업데이트
+				fromAccount.updateBalance(fromAccount.getPostedBalance() - amount);
+				toAccount.updateBalance(toAccount.getPostedBalance() + amount);
+
+				// 3) 버전 캡처, 반드시 Account 업데이트 이후에 호출되어야 함
+				long fromVersionBefore = fromAccount.getLedgerVersion();
+				long toVersionBefore = toAccount.getLedgerVersion();
+
+				LocalDateTime now = LocalDateTime.now();
+
+				// 4) 트랜잭션 생성 (posted)
+				CoinTransaction txn = coinTransactionRepository.save(
+					CoinTransaction.builder()
+						.status(TransactionStatus.POSTED)
+						.effectiveAt(now)
+						.build()
+				);
+
+				// 5) 엔트리 생성
+				entryRepository.save(CoinTransactionEntity.createPostedTransaction(
+					fromAccount.getId(), fromVersionBefore, txn.getId(),
+					TransactionDirection.DEBIT, amount, now
+				));
+				entryRepository.save(CoinTransactionEntity.createPostedTransaction(
+					toAccount.getId(), toVersionBefore, txn.getId(),
+					TransactionDirection.CREDIT, amount, now
+				));
+				accountRepository.save(fromAccount);
+				accountRepository.save(toAccount);
+			});
+		} catch (LockException e) {
+			throw new AppException(COIN_TRANSFER_FAIL_EXCEPTION);
+		}
+	}
+}

--- a/src/main/java/hanium/modic/backend/infra/redis/distributedLock/LockManager.java
+++ b/src/main/java/hanium/modic/backend/infra/redis/distributedLock/LockManager.java
@@ -32,7 +32,7 @@ public class LockManager {
 	private final String VOTE_STREAK_PREFIX = "lock:vote:streak:";
 	private final String ACCOUNT_PREFIX = "lock:account:";
 
-	// 유저당 계쫘가 한 개라 userId로 락을 걸어도 무방
+	// 유저당 계좌가 한 개라 userId로 락을 걸어도 무방
 	public void multipleAccountLock(List<Long> userIds, Runnable block) throws LockException {
 		List<String> keys = userIds.stream()
 			.map(id -> ACCOUNT_PREFIX + id)

--- a/src/main/java/hanium/modic/backend/infra/redis/distributedLock/LockManager.java
+++ b/src/main/java/hanium/modic/backend/infra/redis/distributedLock/LockManager.java
@@ -32,8 +32,12 @@ public class LockManager {
 	private final String VOTE_STREAK_PREFIX = "lock:vote:streak:";
 	private final String ACCOUNT_PREFIX = "lock:account:";
 
-	public void accountLock(long userId, Runnable block) throws LockException {
-		exec.withLock(ACCOUNT_PREFIX + userId, block);
+	// 유저당 계쫘가 한 개라 userId로 락을 걸어도 무방
+	public void multipleAccountLock(List<Long> userIds, Runnable block) throws LockException {
+		List<String> keys = userIds.stream()
+			.map(id -> ACCOUNT_PREFIX + id)
+			.toList();
+		exec.withMultiLock(keys, block);
 	}
 
 	public void multipleUserLock(List<Long> userIds, Runnable block) throws LockException {

--- a/src/main/java/hanium/modic/backend/web/transaction/controller/AccountController.java
+++ b/src/main/java/hanium/modic/backend/web/transaction/controller/AccountController.java
@@ -45,6 +45,7 @@ public class AccountController {
 		description = "유저가 다른 유저에게 코인을 송금합니다."
 	)
 	@ApiErrorMapping({
+		USER_NOT_FOUND_EXCEPTION,
 		COIN_NOT_ENOUGH_EXCEPTION,
 		COIN_TRANSFER_SAME_USER_EXCEPTION,
 		COIN_TRANSFER_FAIL_EXCEPTION,

--- a/src/test/java/hanium/modic/backend/domain/ai/service/AiImagePermissionServiceTest.java
+++ b/src/test/java/hanium/modic/backend/domain/ai/service/AiImagePermissionServiceTest.java
@@ -76,7 +76,7 @@ class AiImagePermissionServiceTest {
 		// then
 		verify(postRepository).findById(testPost.getId());
 		verify(aiChatRoomRepository).upsertAndIncrease(testUser.getId(), testPost.getId(), 20);
-		verify(accountService).consumeCoin(testUser.getId(), testPost.getNonCommercialPrice());
+		verify(accountService).transferCoin(testUser.getId(), testPost.getUserId(), testPost.getNonCommercialPrice());
 	}
 
 	@Test
@@ -96,7 +96,7 @@ class AiImagePermissionServiceTest {
 
 		verify(postRepository).findById(testPost.getId());
 		verify(aiChatRoomRepository, never()).upsertAndIncrease(anyLong(), anyLong(), anyInt());
-		verify(accountService, never()).consumeCoin(anyLong(), anyLong());
+		verify(accountService, never()).transferCoin(anyLong(), anyLong(), anyLong());
 	}
 
 	@Test
@@ -110,7 +110,7 @@ class AiImagePermissionServiceTest {
 		when(aiChatRoomRepository.upsertAndIncrease(anyLong(), anyLong(), anyInt()))
 			.thenReturn(1);
 		doThrow(new AppException(COIN_NOT_ENOUGH_EXCEPTION))
-			.when(accountService).consumeCoin(anyLong(), anyLong());
+			.when(accountService).transferCoin(anyLong(), anyLong(), anyLong());
 
 		// when & then
 		AppException exception = assertThrows(AppException.class,
@@ -120,7 +120,7 @@ class AiImagePermissionServiceTest {
 
 		verify(postRepository).findById(testPost.getId());
 		verify(aiChatRoomRepository).upsertAndIncrease(testUser.getId(), testPost.getId(), 20);
-		verify(accountService).consumeCoin(testUser.getId(), testPost.getNonCommercialPrice());
+		verify(accountService).transferCoin(testUser.getId(), testPost.getUserId(), testPost.getNonCommercialPrice());
 	}
 
 	@Test

--- a/src/test/java/hanium/modic/backend/domain/transaction/AccountServiceIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/domain/transaction/AccountServiceIntegrationTest.java
@@ -32,9 +32,11 @@ class AccountServiceIntegrationTest extends BaseIntegrationTest {
 
 	private UserEntity userA;
 	private UserEntity userB;
+	private UserEntity userC;
 
 	private Account accountA;
 	private Account accountB;
+	private Account accountC;
 
 	@BeforeEach
 	void setup() {
@@ -43,40 +45,25 @@ class AccountServiceIntegrationTest extends BaseIntegrationTest {
 		accountA = accountRepository.save(Account.builder().userId(userA.getId()).build());
 		userB = userRepository.save(UserFactory.createMockUserWithoutId("userB"));
 		accountB = accountRepository.save(Account.builder().userId(userB.getId()).build());
+		userC = userRepository.save(UserFactory.createMockUserWithoutId("userC"));
+		accountC = accountRepository.save(Account.builder().userId(userC.getId()).build());
 	}
 
 	@Test
-	@DisplayName("TEST1: 동시에 코인 충전이 되면 차례대로 처리된다")
-	void coinChargeConcurrencyTest() throws InterruptedException {
-		int threadCount = 5;
-		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-		CountDownLatch latch = new CountDownLatch(threadCount);
-
-		for (int i = 0; i < threadCount; i++) {
-			executor.execute(() -> {
-				try {
-					accountService.chargeCoin(userA.getId(), 100);
-				} finally {
-					latch.countDown();
-				}
-			});
-		}
-
-		latch.await();
-		Account account = accountRepository.findById(userA.getId()).orElseThrow();
-		assertThat(account.getCoin()).isEqualTo(100 * threadCount);
-	}
-
-	@Test
-	@DisplayName("TEST2: 동시에 A유저가 코인을 충전하고, B유저가 A유저에게 코인을 양도하면 무사히 처리된다")
+	@DisplayName("TEST1: 동시에 B, C유저가 A유저에게 코인을 양도하면 무사히 처리된다")
 	void chargeAndTransferCoinConcurrencyTest() throws InterruptedException {
+		accountB.updateBalance(500L);
+		accountC.updateBalance(500L);
+		accountRepository.save(accountB);
+		accountRepository.save(accountC);
+
 		int threadCount = 2;
 		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 		CountDownLatch latch = new CountDownLatch(threadCount);
 
 		executor.execute(() -> {
 			try {
-				accountService.chargeCoin(userA.getId(), 200);
+				accountService.transferCoin(userC.getId(), userA.getId(), 500);
 			} finally {
 				latch.countDown();
 			}
@@ -84,7 +71,7 @@ class AccountServiceIntegrationTest extends BaseIntegrationTest {
 
 		executor.execute(() -> {
 			try {
-				accountService.transferCoin(userA.getId(), userB.getId(), 100);
+				accountService.transferCoin(userB.getId(), userA.getId(), 500);
 			} finally {
 				latch.countDown();
 			}
@@ -93,34 +80,7 @@ class AccountServiceIntegrationTest extends BaseIntegrationTest {
 		latch.await();
 
 		Account accountA = accountRepository.findById(userA.getId()).orElseThrow();
-		Account accountB = accountRepository.findById(userB.getId()).orElseThrow();
 
-		assertThat(accountA.getCoin() + accountB.getCoin()).isEqualTo(200);
-	}
-
-	@Test
-	@DisplayName("TEST3: 동시에 코인 소비가 되면 차례대로 처리된다")
-	void coinConsumeConcurrencyTest() throws InterruptedException {
-		// 사전 충전
-		accountService.chargeCoin(userA.getId(), 500);
-
-		int threadCount = 5;
-		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-		CountDownLatch latch = new CountDownLatch(threadCount);
-
-		for (int i = 0; i < threadCount; i++) {
-			executor.execute(() -> {
-				try {
-					accountService.consumeCoin(userA.getId(), 50);
-				} finally {
-					latch.countDown();
-				}
-			});
-		}
-
-		latch.await();
-
-		Account updatedAccount = accountRepository.findById(userA.getId()).orElseThrow();
-		assertThat(updatedAccount.getCoin()).isEqualTo(500 - (50 * threadCount));
+		assertThat(accountA.getPostedBalance()).isEqualTo(1000L);
 	}
 }

--- a/src/test/java/hanium/modic/backend/web/ai/controller/AiImagePermissionControllerIntegrationTest.java
+++ b/src/test/java/hanium/modic/backend/web/ai/controller/AiImagePermissionControllerIntegrationTest.java
@@ -23,6 +23,7 @@ import hanium.modic.backend.domain.ticket.repository.TicketRepository;
 import hanium.modic.backend.domain.transaction.entity.Account;
 import hanium.modic.backend.domain.transaction.repository.AccountRepository;
 import hanium.modic.backend.domain.user.entity.UserEntity;
+import hanium.modic.backend.domain.user.factory.UserFactory;
 import hanium.modic.backend.domain.user.repository.UserEntityRepository;
 import hanium.modic.backend.web.ai.aiChat.dto.request.BuyAiImagePermissionRequest;
 
@@ -66,7 +67,7 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 		Account account = Account.builder()
 			.userId(user.getId())
 			.build();
-		account.addCoin(initialCoin);
+		account.updateBalance(initialCoin);
 		return accountRepository.save(account);
 	}
 
@@ -77,7 +78,10 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 		// given
 		UserEntity user = userRepository.findByEmail("test@test.com").orElseThrow();
 		Account account = createAccountForUser(user, 10000L);
-		PostEntity post = createTestPost(user);
+
+		UserEntity user2 = userRepository.save(UserFactory.createMockUserWithoutId("sellerUser"));
+		Account account2 = createAccountForUser(user2, 0L);
+		PostEntity post = createTestPost(user2);
 
 		BuyAiImagePermissionRequest request = new BuyAiImagePermissionRequest(post.getId());
 
@@ -101,7 +105,7 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 		UserEntity updatedUser = userRepository.findById(user.getId()).orElse(null);
 		Account updatedAccount = accountRepository.findById(user.getId()).orElse(null);
 		assertThat(updatedUser).isNotNull();
-		assertThat(updatedAccount.getCoin()).isEqualTo(5000L); // 10000 - 5000
+		assertThat(updatedAccount.getPostedBalance()).isEqualTo(5000L); // 10000 - 5000
 	}
 
 	@Test
@@ -111,7 +115,10 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 		// given
 		UserEntity user = userRepository.findByEmail("test@test.com").orElseThrow();
 		Account account = createAccountForUser(user, 10000L);
-		PostEntity post = createTestPost(user);
+
+		UserEntity user2 = userRepository.save(UserFactory.createMockUserWithoutId("sellerUser"));
+		Account account2 = createAccountForUser(user2, 0L);
+		PostEntity post = createTestPost(user2);
 
 		// 이미 구매한 권한 생성
 		AiChatRoomEntity existingPermission = AiChatRoomEntity.builder()
@@ -147,7 +154,10 @@ class AiImagePermissionControllerIntegrationTest extends BaseIntegrationTest {
 		// given
 		UserEntity user = userRepository.findByEmail("test@test.com").orElseThrow();
 		Account account = createAccountForUser(user, 500L);
-		PostEntity post = createTestPost(user);
+
+		UserEntity user2 = userRepository.save(UserFactory.createMockUserWithoutId("sellerUser"));
+		Account account2 = createAccountForUser(user2, 0L);
+		PostEntity post = createTestPost(user2);
 
 		BuyAiImagePermissionRequest request = new BuyAiImagePermissionRequest(post.getId());
 


### PR DESCRIPTION
## 개요
- close #269

## 작업사항
# 기존 Redis 분산 락 로직에 장부 처리 로직 적용하기

<img width="691" height="367" alt="image" src="https://github.com/user-attachments/assets/19cf9627-b5ac-4a9c-915d-90959207f9bc" />

현재 Redis 분산락은 위와 같이 내부적으로 REQUIRED_NEW 트랜잭션으로 새로운 트랜잭션에서 처리하게 끔 해두었다.(트랜잭션 생명주기가 레디스 분산 락 생명주기보다 짧게 가져가기 위하여)

여기서 Transaction을 분산 락 안에서 처리해야할지 밖에서 처리해도 되는지 고민이 되었다.

밖에서 처리하는 경우

```java
1. Transaction과 Entities를 PENDING 상태로 저장(commit)
2. REDIS 분산 락 처리(commit)
3. Transaction과 Entities를 POSTED로 처리(commit)
```

이렇게 세 번의 커밋과정을 거쳐야 한다.

여기서 만약 2번 과정까지 성공했는데, 3번에서 실패하면 실제 돈은 전송됐는데, 장부에는 안남는 문제가 생긴다,

그러므로 분산 락 안에서 장부 처리가 이뤄져야 한다.

# 레디스 분산락에서 고려해야할 케이스

```java

1. PENDING 실패
-> 더 이상 진행 x

1. PENDING 성공
2. 레디스 분산 락 처리 실패
-> PENDING은 취소로 바꾸고 실패 처리

1. PENDING 성공
2. 레디스 분산 락 처리 성공
3. POSTED 실패
-> 

1. PENDING 성공
2. 레디스 분산 락 처리 성공(Account 변경)
3. POSTED 성공
```

PG사 API가 아니라 내부적으로 처리되는 로직이므로, 별도의 PENDING을 고려할 필요 없었다. 

따라서 이 경우 아래와 같이 동작하게 했다.

```java

2. 레디스 분산 락 처리 실패
-> 끝

2. 레디스 분산 락 처리 성공
3. POSTED 실패
-> 전체 롤백

2. 레디스 분산 락 처리 성공(Account 변경)
3. POSTED 성공
-> 성공
```

즉 코인 송금과 Ledger 처리가 Atomicity하게 동작하여야 했다.

따라서 기존 로직을 수정하여

<img width="689" height="859" alt="image" src="https://github.com/user-attachments/assets/3386e31f-528f-4df2-af5a-aa708e2594ce" />

분산 락 안에서 거래, Transaction 저장, Entity 저장이 모두 이뤄지게 했다.

그리고 내부적으로, Transaction과 한 쌍의 Entity(debit, credit)을 모두 저장하여 복식부기를 따르게 했다.

또한 알람 같은 경우 락 내에서 이뤄질 필요가 없었기에 

<img width="679" height="462" alt="image" src="https://github.com/user-attachments/assets/26fbb366-2c88-41fd-b0c5-a38c5cba008a" />

외부에서 처리되게 했다.

# 고려사항
- 당장은 내부 거래이기 떄문에 장부 처리를 쉽게 할 수 있었다. 하지만 외부 API를 사용하는 경우 단일 트랜잭션 내에서 장부처리를 할 수 없으므로 더 많은 고민이 필요할 거 같다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 이미지 구매 시 코인 전송을 원장 기반 전송으로 전환해 동시성 안정성 향상
  * 계정 잔액 표시를 개선해 잔액 추적성 및 일관성 강화

* **버그 수정**
  * 거래 관련 데이터베이스 테이블명 오타 수정

* **Chores**
  * API 오류 매핑 확장(사용자 미발견 처리 추가)
  * 변경된 전송/잔액 흐름에 맞춰 관련 테스트 및 시나리오 갱신

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->